### PR TITLE
tenant controller: read secrets from CR namespace only

### DIFF
--- a/deploy/crds/api_v1alpha1_tenant_crd.yaml
+++ b/deploy/crds/api_v1alpha1_tenant_crd.yaml
@@ -26,13 +26,9 @@ spec:
               properties:
                 name:
                   type: string
-                namespace:
-                  type: string
             masterCredentialsRef:
               properties:
                 name:
-                  type: string
-                namespace:
                   type: string
             tenantSecretRef:
               properties:

--- a/pkg/controller/tenant/internal_reconciler.go
+++ b/pkg/controller/tenant/internal_reconciler.go
@@ -202,7 +202,7 @@ func (r *InternalReconciler) getAdminPassword() (string, error) {
 	err := r.k8sClient.Get(context.TODO(),
 		types.NamespacedName{
 			Name:      r.tenantR.Spec.AdminPasswordRef.Name,
-			Namespace: r.tenantR.Spec.AdminPasswordRef.Namespace,
+			Namespace: r.tenantR.Namespace,
 		},
 		tenantAdminSecret)
 
@@ -213,7 +213,7 @@ func (r *InternalReconciler) getAdminPassword() (string, error) {
 	passwordByteArray, ok := tenantAdminSecret.Data[secretMasterAdminPasswordKey]
 	if !ok {
 		return "", fmt.Errorf("Not found admin password secret (ns: %s, name: %s) attribute: %s",
-			r.tenantR.Spec.AdminPasswordRef.Namespace, r.tenantR.Spec.AdminPasswordRef.Name,
+			r.tenantR.Namespace, r.tenantR.Spec.AdminPasswordRef.Name,
 			secretMasterAdminPasswordKey)
 	}
 

--- a/pkg/controller/tenant/tenant_controller.go
+++ b/pkg/controller/tenant/tenant_controller.go
@@ -149,8 +149,9 @@ func FetchMasterCredentials(k8sClient client.Client, tenantR *apiv1alpha1.Tenant
 
 	err := k8sClient.Get(context.TODO(),
 		types.NamespacedName{
-			Name:      tenantR.Spec.MasterCredentialsRef.Name,
-			Namespace: tenantR.Spec.MasterCredentialsRef.Namespace,
+			Name: tenantR.Spec.MasterCredentialsRef.Name,
+			// Master credential secret MUST be on same namespace as tenant CR
+			Namespace: tenantR.Namespace,
 		},
 		masterCredentialsSecret)
 


### PR DESCRIPTION
Fixes #51 

Tenant controller will try to read master secret and admin password secret only from tenant CR namespace. Namespace cannot be specified in spec.