### PR TITLE
Local operator sdk command on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,16 @@ jobs:
             - v1-gopkg-cache-{{ arch }}-{{ .Branch }}
 
       - run:
+          name: Install operator-sdk
+          command: |
+              mkdir -p ${GOPATH}/src/github.com/operator-framework
+              cd ${GOPATH}/src/github.com/operator-framework
+              git clone https://github.com/operator-framework/operator-sdk --branch v0.2.1
+              cd operator-sdk
+              make dep
+              make install
+
+      - run:
           name: Install dependencies
           command: |
             make vendor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             172.30.1.1:5000/$project/amp-system:latest=quay.io/3scale/porta:nightly --insecure
   generator:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.11
     working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - checkout

--- a/pkg/3scale/amp/Makefile
+++ b/pkg/3scale/amp/Makefile
@@ -1,8 +1,6 @@
 .DEFAULT_GOAL := help
 SHELL := bash -eo pipefail
 
-MAKEFLAGS := -j $(shell nproc)
-
 templates = amp.yml amp-s3.yml amp-eval.yml amp-eval-s3.yml amp-ha.yml
 
 targets = $(foreach template,$(templates),./auto-generated-templates/amp/$(template) ./auto-generated-templates/productized_templates/amp/$(template))


### PR DESCRIPTION
This PR adds a run step to the CircleCI 'build' job that installs operator-sdk v0.2.1 tag locally, which is the n used to be able to use the operator-sdk command.
It also updates all CircleCI Docker images that use Go to 1.11.

This PR is based on the contents of the branch that has been requested to be merged into master in the https://github.com/3scale/3scale-operator/pull/14 PR.