### PR TITLE
Upgrade contents of files that change from the upgrade to v0.2.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,7 @@
-FROM alpine:3.6
+FROM alpine:3.8
+
+RUN apk upgrade --update --no-cache
 
 USER nobody
 
-ADD build/_output/bin/3scale-operator /usr/local/bin/3scale-operator
+ADD build/_output/bin/3scale-operator /usr/local/bin/testop

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,61 +1,94 @@
 package main
 
 import (
+	"context"
 	"flag"
-	"log"
+	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/3scale/3scale-operator/pkg/apis"
 	"github.com/3scale/3scale-operator/pkg/controller"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+var log = logf.Log.WithName("cmd")
+
 func printVersion() {
-	log.Printf("Go Version: %s", runtime.Version())
-	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	log.Printf("operator-sdk Version: %v", sdkVersion.Version)
+	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
 func main() {
-	printVersion()
 	flag.Parse()
+
+	// The logger instantiated here can be changed to any logger
+	// implementing the logr.Logger interface. This logger will
+	// be propagated through the whole operator, generating
+	// uniform and structured logs.
+	logf.SetLogger(logf.ZapLogger(false))
+
+	printVersion()
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Fatalf("failed to get watch namespace: %v", err)
+		log.Error(err, "failed to get watch namespace")
+		os.Exit(1)
 	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
+
+	// Become the leader before proceeding
+	leader.Become(context.TODO(), "3scale-operator-lock")
+
+	r := ready.NewFileReady()
+	err = r.Set()
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	defer r.Unset()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
-	log.Print("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
-	log.Print("Starting the Cmd.")
+	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "manager exited non-zero")
+		os.Exit(1)
+	}
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,6 +23,14 @@ spec:
           command:
           - 3scale-operator
           imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,6 @@
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  creationTimestamp: null
   name: 3scale-operator
 rules:
 - apiGroups:
@@ -15,7 +14,7 @@ rules:
   - configmaps
   - secrets
   verbs:
-  - '*'
+  - "*"
 - apiGroups:
   - apps
   resources:
@@ -24,14 +23,14 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - "*"
 - apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - get
-  - create
+  - "get"
+  - "create"
 - apiGroups:
   - amp.3scale.net
   resources:


### PR DESCRIPTION
Some files change when a new operator project is created in
v0.2.1 compared to previous versions (a notable change
is the change of logging methods). This commit updates
our existing files to match what is created in v0.2.1 for
non api/controlled related files.