### PR TITLE
Refactor component options

### DIFF
--- a/pkg/3scale/amp/component/highavailability.go
+++ b/pkg/3scale/amp/component/highavailability.go
@@ -15,12 +15,20 @@ type HighAvailability struct {
 }
 
 type HighAvailabilityOptions struct {
+	nonRequiredHighAvailabilityOptions
+	requiredHighAvailabilityOptions
+}
+
+type requiredHighAvailabilityOptions struct {
 	apicastProductionRedisURL   string
 	apicastStagingRedisURL      string
 	backendRedisQueuesEndpoint  string
 	backendRedisStorageEndpoint string
 	systemDatabaseURL           string
 	systemRedisURL              string
+}
+
+type nonRequiredHighAvailabilityOptions struct {
 }
 
 const (
@@ -69,26 +77,42 @@ func (ha *HighAvailabilityOptionsBuilder) SystemRedisURL(systemRedisURL string) 
 }
 
 func (ha *HighAvailabilityOptionsBuilder) Build() (*HighAvailabilityOptions, error) {
-	if ha.options.apicastProductionRedisURL == "" {
-		return nil, fmt.Errorf("no Apicast production URL has been provided")
-	}
-	if ha.options.apicastStagingRedisURL == "" {
-		return nil, fmt.Errorf("no Apicast staging redis URL has been provided")
-	}
-	if ha.options.backendRedisQueuesEndpoint == "" {
-		return nil, fmt.Errorf("no Backend Redis queues endpoint option has been provided")
-	}
-	if ha.options.backendRedisStorageEndpoint == "" {
-		return nil, fmt.Errorf("no Backend Redis storage endpoint has been provided")
-	}
-	if ha.options.systemDatabaseURL == "" {
-		return nil, fmt.Errorf("no System database URL has been provided")
-	}
-	if ha.options.systemRedisURL == "" {
-		return nil, fmt.Errorf("no System redis URL has been provided")
+
+	err := ha.setRequiredOptions()
+	if err != nil {
+		return nil, err
 	}
 
+	ha.setNonRequiredOptions()
+
 	return &ha.options, nil
+}
+
+func (ha *HighAvailabilityOptionsBuilder) setRequiredOptions() error {
+	if ha.options.apicastProductionRedisURL == "" {
+		return fmt.Errorf("no Apicast production URL has been provided")
+	}
+	if ha.options.apicastStagingRedisURL == "" {
+		return fmt.Errorf("no Apicast staging redis URL has been provided")
+	}
+	if ha.options.backendRedisQueuesEndpoint == "" {
+		return fmt.Errorf("no Backend Redis queues endpoint option has been provided")
+	}
+	if ha.options.backendRedisStorageEndpoint == "" {
+		return fmt.Errorf("no Backend Redis storage endpoint has been provided")
+	}
+	if ha.options.systemDatabaseURL == "" {
+		return fmt.Errorf("no System database URL has been provided")
+	}
+	if ha.options.systemRedisURL == "" {
+		return fmt.Errorf("no System redis URL has been provided")
+	}
+
+	return nil
+}
+
+func (ha *HighAvailabilityOptionsBuilder) setNonRequiredOptions() {
+
 }
 
 type HighAvailabilityOptionsProvider interface {

--- a/pkg/3scale/amp/component/memcached.go
+++ b/pkg/3scale/amp/component/memcached.go
@@ -21,8 +21,16 @@ type Memcached struct {
 }
 
 type MemcachedOptions struct {
+	memcachedNonRequiredOptions
+	memcachedRequiredOptions
+}
+
+type memcachedRequiredOptions struct {
 	appLabel string
 	image    string
+}
+
+type memcachedNonRequiredOptions struct {
 }
 
 func NewMemcached(options []string) *Memcached {
@@ -45,14 +53,29 @@ func (m *MemcachedOptionsBuilder) Image(image string) {
 }
 
 func (m *MemcachedOptionsBuilder) Build() (*MemcachedOptions, error) {
-	if m.options.appLabel == "" {
-		return nil, fmt.Errorf("no AppLabel has been provided")
-	}
-	if m.options.image == "" {
-		return nil, fmt.Errorf("no Memcached Image has been provided")
+	err := m.setRequiredOptions()
+	if err != nil {
+		return nil, err
 	}
 
+	m.setNonRequiredOptions()
+
 	return &m.options, nil
+}
+
+func (m *MemcachedOptionsBuilder) setRequiredOptions() error {
+	if m.options.appLabel == "" {
+		return fmt.Errorf("no AppLabel has been provided")
+	}
+	if m.options.image == "" {
+		return fmt.Errorf("no Memcached Image has been provided")
+	}
+
+	return nil
+}
+
+func (m *MemcachedOptionsBuilder) setNonRequiredOptions() {
+
 }
 
 type MemcachedOptionsProvider interface {

--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -21,12 +21,20 @@ type Mysql struct {
 }
 
 type MysqlOptions struct {
+	mysqlNonRequiredOptions
+	mysqlRequiredOptions
+}
+
+type mysqlRequiredOptions struct {
 	appLabel     string
 	databaseName string
 	image        string
 	user         string
 	password     string
 	rootPassword string
+}
+
+type mysqlNonRequiredOptions struct {
 }
 
 type MysqlOptionsBuilder struct {
@@ -58,26 +66,41 @@ func (m *MysqlOptionsBuilder) RootPassword(rootPassword string) {
 }
 
 func (m *MysqlOptionsBuilder) Build() (*MysqlOptions, error) {
-	if m.options.appLabel == "" {
-		return nil, fmt.Errorf("no AppLabel has been provided")
-	}
-	if m.options.databaseName == "" {
-		return nil, fmt.Errorf("no Database Name has been provided")
-	}
-	if m.options.image == "" {
-		return nil, fmt.Errorf("no Database Image has been provided")
-	}
-	if m.options.user == "" {
-		return nil, fmt.Errorf("no User has been provided")
-	}
-	if m.options.password == "" {
-		return nil, fmt.Errorf("no Password has been provided")
-	}
-	if m.options.rootPassword == "" {
-		return nil, fmt.Errorf("no Root Password has been provided")
+	err := m.setRequiredOptions()
+	if err != nil {
+		return nil, err
 	}
 
+	m.setNonRequiredOptions()
+
 	return &m.options, nil
+}
+
+func (m *MysqlOptionsBuilder) setRequiredOptions() error {
+	if m.options.appLabel == "" {
+		return fmt.Errorf("no AppLabel has been provided")
+	}
+	if m.options.databaseName == "" {
+		return fmt.Errorf("no Database Name has been provided")
+	}
+	if m.options.image == "" {
+		return fmt.Errorf("no Database Image has been provided")
+	}
+	if m.options.user == "" {
+		return fmt.Errorf("no User has been provided")
+	}
+	if m.options.password == "" {
+		return fmt.Errorf("no Password has been provided")
+	}
+	if m.options.rootPassword == "" {
+		return fmt.Errorf("no Root Password has been provided")
+	}
+
+	return nil
+}
+
+func (m *MysqlOptionsBuilder) setNonRequiredOptions() {
+
 }
 
 type MysqlOptionsProvider interface {

--- a/pkg/3scale/amp/component/productized.go
+++ b/pkg/3scale/amp/component/productized.go
@@ -23,6 +23,11 @@ func NewProductized(options []string) *Productized {
 }
 
 type ProductizedOptions struct {
+	productizedNonRequiredOptions
+	productizedRequiredOptions
+}
+
+type productizedRequiredOptions struct {
 	ampRelease     string
 	apicastImage   string
 	backendImage   string
@@ -30,6 +35,9 @@ type ProductizedOptions struct {
 	systemImage    string
 	zyncImage      string
 	memcachedImage string
+}
+
+type productizedNonRequiredOptions struct {
 }
 
 type ProductizedOptionsBuilder struct {
@@ -65,28 +73,42 @@ func (productized *ProductizedOptionsBuilder) MemcachedImage(memcachedImage stri
 }
 
 func (productized *ProductizedOptionsBuilder) Build() (*ProductizedOptions, error) {
+	err := productized.setRequiredOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	productized.setNonRequiredOptions()
+
+	return &productized.options, nil
+}
+
+func (productized *ProductizedOptionsBuilder) setRequiredOptions() error {
 	if productized.options.ampRelease == "" {
-		return nil, fmt.Errorf("no AMP release has been provided")
+		return fmt.Errorf("no AMP release has been provided")
 	}
 	if productized.options.apicastImage == "" {
-		return nil, fmt.Errorf("no Apicast image has been provided")
+		return fmt.Errorf("no Apicast image has been provided")
 	}
 	if productized.options.backendImage == "" {
-		return nil, fmt.Errorf("no Backend image has been provided")
+		return fmt.Errorf("no Backend image has been provided")
 	}
 	if productized.options.routerImage == "" {
-		return nil, fmt.Errorf("no Router image has been provided")
+		return fmt.Errorf("no Router image has been provided")
 	}
 	if productized.options.systemImage == "" {
-		return nil, fmt.Errorf("no System image has been provided")
+		return fmt.Errorf("no System image has been provided")
 	}
 	if productized.options.zyncImage == "" {
-		return nil, fmt.Errorf("no Zync image has been provided")
+		return fmt.Errorf("no Zync image has been provided")
 	}
 	if productized.options.memcachedImage == "" {
-		return nil, fmt.Errorf("no Memcached image has been provided")
+		return fmt.Errorf("no Memcached image has been provided")
 	}
-	return &productized.options, nil
+	return nil
+}
+
+func (productized *ProductizedOptionsBuilder) setNonRequiredOptions() {
 }
 
 type ProductizedOptionsProvider interface {

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -21,8 +21,16 @@ type Redis struct {
 }
 
 type RedisOptions struct {
+	redisNonRequiredOptions
+	redisRequiredOptions
+}
+
+type redisRequiredOptions struct {
 	appLabel string
 	image    string
+}
+
+type redisNonRequiredOptions struct {
 }
 
 func NewRedis(options []string) *Redis {
@@ -45,19 +53,35 @@ func (r *RedisOptionsBuilder) Image(image string) {
 }
 
 func (r *RedisOptionsBuilder) Build() (*RedisOptions, error) {
-	if r.options.appLabel == "" {
-		return nil, fmt.Errorf("no AppLabel has been provided")
-	}
-	if r.options.image == "" {
-		return nil, fmt.Errorf("no Redis Image has been provided")
+	err := r.setRequiredOptions()
+	if err != nil {
+		return nil, err
 	}
 
+	r.setNonRequiredOptions()
+
 	return &r.options, nil
+}
+
+func (r *RedisOptionsBuilder) setRequiredOptions() error {
+	if r.options.appLabel == "" {
+		return fmt.Errorf("no AppLabel has been provided")
+	}
+	if r.options.image == "" {
+		return fmt.Errorf("no Redis Image has been provided")
+	}
+
+	return nil
+}
+
+func (r *RedisOptionsBuilder) setNonRequiredOptions() {
+
 }
 
 type RedisOptionsProvider interface {
 	GetRedisOptions() *RedisOptions
 }
+
 type CLIRedisOptionsProvider struct {
 }
 

--- a/pkg/3scale/amp/component/s3.go
+++ b/pkg/3scale/amp/component/s3.go
@@ -16,11 +16,19 @@ type S3 struct {
 }
 
 type S3Options struct {
+	s3NonRequiredOptions
+	s3RequiredOptions
+}
+
+type s3RequiredOptions struct {
 	awsAccessKeyId     string
 	awsSecretAccessKey string
 	awsRegion          string
 	awsBucket          string
 	fileUploadStorage  string
+}
+
+type s3NonRequiredOptions struct {
 }
 
 func NewS3(options []string) *S3 {
@@ -55,23 +63,39 @@ func (s3 *S3OptionsBuilder) FileUploadStorage(fileUploadStorage string) {
 }
 
 func (s3 *S3OptionsBuilder) Build() (*S3Options, error) {
-	if s3.options.awsAccessKeyId == "" {
-		return nil, fmt.Errorf("no AWS access key id has been provided")
-	}
-	if s3.options.awsSecretAccessKey == "" {
-		return nil, fmt.Errorf("no AWS secret access key has been provided")
-	}
-	if s3.options.awsRegion == "" {
-		return nil, fmt.Errorf("no AWS region has been provided")
-	}
-	if s3.options.awsBucket == "" {
-		return nil, fmt.Errorf("no AWS bucket has been provided")
-	}
-	if s3.options.fileUploadStorage == "" {
-		return nil, fmt.Errorf("no file upload storage has been provided")
+	err := s3.setRequiredOptions()
+	if err != nil {
+		return nil, err
 	}
 
+	s3.setNonRequiredOptions()
+
 	return &s3.options, nil
+
+}
+
+func (s3 *S3OptionsBuilder) setRequiredOptions() error {
+	if s3.options.awsAccessKeyId == "" {
+		return fmt.Errorf("no AWS access key id has been provided")
+	}
+	if s3.options.awsSecretAccessKey == "" {
+		return fmt.Errorf("no AWS secret access key has been provided")
+	}
+	if s3.options.awsRegion == "" {
+		return fmt.Errorf("no AWS region has been provided")
+	}
+	if s3.options.awsBucket == "" {
+		return fmt.Errorf("no AWS bucket has been provided")
+	}
+	if s3.options.fileUploadStorage == "" {
+		return fmt.Errorf("no file upload storage has been provided")
+	}
+
+	return nil
+}
+
+func (s3 *S3OptionsBuilder) setNonRequiredOptions() {
+
 }
 
 type S3OptionsProvider interface {

--- a/pkg/3scale/amp/component/wildcardrouter.go
+++ b/pkg/3scale/amp/component/wildcardrouter.go
@@ -19,9 +19,17 @@ type WildcardRouter struct {
 }
 
 type WildcardRouterOptions struct {
+	wildcardRouterNonRequiredOptions
+	wildcardRouterRequiredOptions
+}
+
+type wildcardRouterRequiredOptions struct {
 	appLabel       string
 	wildcardDomain string
 	wildcardPolicy string
+}
+
+type wildcardRouterNonRequiredOptions struct {
 }
 
 type WildcardRouterOptionsBuilder struct {
@@ -41,17 +49,32 @@ func (wr *WildcardRouterOptionsBuilder) WildcardPolicy(wildcardPolicy string) {
 }
 
 func (wr *WildcardRouterOptionsBuilder) Build() (*WildcardRouterOptions, error) {
-	if wr.options.appLabel == "" {
-		return nil, fmt.Errorf("no AppLabel has been provided")
-	}
-	if wr.options.wildcardDomain == "" {
-		return nil, fmt.Errorf("no Wildcard Domain has been provided")
-	}
-	if wr.options.wildcardPolicy == "" {
-		return nil, fmt.Errorf("no Wildcard Policy has been provided")
+	err := wr.setRequiredOptions()
+	if err != nil {
+		return nil, err
 	}
 
+	wr.setNonRequiredOptions()
+
 	return &wr.options, nil
+}
+
+func (wr *WildcardRouterOptionsBuilder) setRequiredOptions() error {
+	if wr.options.appLabel == "" {
+		return fmt.Errorf("no AppLabel has been provided")
+	}
+	if wr.options.wildcardDomain == "" {
+		return fmt.Errorf("no Wildcard Domain has been provided")
+	}
+	if wr.options.wildcardPolicy == "" {
+		return fmt.Errorf("no Wildcard Policy has been provided")
+	}
+
+	return nil
+}
+
+func (wr *WildcardRouterOptionsBuilder) setNonRequiredOptions() {
+
 }
 
 type WildcardRouterOptionsProvider interface {


### PR DESCRIPTION
Refactor generator component options into required and nonrequired
    
Refactor options for apicast, backend, ha, memcached,
mysql, productized, redis, s3, system and wildcardrouter
components.

This has been done because at operator level you need to be able to set the secrets fields when constructing the components, to be able to reconcile the possible secrets that already exist.