### PR TITLE
Move system-mysql service into mysql component in 3scale datamodel

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1036,6 +1036,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1287,25 +1306,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1035,6 +1035,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1303,25 +1322,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -697,19 +697,6 @@ objects:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
     service_endpoint: http://backend-listener:3000
   type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      app: ${APP_LABEL}
-    name: system-database
-  stringData:
-    DB_PASSWORD: ${MYSQL_PASSWORD}
-    DB_USER: ${MYSQL_USER}
-    URL: ${SYSTEM_DATABASE_URL}
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -3327,6 +3314,17 @@ objects:
     wildcardPolicy: ${WILDCARD_POLICY}
   status:
     ingress: null
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      app: ${APP_LABEL}
+    name: system-database
+  stringData:
+    URL: ${SYSTEM_DATABASE_URL}
+  type: Opaque
 parameters:
 - description: AMP release tag.
   name: AMP_RELEASE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1071,6 +1071,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1328,25 +1347,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1070,6 +1070,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1344,25 +1363,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -1025,6 +1025,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1276,25 +1295,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -1024,6 +1024,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1292,25 +1311,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -687,19 +687,6 @@ objects:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
     service_endpoint: http://backend-listener:3000
   type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      app: ${APP_LABEL}
-    name: system-database
-  stringData:
-    DB_PASSWORD: ${MYSQL_PASSWORD}
-    DB_USER: ${MYSQL_USER}
-    URL: ${SYSTEM_DATABASE_URL}
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -3310,6 +3297,17 @@ objects:
     wildcardPolicy: ${WILDCARD_POLICY}
   status:
     ingress: null
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      app: ${APP_LABEL}
+    name: system-database
+  stringData:
+    URL: ${SYSTEM_DATABASE_URL}
+  type: Opaque
 parameters:
 - description: AMP release tag.
   name: AMP_RELEASE

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -1060,6 +1060,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1317,25 +1336,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -1059,6 +1059,25 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 - apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      3scale.component: system
+      3scale.component-element: mysql
+      app: ${APP_LABEL}
+    name: system-mysql
+  spec:
+    ports:
+    - name: system-mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      deploymentConfig: system-mysql
+  status:
+    loadBalancer: {}
+- apiVersion: v1
   data:
     my.cnf: |
       !include /etc/my.cnf
@@ -1333,25 +1352,6 @@ objects:
       weight: null
   status:
     ingress: null
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      3scale.component: system
-      3scale.component-element: mysql
-      app: ${APP_LABEL}
-    name: system-mysql
-  spec:
-    ports:
-    - name: system-mysql
-      port: 3306
-      protocol: TCP
-      targetPort: 3306
-    selector:
-      deploymentConfig: system-mysql
-  status:
-    loadBalancer: {}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pkg/3scale/amp/component/amphatemplate.go
+++ b/pkg/3scale/amp/component/amphatemplate.go
@@ -16,7 +16,14 @@ type AmpHATemplateOptions struct {
 
 func NewAmpHATemplate(options []string) *AmpHATemplate {
 	components := []Component{
-		NewAmpTemplate(options),
+		NewAmpImages(options),
+		NewRedis(options),
+		NewBackend(options),
+		NewMemcached(options),
+		NewSystem(options),
+		NewZync(options),
+		NewApicast(options),
+		NewWildcardRouter(options),
 		NewHighAvailability(options),
 	}
 

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -449,7 +449,6 @@ func (system *System) buildObjects() []runtime.RawExtension {
 	systemProviderRoute := system.buildSystemProviderRoute()
 	systemMasterRoute := system.buildSystemMasterRoute()
 	systemDeveloperRoute := system.buildSystemDeveloperRoute()
-	systemMysqlService := system.buildSystemMysqlService()
 	systemRedisService := system.buildSystemRedisService()
 	systemSphinxService := system.buildSystemSphinxService()
 	systemMemcachedService := system.buildSystemMemcachedService()
@@ -480,7 +479,6 @@ func (system *System) buildObjects() []runtime.RawExtension {
 		runtime.RawExtension{Object: systemProviderRoute},
 		runtime.RawExtension{Object: systemMasterRoute},
 		runtime.RawExtension{Object: systemDeveloperRoute},
-		runtime.RawExtension{Object: systemMysqlService},
 		runtime.RawExtension{Object: systemRedisService},
 		runtime.RawExtension{Object: systemSphinxService},
 		runtime.RawExtension{Object: systemMemcachedService},
@@ -1345,36 +1343,6 @@ func (system *System) buildSystemDeveloperService() *v1.Service {
 		},
 	}
 }
-
-func (system *System) buildSystemMysqlService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-mysql",
-			Labels: map[string]string{
-				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "mysql",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "system-mysql",
-					Protocol:   v1.Protocol("TCP"),
-					Port:       3306,
-					TargetPort: intstr.FromInt(3306),
-					NodePort:   0,
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "system-mysql"},
-		},
-	}
-}
-
 func (system *System) buildSystemRedisService() *v1.Service {
 	return &v1.Service{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
The system-mysql service has been moved into the
mysql component. This has been done because there are situations
where we don't want to deploy a mysql pod and instead use another
element, like an external database or a different database type.
By moving the system-mysql specific elements into the mysql component
we make sure that when this component is not used then this
elements are no created, and also we don't need another element
to remove them.

Also, highavailability component has been updated to create the secret
by itself because when highavailabilty compoent is used no mysql
component is used in the cluster.
