### PR TITLE
Change operator dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,12 @@
 
 
 [[projects]]
-  digest = "1:c4638ce2e73b35bb3b0a109d687d798159a1844e1174a80c1cc6d1895d2f6fe0"
+  digest = "1:fd1a7ca82682444a45424f6af37b1e0373f632e5a303441b111558ae8656a9b7"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = "NT"
-  revision = "74b12019e2aa53ec27882158f59192d7cd6d1998"
-  version = "v0.33.1"
-
-[[projects]]
-  digest = "1:75d2b55b13298745ec068057251d05d65bbae0a668201fe45ad6986551a55601"
-  name = "github.com/BurntSushi/toml"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
-  version = "v0.3.1"
+  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
+  version = "v0.34.0"
 
 [[projects]]
   digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
@@ -42,15 +34,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e6f888d4be8ec0f05c50e2aba83da4948b58045dee54d03be81fa74ea673302c"
+  digest = "1:3f718788c59f3ec687bcc963cb6034a132327387784c8c04392abaaea9ad7498"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
     "log",
   ]
   pruneopts = "NT"
-  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
-  version = "v2.8.0"
+  revision = "e37671aced663c8d3a395bd301857e26dcf4340c"
+  version = "v2.8.1"
 
 [[projects]]
   digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
@@ -90,7 +82,7 @@
   packages = ["."]
   pruneopts = "NT"
   revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
-  version = "v0.17.2"
+  version = "v0.18.0"
 
 [[projects]]
   digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
@@ -98,42 +90,34 @@
   packages = ["."]
   pruneopts = "NT"
   revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
-  version = "v0.17.2"
+  version = "v0.18.0"
 
 [[projects]]
-  digest = "1:dfab391de021809e0041f0ab5648da6b74dd16a685472a1b8c3dc06b3dca1ee2"
+  digest = "1:4da4ea0a664ba528965683d350f602d0f11464e6bb2e17aad0914723bc25d163"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "NT"
-  revision = "5bae59e25b21498baea7f9d46e9c147ec106a42e"
-  version = "v0.17.2"
+  revision = "5b6cdde3200976e3ecceb2868706ee39b6aff3e4"
+  version = "v0.18.0"
 
 [[projects]]
-  digest = "1:983f95b2fae6fe8fdd361738325ed6090f4f3bd15ce4db745e899fb5b0fdfc46"
+  digest = "1:dc0f590770e5a6c70ea086232324f7b7dc4857c60eca63ab8ff78e0a5cfcdbf3"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   pruneopts = "NT"
-  revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
-  version = "v0.17.2"
+  revision = "1d29f06aebd59ccdf11ae04aa0334ded96e2d909"
+  version = "v0.18.0"
 
 [[projects]]
-  digest = "1:8a2045aab206dde28171e023e0d1ef83f38adf8bc86de0b2d1dfec1bb2fd994a"
-  name = "github.com/gobuffalo/envy"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "b29bf6b8134f3398b9333ba1893c58620152edb0"
-  version = "v1.6.9"
-
-[[projects]]
-  digest = "1:2a9d5e367df8c95e780975ca1dd4010bef8e39a3777066d3880ce274b39d4b5a"
+  digest = "1:932970e69f16e127aa0653b8263ae588cd127fa53273e19ba44332902c9826f2"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "NT"
-  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
-  version = "v1.1.1"
+  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -259,28 +243,12 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:f5b9328966ccea0970b1d15075698eff0ddb3e75889560aad2e9f76b289b536a"
-  name = "github.com/joho/godotenv"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "23d116af351c84513e1946b527c88823e476be13"
-  version = "v1.3.0"
-
-[[projects]]
   digest = "1:1d39c063244ad17c4b18e8da1551163b6ffb52bd1640a49a8ec5c3b7bf4dbd5d"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "NT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
-
-[[projects]]
-  digest = "1:4059c14e87a2de3a434430340521b5feece186c1469eff0834c29a63870de3ed"
-  name = "github.com/konsorten/go-windows-terminal-sequences"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
-  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
@@ -309,14 +277,6 @@
   ]
   pruneopts = "NT"
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
-
-[[projects]]
-  digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"
-  name = "github.com/markbates/inflect"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
-  version = "v1.0.4"
 
 [[projects]]
   branch = "master"
@@ -359,95 +319,33 @@
   version = "1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:a6156889b651cc0bf3d9bef82b6ba8fbb9eb19aefd7bc5718357c38b67297cbc"
-  name = "github.com/mxk/go-flowrate"
-  packages = ["flowrate"]
-  pruneopts = "NT"
-  revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
-
-[[projects]]
-  branch = "master"
-  digest = "1:d60f58238786f29df539514efed06fae076de3d0db6aadf37c17c70449c3657a"
+  digest = "1:66dec43174af7bc882f832dbc67257f31c724245565cc059d188fb7ae08b9e7f"
   name = "github.com/openshift/api"
   packages = [
-    ".",
-    "apps",
     "apps/v1",
-    "authorization",
     "authorization/v1",
-    "build",
     "build/v1",
-    "config",
-    "config/v1",
-    "image",
     "image/docker10",
     "image/dockerpre012",
     "image/v1",
-    "kubecontrolplane",
-    "kubecontrolplane/v1",
-    "legacyconfig/v1",
-    "network",
     "network/v1",
-    "oauth",
     "oauth/v1",
-    "openshiftcontrolplane",
-    "openshiftcontrolplane/v1",
-    "operator",
-    "operator/v1",
-    "operator/v1alpha1",
-    "osin",
-    "osin/v1",
     "pkg/serialization",
-    "project",
     "project/v1",
-    "quota",
     "quota/v1",
-    "route",
     "route/v1",
-    "security",
     "security/v1",
-    "servicecertsigner",
-    "servicecertsigner/v1alpha1",
-    "template",
     "template/v1",
-    "user",
     "user/v1",
-    "webconsole",
-    "webconsole/v1",
   ]
   pruneopts = "NT"
-  revision = "83b2fe56301417028bd52e56edd75768e2ea051c"
+  revision = "5ad8479f64f1b60ee9c62ce8ef1fe6638838725e"
 
 [[projects]]
   digest = "1:b186c2fcf87d05c5129ad0d89ea062853b0bdf6d6bca1ed4a22157962f2ad8dd"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
-    "commands/operator-sdk",
-    "commands/operator-sdk/cmd",
-    "commands/operator-sdk/cmd/add",
-    "commands/operator-sdk/cmd/completion",
-    "commands/operator-sdk/cmd/generate",
-    "commands/operator-sdk/cmd/test",
-    "commands/operator-sdk/cmd/up",
-    "internal/util/fileutil",
-    "internal/util/k8sutil",
-    "internal/util/projutil",
-    "pkg/ansible/controller",
-    "pkg/ansible/controller/status",
-    "pkg/ansible/events",
-    "pkg/ansible/operator",
-    "pkg/ansible/paramconv",
-    "pkg/ansible/proxy",
-    "pkg/ansible/proxy/kubeconfig",
-    "pkg/ansible/runner",
-    "pkg/ansible/runner/eventapi",
-    "pkg/ansible/runner/internal/inputdir",
     "pkg/k8sutil",
-    "pkg/scaffold",
-    "pkg/scaffold/ansible",
-    "pkg/scaffold/input",
-    "pkg/test",
     "version",
   ]
   pruneopts = "NT"
@@ -487,23 +385,15 @@
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:cd2f2cba5b7ffafd0412fb647ff4bcff170292de57270f05fbbf391e3eb9566b"
-  name = "github.com/sirupsen/logrus"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
-  version = "v1.2.0"
-
-[[projects]]
-  digest = "1:2a7c79c506479dc73c0100982a40bacc89e06d96dc458eb41c9b6aa44d9e0b6d"
+  digest = "1:a3d234acd819fde4b1875e9e9e68a1d8368115983a74ec23c379973a8f179f07"
   name = "github.com/spf13/afero"
   packages = [
     ".",
     "mem",
   ]
   pruneopts = "NT"
-  revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
-  version = "v1.1.2"
+  revision = "a5d6946387efe7d64d09dcba68cdd523dc1273a3"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:c5e6b121ef3d2043505edaf4c80e5a008cec2513dc8804795eb0479d1555bcf7"
@@ -582,32 +472,30 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:417055c259ab65cfeacd7d0bf0b039c2809e80300cf0894937ff4eec2c5a866a"
+  digest = "1:3152b340c093c4fab5b097bae35a1b7f3c3a9c8627439a12cab4bfeeff9327b9"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NT"
-  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
+  revision = "ff983b9c42bc9fbf91556e191cc8efb585c16908"
 
 [[projects]]
   branch = "master"
-  digest = "1:d103910996bb5cd0c1cdbae00f22238e8f136ba70e70c242fcc28c400f2b2c75"
+  digest = "1:122c84e1426c98cac9e77db3ff47e41254e6cd4c9368e0786da5b01f5bc0635d"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
-    "html",
-    "html/atom",
     "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
   ]
   pruneopts = "NT"
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "ed066c81e75eba56dd9bd2139ade88125b855585"
 
 [[projects]]
   branch = "master"
-  digest = "1:d25e419b2334aeb766bd3ed55ad61c9e85f82a46b53fc38d31ce909252dab20a"
+  digest = "1:9a9a8b8635685e9e4ff68c80bebf00726f5019fb41da508a56df54e6e7277eeb"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -617,18 +505,18 @@
     "jwt",
   ]
   pruneopts = "NT"
-  revision = "8f65e3013ebad444f13bc19536f7865efc793816"
+  revision = "5dab4167f31cbd76b407f1486c86b40748bc5073"
 
 [[projects]]
   branch = "master"
-  digest = "1:478c51e86c9a8a3681d8ab60317e1f9115e805c3288a08d9cecef33a5dda1c94"
+  digest = "1:248984d86ab98a20dbb339cf8df029351b2330cddc797c6912e9b4b3404673d5"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NT"
-  revision = "0cf1ed9e522b7dbb416f080a5c8003de9b702bf4"
+  revision = "770c60269bf0ef965e9e7ac8bedcb6bca2a1cefd"
 
 [[projects]]
   digest = "1:8c74f97396ed63cc2ef04ebb5fc37bb032871b8fd890a25991ed40974b00cd2a"
@@ -664,19 +552,26 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cae47cade9be1782031931b812a66d0f5ed37e22edefd803b9cc1007f91659b4"
+  digest = "1:4984611ef17bbe3f1e31f13eca5d17454edd18af14ff5400f52b5eb5098baed0"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/cgo",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
     "imports",
     "internal/fastwalk",
     "internal/gopathwalk",
+    "internal/semver",
   ]
   pruneopts = "NT"
-  revision = "b5f2cae84da8243ade5d6a1d2b6c92ec1907be0f"
+  revision = "24cd39ecf74570612483b772d45cf9d53d908340"
 
 [[projects]]
-  digest = "1:2a4972ee51c3b9dfafbb3451fa0552e7a198d9d12c721bfc492050fe2f72e0f6"
+  digest = "1:902ffa11f1d8c19c12b05cabffe69e1a16608ad03a8899ebcb9c6bde295660ae"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -691,8 +586,8 @@
     "urlfetch",
   ]
   pruneopts = "NT"
-  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
-  version = "v1.3.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -703,12 +598,12 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
+  digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
   digest = "1:f11e5753e619f411a51a49d60d39b2bc4da6766f5f0af2e2291daa6a3d9385d5"
@@ -733,7 +628,6 @@
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
-    "imagepolicy/v1alpha1",
     "networking/v1",
     "policy/v1beta1",
     "rbac/v1",
@@ -748,17 +642,6 @@
   ]
   pruneopts = "NT"
   revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
-
-[[projects]]
-  digest = "1:117a407949aaaad9f7fbe3da8d6c2055f2c223ac0cbebd39f47ff71899622a91"
-  name = "k8s.io/apiextensions-apiserver"
-  packages = [
-    "pkg/apis/apiextensions",
-    "pkg/apis/apiextensions/v1beta1",
-    "pkg/client/clientset/clientset/scheme",
-  ]
-  pruneopts = "NT"
-  revision = "408db4a50408e2149acbd657bceb2480c13cb0a4"
 
 [[projects]]
   digest = "1:b07bf863262aae765494d60f0d524483f211b29f9bb27d445a79c13af8676bf2"
@@ -790,12 +673,10 @@
     "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
-    "pkg/util/httpstream",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
     "pkg/util/net",
-    "pkg/util/proxy",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/strategicpatch",
@@ -807,7 +688,6 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NT"
@@ -818,7 +698,6 @@
   name = "k8s.io/client-go"
   packages = [
     "discovery",
-    "discovery/cached",
     "dynamic",
     "kubernetes",
     "kubernetes/scheme",
@@ -921,7 +800,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5edbd655d7ee65178fd5750bda9a3d3cd7fb96291937926f4969e6b2dfbc5743"
+  digest = "1:4d52082d1d9ea18e04c8b859f6696f1ca42849d68257e5b84812f8067694a2e6"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -934,7 +813,7 @@
     "types",
   ]
   pruneopts = "NT"
-  revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
+  revision = "f8a0810f38afb8478882b3835a615aebfda39afa"
 
 [[projects]]
   digest = "1:f3b42f307c7f49a1a7276c48d4b910db76e003220e88797f7acd41e3a9277ddf"
@@ -946,7 +825,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9ac2fdede4a8304e3b00ea3b36526536339f306d0306e320fc74f6cefeead18e"
+  digest = "1:653cd4cf804493513d5ec945e687639e5fe9a1f7adbcf2db5cd21da31a96674e"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen/args",
@@ -957,10 +836,10 @@
     "pkg/util/sets",
   ]
   pruneopts = "NT"
-  revision = "0317810137be915b9cf888946c6e115c1bfac693"
+  revision = "ced9eb3070a5f1c548ef46e8dfe2a97c208d9f03"
 
 [[projects]]
-  digest = "1:d1b7a6ed45c957e6308759f31fdbff8063741ecb08b7c3b6d67f0c9f4357b2ae"
+  digest = "1:a8fb38656b3b59a487e3f74c7d9ad4d90c4f7a3b45413284311f9751b6905448"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -969,6 +848,7 @@
     "pkg/client/apiutil",
     "pkg/client/config",
     "pkg/controller",
+    "pkg/controller/controllerutil",
     "pkg/event",
     "pkg/handler",
     "pkg/internal/controller",
@@ -981,6 +861,7 @@
     "pkg/recorder",
     "pkg/runtime/inject",
     "pkg/runtime/log",
+    "pkg/runtime/scheme",
     "pkg/runtime/signals",
     "pkg/source",
     "pkg/source/internal",
@@ -989,22 +870,42 @@
     "pkg/webhook/types",
   ]
   pruneopts = "NT"
-  revision = "5fd1e9e9fac5261e9ad9d47c375afc014fc31d21"
-  version = "v0.1.7"
+  revision = "53fc44b56078cd095b11bd44cfa0288ee4cf718f"
+  version = "v0.1.4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/luci/go-render/render",
-    "github.com/openshift/api",
-    "github.com/operator-framework/operator-sdk/commands/operator-sdk",
+    "github.com/mitchellh/go-homedir",
+    "github.com/openshift/api/apps/v1",
+    "github.com/openshift/api/authorization/v1",
+    "github.com/openshift/api/build/v1",
+    "github.com/openshift/api/image/v1",
+    "github.com/openshift/api/network/v1",
+    "github.com/openshift/api/oauth/v1",
+    "github.com/openshift/api/project/v1",
+    "github.com/openshift/api/quota/v1",
+    "github.com/openshift/api/route/v1",
+    "github.com/openshift/api/security/v1",
+    "github.com/openshift/api/template/v1",
+    "github.com/openshift/api/user/v1",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/spf13/cobra",
     "github.com/spf13/cobra/cobra",
+    "github.com/spf13/viper",
     "gopkg.in/yaml.v2",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer/json",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
@@ -1015,9 +916,17 @@
     "k8s.io/code-generator/cmd/lister-gen",
     "k8s.io/code-generator/cmd/openapi-gen",
     "k8s.io/gengo/args",
+    "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/controller",
+    "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
+    "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/reconcile",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/log",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
+    "sigs.k8s.io/controller-runtime/pkg/source",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,18 +45,18 @@ required = [
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "v0.1.4"
+  version = "=v0.1.4"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "v0.1.x" #osdk_branch_annotation
+  # branch = "v0.2.x" #osdk_branch_annotation
   version = "=v0.2.1" #osdk_version_annotation
 
 [prune]
   go-tests = true
   non-go = true
-  
+
   [[prune.project]]
     name = "k8s.io/code-generator"
     non-go = false

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,7 +10,6 @@ required = [
   "k8s.io/gengo/args",
 
   "github.com/spf13/cobra/cobra",
-  "github.com/openshift/api",
   "github.com/luci/go-render/render",
   "gopkg.in/yaml.v2",
 ]
@@ -49,6 +48,11 @@ required = [
   # The version rule is used for a specific release and the master branch for in between releases.
   # branch = "v0.2.x" #osdk_branch_annotation
   version = "=v0.2.1" #osdk_version_annotation
+
+[[override]]
+  name = "github.com/openshift/api"
+  # revision for the current tip of the branch "release-3.11"
+  revision = "5ad8479f64f1b60ee9c62ce8ef1fe6638838725e"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,8 +11,6 @@ required = [
 
   "github.com/spf13/cobra/cobra",
   "github.com/openshift/api",
-  "k8s.io/apimachinery/pkg/runtime/serializer",
-  "k8s.io/client-go/kubernetes/scheme",
   "github.com/luci/go-render/render",
   "gopkg.in/yaml.v2",
 ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,6 @@ required = [
   "k8s.io/code-generator/cmd/informer-gen",
   "k8s.io/code-generator/cmd/openapi-gen",
   "k8s.io/gengo/args",
-  "github.com/operator-framework/operator-sdk/commands/operator-sdk",
 
   "github.com/spf13/cobra/cobra",
   "github.com/openshift/api",

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,17 @@
 .PHONY: build
 
-operator-sdk = ./vendor/github.com/operator-framework/operator-sdk/commands/operator-sdk
-
 Gopkg.lock: Gopkg.toml
 	dep check
 
 vendor: Gopkg.lock
 	dep ensure -v
 
-$(operator-sdk): vendor
-
 NAMESPACE ?= 3scale/3scale-operator
 VERSION ?= latest
 
-build: $(operator-sdk)
-	go run $(operator-sdk) build $(NAMESPACE):$(VERSION)
+build:
+	operator-sdk build $(NAMESPACE):$(VERSION)
 
-test: $(operator-sdk)
-	go run $(operator-sdk) test local $@
+test:
+	operator-sdk test local $@
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # 3scale-operator
+
+## Prerequisites
+
+- [operator-sdk] version v0.2.1.
+- [dep][dep_tool] version v0.5.0+.
+- [git][git_tool]
+- Access to a Openshift v3.11.0+ cluster.
+
+## Quick Start
+
+To download and prepare the environment for 3scale-operator:
+
+```sh
+$ mkdir -p $GOPATH/src/github.com/3scale
+$ cd $GOPATH/src/github.com/3scale
+$ git clone https://github.com/3scale/3scale-operator
+$ cd 3scale-operator
+$ git checkout master
+$ make vendor
+```
+
+[git_tool]:https://git-scm.com/downloads
+[operator-sdk]:https://github.com/operator-framework/operator-sdk
+[dep_tool]:https://golang.github.io/dep/docs/installation.html


### PR DESCRIPTION
This PR:
 * Fixes some minor operator-sdk v0.2.1 direct dependency. operator-sdk in master was already v0.2.1 in master but not all direct operator-sdk dependencies matched what the "operator-sdk print-deps --as-file" generated
 * Removes unnecessary imports from Gopkg.toml
 * Fixes openshift/api version in Gopkg.toml to the revision commit that currently matches the v3.11 branch (no tag exists in the openshift/api repository)
 * Regenerates Gopkg.toml
 * Updates Makefile to use a locally installed operator-sdk command instead of a vendored one. This has been done because it is not supported by operator-sdk (see https://github.com/operator-framework/operator-sdk/issues/852). This breaks our current CI/CD integration and in a future PR will be fixed
 * Updates README.md with an explanation of prerequisites at the time of writing this and a quick start section