### PR TITLE
Move secret field names and names into constants

### DIFF
--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -13,6 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	ApicastSecretRedisSecretName             = "apicast-redis"
+	ApicastSecretRedisProductionURLFieldName = "PRODUCTION_URL"
+	ApicastSecretRedisStagingURLFieldName    = "STAGING_URL"
+)
+
 type Apicast struct {
 	options []string
 	Options *ApicastOptions
@@ -619,7 +625,7 @@ func (apicast *Apicast) buildApicastStagingEnv() []v1.EnvVar {
 		createEnvVarFromValue("APICAST_CONFIGURATION_LOADER", "lazy"),
 		createEnvVarFromValue("APICAST_CONFIGURATION_CACHE", "0"),
 		createEnvVarFromValue("THREESCALE_DEPLOYMENT_ENV", "staging"),
-		createEnvvarFromSecret("REDIS_URL", "apicast-redis", "STAGING_URL"),
+		createEnvvarFromSecret("REDIS_URL", ApicastSecretRedisSecretName, ApicastSecretRedisStagingURLFieldName),
 	)
 	return result
 }
@@ -631,7 +637,7 @@ func (apicast *Apicast) buildApicastProductionEnv() []v1.EnvVar {
 		createEnvVarFromValue("APICAST_CONFIGURATION_LOADER", "boot"),
 		createEnvVarFromValue("APICAST_CONFIGURATION_CACHE", "300"),
 		createEnvVarFromValue("THREESCALE_DEPLOYMENT_ENV", "production"),
-		createEnvvarFromSecret("REDIS_URL", "apicast-redis", "PRODUCTION_URL"),
+		createEnvvarFromSecret("REDIS_URL", ApicastSecretRedisSecretName, ApicastSecretRedisProductionURLFieldName),
 	)
 	return result
 }
@@ -661,15 +667,15 @@ func (apicast *Apicast) buildApicastRedisSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "apicast-redis",
+			Name: ApicastSecretRedisSecretName,
 			Labels: map[string]string{
 				"app":              apicast.Options.appLabel,
 				"3scale.component": "apicast",
 			},
 		},
 		StringData: map[string]string{
-			"PRODUCTION_URL": *apicast.Options.redisProductionURL,
-			"STAGING_URL":    *apicast.Options.redisStagingURL,
+			ApicastSecretRedisProductionURLFieldName: *apicast.Options.redisProductionURL,
+			ApicastSecretRedisStagingURLFieldName:    *apicast.Options.redisStagingURL,
 		},
 		Type: v1.SecretTypeOpaque,
 	}

--- a/pkg/3scale/amp/component/s3.go
+++ b/pkg/3scale/amp/component/s3.go
@@ -10,6 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	S3SecretAWSSecretName               = "aws-auth"
+	S3SecretAWSAccessKeyIdFieldName     = "AWS_ACCESS_KEY_ID"
+	S3SecretAWSSecretAccessKeyFieldName = "AWS_SECRET_ACCESS_KEY"
+)
+
 type S3 struct {
 	options []string
 	Options *S3Options
@@ -209,8 +215,8 @@ func (s3 *S3) removeRWXStorageClassParameter(template *templatev1.Template) {
 func (s3 *S3) getNewCfgMapElements() []v1.EnvVar {
 	return []v1.EnvVar{
 		createEnvVarFromConfigMap("FILE_UPLOAD_STORAGE", "system-environment", "FILE_UPLOAD_STORAGE"),
-		createEnvvarFromSecret("AWS_ACCESS_KEY_ID", "aws-auth", "AWS_ACCESS_KEY_ID"),
-		createEnvvarFromSecret("AWS_SECRET_ACCESS_KEY", "aws-auth", "AWS_SECRET_ACCESS_KEY"),
+		createEnvvarFromSecret("AWS_ACCESS_KEY_ID", S3SecretAWSSecretName, S3SecretAWSAccessKeyIdFieldName),
+		createEnvvarFromSecret("AWS_SECRET_ACCESS_KEY", S3SecretAWSSecretName, S3SecretAWSSecretAccessKeyFieldName),
 		createEnvVarFromConfigMap("AWS_BUCKET", "system-environment", "AWS_BUCKET"),
 		createEnvVarFromConfigMap("AWS_REGION", "system-environment", "AWS_REGION"),
 	}
@@ -341,13 +347,12 @@ func (s3 *S3) buildS3AWSSecret() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "aws-auth",
+			Name: S3SecretAWSSecretName,
 		},
 		StringData: map[string]string{
-			"AWS_ACCESS_KEY_ID":     s3.Options.awsAccessKeyId,
-			"AWS_SECRET_ACCESS_KEY": s3.Options.awsSecretAccessKey,
+			S3SecretAWSAccessKeyIdFieldName:     s3.Options.awsAccessKeyId,
+			S3SecretAWSSecretAccessKeyFieldName: s3.Options.awsSecretAccessKey,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-
 }

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -14,6 +14,56 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	SystemSecretSystemDatabaseSecretName   = "system-database"
+	SystemSecretSystemDatabaseURLFieldName = "URL"
+)
+
+const (
+	SystemSecretSystemMemcachedSecretName       = "system-memcache"
+	SystemSecretSystemMemcachedServersFieldName = "SERVERS"
+)
+
+const (
+	SystemSecretSystemRecaptchaSecretName          = "system-recaptcha"
+	SystemSecretSystemRecaptchaPublicKeyFieldName  = "PUBLIC_KEY"
+	SystemSecretSystemRecaptchaPrivateKeyFieldName = "PRIVATE_KEY"
+)
+
+const (
+	SystemSecretSystemEventsHookSecretName        = "system-events-hook"
+	SystemSecretSystemEventsHookURLFieldName      = "URL"
+	SystemSecretSystemEventsHookPasswordFieldName = "PASSWORD"
+)
+
+const (
+	SystemSecretSystemRedisSecretName   = "system-redis"
+	SystemSecretSystemRedisURLFieldName = "URL"
+)
+
+const (
+	SystemSecretSystemAppSecretName             = "system-app"
+	SystemSecretSystemAppSecretKeyBaseFieldName = "SECRET_KEY_BASE"
+)
+
+const (
+	SystemSecretSystemSeedSecretName                = "system-seed"
+	SystemSecretSystemSeedMasterDomainFieldName     = "MASTER_DOMAIN"
+	SystemSecretSystemSeedMasterUserFieldName       = "MASTER_USER"
+	SystemSecretSystemSeedMasterPasswordFieldName   = "MASTER_PASSWORD"
+	SystemSecretSystemSeedAdminAccessTokenFieldName = "ADMIN_ACCESS_TOKEN"
+	SystemSecretSystemSeedAdminUserFieldName        = "ADMIN_USER"
+	SystemSecretSystemSeedAdminPasswordFieldName    = "ADMIN_PASSWORD"
+	SystemSecretSystemSeedTenantNameFieldName       = "TENANT_NAME"
+)
+
+const (
+	SystemSecretSystemMasterApicastSecretName                    = "system-master-apicast"
+	SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName = "PROXY_CONFIGS_ENDPOINT"
+	SystemSecretSystemMasterApicastBaseURL                       = "BASE_URL"
+	SystemSecretSystemMsaterApicastAccessToken                   = "ACCESS_TOKEN"
+)
+
 type System struct {
 	options []string
 	Options *SystemOptions
@@ -528,7 +578,7 @@ func (system *System) buildSystemSphinxEnv() []v1.EnvVar {
 
 	result = append(result,
 		createEnvVarFromConfigMap("RAILS_ENV", "system-environment", "RAILS_ENV"),
-		createEnvvarFromSecret("DATABASE_URL", "system-database", "URL"),
+		createEnvvarFromSecret("DATABASE_URL", SystemSecretSystemDatabaseSecretName, SystemSecretSystemDatabaseURLFieldName),
 		createEnvVarFromValue("THINKING_SPHINX_ADDRESS", "0.0.0.0"),
 		createEnvVarFromValue("THINKING_SPHINX_CONFIGURATION_FILE", "db/sphinx/production.conf"),
 		createEnvVarFromValue("THINKING_SPHINX_PID_FILE", "db/sphinx/searchd.pid"),
@@ -545,30 +595,30 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 	result = append(result, baseEnvConfigMapEnvs...)
 
 	result = append(result,
-		createEnvvarFromSecret("DATABASE_URL", "system-database", "URL"),
+		createEnvvarFromSecret("DATABASE_URL", SystemSecretSystemDatabaseSecretName, SystemSecretSystemDatabaseURLFieldName),
 
-		createEnvvarFromSecret("MASTER_DOMAIN", "system-seed", "MASTER_DOMAIN"),
-		createEnvvarFromSecret("MASTER_USER", "system-seed", "MASTER_USER"),
-		createEnvvarFromSecret("MASTER_PASSWORD", "system-seed", "MASTER_PASSWORD"),
+		createEnvvarFromSecret("MASTER_DOMAIN", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedMasterDomainFieldName),
+		createEnvvarFromSecret("MASTER_USER", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedMasterUserFieldName),
+		createEnvvarFromSecret("MASTER_PASSWORD", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedMasterPasswordFieldName),
 
-		createEnvvarFromSecret("ADMIN_ACCESS_TOKEN", "system-seed", "ADMIN_ACCESS_TOKEN"),
-		createEnvvarFromSecret("USER_LOGIN", "system-seed", "ADMIN_USER"),
-		createEnvvarFromSecret("USER_PASSWORD", "system-seed", "ADMIN_PASSWORD"),
-		createEnvvarFromSecret("TENANT_NAME", "system-seed", "TENANT_NAME"),
+		createEnvvarFromSecret("ADMIN_ACCESS_TOKEN", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedAdminAccessTokenFieldName),
+		createEnvvarFromSecret("USER_LOGIN", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedAdminUserFieldName),
+		createEnvvarFromSecret("USER_PASSWORD", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedAdminPasswordFieldName),
+		createEnvvarFromSecret("TENANT_NAME", SystemSecretSystemSeedSecretName, SystemSecretSystemSeedTenantNameFieldName),
 
 		createEnvVarFromValue("THINKING_SPHINX_ADDRESS", "system-sphinx"),
 		createEnvVarFromValue("THINKING_SPHINX_CONFIGURATION_FILE", "/tmp/sphinx.conf"),
 
-		createEnvvarFromSecret("EVENTS_SHARED_SECRET", "system-events-hook", "PASSWORD"),
+		createEnvvarFromSecret("EVENTS_SHARED_SECRET", SystemSecretSystemEventsHookSecretName, SystemSecretSystemEventsHookPasswordFieldName),
 
-		createEnvvarFromSecret("RECAPTCHA_PUBLIC_KEY", "system-recaptcha", "PUBLIC_KEY"),
-		createEnvvarFromSecret("RECAPTCHA_PRIVATE_KEY", "system-recaptcha", "PRIVATE_KEY"),
+		createEnvvarFromSecret("RECAPTCHA_PUBLIC_KEY", SystemSecretSystemRecaptchaSecretName, SystemSecretSystemRecaptchaPublicKeyFieldName),
+		createEnvvarFromSecret("RECAPTCHA_PRIVATE_KEY", SystemSecretSystemRecaptchaSecretName, SystemSecretSystemRecaptchaPrivateKeyFieldName),
 
-		createEnvvarFromSecret("SECRET_KEY_BASE", "system-app", "SECRET_KEY_BASE"),
+		createEnvvarFromSecret("SECRET_KEY_BASE", SystemSecretSystemAppSecretName, SystemSecretSystemAppSecretKeyBaseFieldName),
 
-		createEnvvarFromSecret("REDIS_URL", "system-redis", "URL"),
+		createEnvvarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
 
-		createEnvvarFromSecret("MEMCACHE_SERVERS", "system-memcache", "SERVERS"),
+		createEnvvarFromSecret("MEMCACHE_SERVERS", SystemSecretSystemMemcachedSecretName, SystemSecretSystemMemcachedServersFieldName),
 
 		createEnvvarFromSecret("BACKEND_REDIS_URL", "backend-redis", "REDIS_STORAGE_URL"),
 	)
@@ -632,14 +682,14 @@ func (system *System) buildSystemDatabaseSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-database",
+			Name: SystemSecretSystemDatabaseSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"URL": *system.Options.databaseURL,
+			SystemSecretSystemDatabaseURLFieldName: *system.Options.databaseURL,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -652,14 +702,14 @@ func (system *System) buildSystemMemcachedSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-memcache",
+			Name: SystemSecretSystemMemcachedSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"SERVERS": *system.Options.memcachedURL,
+			SystemSecretSystemMemcachedServersFieldName: *system.Options.memcachedURL,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -672,15 +722,15 @@ func (system *System) buildSystemRecaptchaSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-recaptcha",
+			Name: SystemSecretSystemRecaptchaSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"PUBLIC_KEY":  system.Options.recaptchaPublicKey,
-			"PRIVATE_KEY": system.Options.recaptchaPrivateKey,
+			SystemSecretSystemRecaptchaPublicKeyFieldName:  system.Options.recaptchaPublicKey,
+			SystemSecretSystemRecaptchaPrivateKeyFieldName: system.Options.recaptchaPrivateKey,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -693,15 +743,15 @@ func (system *System) buildSystemEventsHookSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-events-hook",
+			Name: SystemSecretSystemEventsHookSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"URL":      *system.Options.eventHooksURL,
-			"PASSWORD": system.Options.backendSharedSecret,
+			SystemSecretSystemEventsHookURLFieldName:      *system.Options.eventHooksURL,
+			SystemSecretSystemEventsHookPasswordFieldName: system.Options.backendSharedSecret,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -714,14 +764,14 @@ func (system *System) buildSystemRedisSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-redis",
+			Name: SystemSecretSystemRedisSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"URL": *system.Options.redisURL,
+			SystemSecretSystemRedisURLFieldName: *system.Options.redisURL,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -734,14 +784,14 @@ func (system *System) buildSystemAppSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-app", // TODO sure this should be a secret on its own?? maybe can join different secrets into one with more values?
+			Name: SystemSecretSystemAppSecretName, // TODO sure this should be a secret on its own?? maybe can join different secrets into one with more values?
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"SECRET_KEY_BASE": system.Options.appSecretKeyBase,
+			SystemSecretSystemAppSecretKeyBaseFieldName: system.Options.appSecretKeyBase,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -754,20 +804,20 @@ func (system *System) buildSystemSeedSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-seed",
+			Name: SystemSecretSystemSeedSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"MASTER_DOMAIN":      system.Options.masterName,
-			"MASTER_USER":        system.Options.masterUsername,
-			"MASTER_PASSWORD":    system.Options.masterPassword,
-			"ADMIN_ACCESS_TOKEN": system.Options.adminAccessToken,
-			"ADMIN_USER":         system.Options.adminUsername,
-			"ADMIN_PASSWORD":     system.Options.adminPassword,
-			"TENANT_NAME":        system.Options.tenantName,
+			SystemSecretSystemSeedMasterDomainFieldName:     system.Options.masterName,
+			SystemSecretSystemSeedMasterUserFieldName:       system.Options.masterUsername,
+			SystemSecretSystemSeedMasterPasswordFieldName:   system.Options.masterPassword,
+			SystemSecretSystemSeedAdminAccessTokenFieldName: system.Options.adminAccessToken,
+			SystemSecretSystemSeedAdminUserFieldName:        system.Options.adminUsername,
+			SystemSecretSystemSeedAdminPasswordFieldName:    system.Options.adminPassword,
+			SystemSecretSystemSeedTenantNameFieldName:       system.Options.tenantName,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -780,16 +830,16 @@ func (system *System) buildSystemMasterApicastSecrets() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-master-apicast",
+			Name: SystemSecretSystemMasterApicastSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
 				"3scale.component": "system",
 			},
 		},
 		StringData: map[string]string{
-			"PROXY_CONFIGS_ENDPOINT": *system.Options.apicastSystemMasterProxyConfigEndpoint,
-			"BASE_URL":               *system.Options.apicastSystemMasterBaseURL,
-			"ACCESS_TOKEN":           system.Options.apicastAccessToken,
+			SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName: *system.Options.apicastSystemMasterProxyConfigEndpoint,
+			SystemSecretSystemMasterApicastBaseURL:                       *system.Options.apicastSystemMasterBaseURL,
+			SystemSecretSystemMsaterApicastAccessToken:                   system.Options.apicastAccessToken,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -1184,7 +1234,7 @@ func (system *System) buildSystemSidekiqDeploymentConfig() *appsv1.DeploymentCon
 							},
 							Env: []v1.EnvVar{
 								createEnvVarFromValue("SLEEP_SECONDS", "1"),
-								createEnvvarFromSecret("REDIS_URL", "system-redis", "URL"),
+								createEnvvarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
 							},
 						},
 					},

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -12,6 +12,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	ZyncSecretName                         = "zync"
+	ZyncSecretKeyBaseFieldName             = "SECRET_KEY_BASE"
+	ZyncSecretDatabaseURLFieldName         = "DATABASE_URL"
+	ZyncSecretDatabasePasswordFieldName    = "ZYNC_DATABASE_PASSWORD"
+	ZyncSecretAuthenticationTokenFieldName = "ZYNC_AUTHENTICATION_TOKEN"
+)
+
 type Zync struct {
 	options []string
 	Options *ZyncOptions
@@ -192,17 +200,17 @@ func (zync *Zync) buildZyncSecret() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "zync",
+			Name: ZyncSecretName,
 			Labels: map[string]string{
 				"app":              zync.Options.appLabel,
 				"3scale.component": "zync",
 			},
 		},
 		StringData: map[string]string{
-			"SECRET_KEY_BASE":           zync.Options.secretKeyBase,
-			"DATABASE_URL":              *zync.Options.databaseURL,
-			"ZYNC_DATABASE_PASSWORD":    zync.Options.databasePassword,
-			"ZYNC_AUTHENTICATION_TOKEN": zync.Options.authenticationToken,
+			ZyncSecretKeyBaseFieldName:             zync.Options.secretKeyBase,
+			ZyncSecretDatabaseURLFieldName:         *zync.Options.databaseURL,
+			ZyncSecretDatabasePasswordFieldName:    zync.Options.databasePassword,
+			ZyncSecretAuthenticationTokenFieldName: zync.Options.authenticationToken,
 		},
 		Type: v1.SecretTypeOpaque,
 	}


### PR DESCRIPTION
Refactor secret names and field names into constants
for apicast, backend, s3, system and zync components