### PR TITLE
Add provider mail param

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1582,6 +1582,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1830,6 +1835,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2096,6 +2106,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2359,6 +2374,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2682,6 +2702,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -3027,6 +3052,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3887,6 +3913,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1595,6 +1595,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1820,6 +1825,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2063,6 +2073,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2303,6 +2318,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2607,6 +2627,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2932,6 +2957,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3786,6 +3812,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -1164,6 +1164,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1389,6 +1394,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -1638,6 +1648,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -1884,6 +1899,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2194,6 +2214,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2531,6 +2556,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3396,6 +3422,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1623,6 +1623,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1871,6 +1876,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2143,6 +2153,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2412,6 +2427,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2741,6 +2761,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -3098,6 +3123,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3988,6 +4014,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1636,6 +1636,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1861,6 +1866,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2110,6 +2120,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2356,6 +2371,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2666,6 +2686,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -3003,6 +3028,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3887,6 +3913,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -1571,6 +1571,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1819,6 +1824,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2085,6 +2095,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2348,6 +2363,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2670,6 +2690,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -3013,6 +3038,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3869,6 +3895,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -1584,6 +1584,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1809,6 +1814,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2052,6 +2062,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2292,6 +2307,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2595,6 +2615,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2918,6 +2943,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3768,6 +3794,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -1154,6 +1154,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1379,6 +1384,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -1628,6 +1638,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -1874,6 +1889,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2183,6 +2203,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2518,6 +2543,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3379,6 +3405,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -1612,6 +1612,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1860,6 +1865,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2132,6 +2142,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2401,6 +2416,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2729,6 +2749,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -3084,6 +3109,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3970,6 +3996,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -1625,6 +1625,11 @@ objects:
                 secretKeyRef:
                   key: ADMIN_PASSWORD
                   name: system-seed
+            - name: USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_EMAIL
+                  name: system-seed
             - name: TENANT_NAME
               valueFrom:
                 secretKeyRef:
@@ -1850,6 +1855,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2099,6 +2109,11 @@ objects:
               secretKeyRef:
                 key: ADMIN_PASSWORD
                 name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
+                name: system-seed
           - name: TENANT_NAME
             valueFrom:
               secretKeyRef:
@@ -2345,6 +2360,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2654,6 +2674,11 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: ADMIN_PASSWORD
+                name: system-seed
+          - name: USER_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: ADMIN_EMAIL
                 name: system-seed
           - name: TENANT_NAME
             valueFrom:
@@ -2989,6 +3014,7 @@ objects:
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
+    ADMIN_EMAIL: ${ADMIN_EMAIL}
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     ADMIN_USER: ${ADMIN_USERNAME}
     MASTER_ACCESS_TOKEN: ${MASTER_ACCESS_TOKEN}
@@ -3869,6 +3895,7 @@ parameters:
 - name: ADMIN_USERNAME
   required: true
   value: admin
+- name: ADMIN_EMAIL
 - description: Admin Access Token with all scopes and write permissions for API access.
   from: '[a-z0-9]{16}'
   generate: expression

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -215,6 +215,11 @@ func (o *OperatorSystemOptionsProvider) setSystemSeedOptions(builder *component.
 		builder.AdminPassword(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminPasswordFieldName, defaultAdminPassword))
 		builder.AdminAccessToken(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminAccessTokenFieldName, defaultAdminAccessToken))
 		builder.MasterAccessToken(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterAccessTokenFieldName, defaultMasterAccessToken))
+
+		result := getSecretDataValue(secretData, component.SystemSecretSystemSeedAdminEmailFieldName)
+		if result != nil {
+			builder.AdminEmail(*result)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Make the provider admin mail configurable when a
deploy is performed via a parameter
named ADMIN_EMAIL, and the USER_EMAIL system envvar
is set from that value.
