### PR TITLE
Make 'deploy' CircleCI job dependant on 'generator' job in 'templates' workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,8 @@ workflows:
       - generator
       - deploy:
           context: org-global
+          requires:
+            - generator
   nightly:
     jobs:
       - deploy:


### PR DESCRIPTION
In case the templates cannot be generated or are out-of-date it's best
to directly not execute the deployment of the api management platform.