### PR TITLE
Relabel 3scale elements

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -19,8 +19,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -56,8 +56,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -93,8 +93,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -130,8 +130,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -167,8 +167,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -202,9 +202,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -234,9 +234,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -249,10 +249,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -311,9 +311,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -376,18 +376,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -402,9 +402,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -417,10 +417,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -479,9 +479,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -496,9 +496,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -517,10 +517,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -608,9 +608,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -629,10 +629,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -734,9 +734,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -753,8 +753,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -774,9 +774,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -795,10 +795,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -899,16 +899,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -919,8 +919,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -935,8 +935,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -947,9 +947,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -962,10 +962,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1042,9 +1042,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1065,9 +1065,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1085,18 +1085,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1111,8 +1111,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1124,9 +1124,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1145,10 +1145,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1191,9 +1191,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1210,9 +1210,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1229,9 +1229,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1248,9 +1248,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1270,9 +1270,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1292,9 +1292,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1314,9 +1314,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1333,9 +1333,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1352,9 +1352,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1417,8 +1417,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1433,9 +1433,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1457,17 +1457,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1732,10 +1732,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2584,9 +2584,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2605,10 +2605,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2911,9 +2911,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2932,10 +2932,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -3014,8 +3014,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -3026,8 +3026,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -3037,8 +3037,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -3050,8 +3050,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -3069,8 +3069,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -3081,8 +3081,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -3092,8 +3092,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3103,8 +3103,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3116,9 +3116,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3208,9 +3208,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3223,10 +3223,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3290,8 +3290,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3308,9 +3308,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3327,8 +3327,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3341,9 +3341,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3365,10 +3365,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3458,9 +3458,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3482,10 +3482,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3588,9 +3588,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3611,9 +3611,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3634,9 +3634,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3656,9 +3656,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3682,16 +3682,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3702,9 +3702,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3723,10 +3723,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3772,9 +3772,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3791,9 +3791,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -18,8 +18,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -55,8 +55,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -92,8 +92,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -129,8 +129,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -166,8 +166,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -201,9 +201,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -233,9 +233,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -248,10 +248,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -310,9 +310,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -375,18 +375,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -401,9 +401,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -416,10 +416,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -478,9 +478,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -495,9 +495,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -516,10 +516,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -607,9 +607,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -628,10 +628,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -733,9 +733,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -752,8 +752,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -773,9 +773,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -794,10 +794,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -898,16 +898,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -918,8 +918,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -934,8 +934,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -946,9 +946,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -961,10 +961,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1041,9 +1041,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1064,9 +1064,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1084,18 +1084,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1110,8 +1110,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1123,9 +1123,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1144,10 +1144,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1190,9 +1190,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-storage
   spec:
     accessModes:
@@ -1208,9 +1208,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1227,9 +1227,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1246,9 +1246,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1265,9 +1265,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1287,9 +1287,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1309,9 +1309,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1331,9 +1331,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1350,9 +1350,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1369,9 +1369,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1434,8 +1434,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1450,9 +1450,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1471,17 +1471,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1723,10 +1723,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2510,9 +2510,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2531,10 +2531,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2817,9 +2817,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2838,10 +2838,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -2920,8 +2920,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -2932,8 +2932,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -2943,8 +2943,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -2956,8 +2956,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -2975,8 +2975,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -2987,8 +2987,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -2998,8 +2998,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3009,8 +3009,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3022,9 +3022,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3114,9 +3114,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3129,10 +3129,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3196,8 +3196,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3214,9 +3214,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3233,8 +3233,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3247,9 +3247,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3271,10 +3271,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3364,9 +3364,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3388,10 +3388,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3494,9 +3494,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3517,9 +3517,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3540,9 +3540,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3562,9 +3562,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3588,16 +3588,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3608,9 +3608,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3629,10 +3629,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3678,9 +3678,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3697,9 +3697,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -18,8 +18,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -55,8 +55,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -92,8 +92,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -129,8 +129,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -166,8 +166,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -201,9 +201,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -233,9 +233,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 2
@@ -254,10 +254,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -351,9 +351,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 2
@@ -372,10 +372,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -483,9 +483,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -502,8 +502,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -523,9 +523,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 2
@@ -544,10 +544,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -654,16 +654,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -674,8 +674,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -690,8 +690,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -702,9 +702,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -723,10 +723,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -775,9 +775,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-storage
   spec:
     accessModes:
@@ -793,9 +793,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -812,9 +812,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -831,9 +831,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -850,9 +850,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -872,9 +872,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -894,9 +894,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -916,9 +916,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -935,9 +935,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1000,8 +1000,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1016,9 +1016,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1037,17 +1037,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 2
@@ -1289,10 +1289,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2094,9 +2094,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 2
@@ -2115,10 +2115,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2407,9 +2407,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2428,10 +2428,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -2516,8 +2516,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -2528,8 +2528,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: ${SYSTEM_REDIS_URL}
@@ -2539,8 +2539,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -2552,8 +2552,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -2571,8 +2571,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -2583,8 +2583,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -2594,8 +2594,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -2605,8 +2605,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 2
@@ -2618,9 +2618,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -2716,9 +2716,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -2731,10 +2731,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -2804,8 +2804,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -2822,9 +2822,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -2841,8 +2841,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -2855,9 +2855,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 2
@@ -2879,10 +2879,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -2978,9 +2978,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 2
@@ -3002,10 +3002,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3114,9 +3114,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3137,9 +3137,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3160,9 +3160,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3182,9 +3182,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3208,16 +3208,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: ${APICAST_PRODUCTION_REDIS_URL}
@@ -3228,9 +3228,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 2
@@ -3249,10 +3249,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3304,9 +3304,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3323,9 +3323,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}
@@ -3346,8 +3346,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     URL: ${SYSTEM_DATABASE_URL}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -19,8 +19,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -56,8 +56,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -93,8 +93,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -130,8 +130,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -167,8 +167,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -202,9 +202,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -234,9 +234,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -249,10 +249,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -317,9 +317,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -382,18 +382,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -408,9 +408,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -423,10 +423,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -491,9 +491,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -508,9 +508,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -529,10 +529,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -626,9 +626,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -647,10 +647,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -758,9 +758,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -777,8 +777,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -798,9 +798,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -819,10 +819,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -929,16 +929,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -949,8 +949,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -965,8 +965,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -977,9 +977,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -992,10 +992,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1077,9 +1077,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1100,9 +1100,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1120,18 +1120,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1146,8 +1146,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1159,9 +1159,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1180,10 +1180,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1232,9 +1232,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1251,9 +1251,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1270,9 +1270,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1289,9 +1289,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1311,9 +1311,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1333,9 +1333,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1355,9 +1355,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1374,9 +1374,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1393,9 +1393,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1458,8 +1458,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1474,9 +1474,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1498,17 +1498,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1773,10 +1773,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2643,9 +2643,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2664,10 +2664,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2976,9 +2976,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2997,10 +2997,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -3085,8 +3085,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -3097,8 +3097,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -3108,8 +3108,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -3121,8 +3121,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -3140,8 +3140,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -3152,8 +3152,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -3163,8 +3163,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3174,8 +3174,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3187,9 +3187,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3285,9 +3285,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3300,10 +3300,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3373,8 +3373,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3391,9 +3391,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3410,8 +3410,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3424,9 +3424,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3448,10 +3448,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3547,9 +3547,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3571,10 +3571,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3683,9 +3683,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3706,9 +3706,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3729,9 +3729,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3751,9 +3751,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3777,16 +3777,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3797,9 +3797,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3818,10 +3818,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3873,9 +3873,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3892,9 +3892,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -18,8 +18,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -55,8 +55,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -92,8 +92,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -129,8 +129,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -166,8 +166,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -201,9 +201,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -233,9 +233,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -248,10 +248,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -316,9 +316,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -381,18 +381,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -407,9 +407,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -422,10 +422,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -490,9 +490,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -507,9 +507,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -528,10 +528,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -625,9 +625,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -646,10 +646,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -757,9 +757,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -776,8 +776,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -797,9 +797,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -818,10 +818,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -928,16 +928,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -948,8 +948,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -964,8 +964,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -976,9 +976,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -991,10 +991,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1076,9 +1076,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1099,9 +1099,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1119,18 +1119,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1145,8 +1145,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1158,9 +1158,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1179,10 +1179,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1231,9 +1231,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-storage
   spec:
     accessModes:
@@ -1249,9 +1249,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1268,9 +1268,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1287,9 +1287,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1306,9 +1306,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1328,9 +1328,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1350,9 +1350,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1372,9 +1372,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1391,9 +1391,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1410,9 +1410,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1475,8 +1475,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1491,9 +1491,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1512,17 +1512,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1764,10 +1764,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2569,9 +2569,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2590,10 +2590,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2882,9 +2882,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2903,10 +2903,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -2991,8 +2991,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -3003,8 +3003,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -3014,8 +3014,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -3027,8 +3027,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -3046,8 +3046,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -3058,8 +3058,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -3069,8 +3069,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3080,8 +3080,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3093,9 +3093,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3191,9 +3191,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3206,10 +3206,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3279,8 +3279,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3297,9 +3297,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3316,8 +3316,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3330,9 +3330,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3354,10 +3354,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3453,9 +3453,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3477,10 +3477,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3589,9 +3589,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3612,9 +3612,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3635,9 +3635,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3657,9 +3657,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3683,16 +3683,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3703,9 +3703,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3724,10 +3724,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3779,9 +3779,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3798,9 +3798,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -19,8 +19,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -56,8 +56,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -93,8 +93,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -130,8 +130,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -167,8 +167,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -202,9 +202,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -227,9 +227,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -242,10 +242,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -303,9 +303,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -368,18 +368,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -394,9 +394,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -409,10 +409,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -471,9 +471,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -488,9 +488,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -509,10 +509,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -599,9 +599,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -620,10 +620,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -724,9 +724,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -743,8 +743,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -764,9 +764,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -785,10 +785,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -888,16 +888,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -908,8 +908,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -924,8 +924,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -936,9 +936,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -951,10 +951,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1031,9 +1031,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1054,9 +1054,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1074,18 +1074,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1100,8 +1100,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1113,9 +1113,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1134,10 +1134,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1180,9 +1180,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1199,9 +1199,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1218,9 +1218,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1237,9 +1237,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1259,9 +1259,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1281,9 +1281,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1303,9 +1303,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1322,9 +1322,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1341,9 +1341,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1406,8 +1406,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1422,9 +1422,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1446,17 +1446,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1721,10 +1721,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2572,9 +2572,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2593,10 +2593,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2898,9 +2898,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2919,10 +2919,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -3000,8 +3000,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -3012,8 +3012,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -3023,8 +3023,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -3036,8 +3036,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -3055,8 +3055,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -3067,8 +3067,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -3078,8 +3078,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3089,8 +3089,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3102,9 +3102,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3193,9 +3193,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3208,10 +3208,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3275,8 +3275,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3293,9 +3293,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3312,8 +3312,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3326,9 +3326,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3350,10 +3350,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3442,9 +3442,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3466,10 +3466,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3571,9 +3571,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3594,9 +3594,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3617,9 +3617,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3639,9 +3639,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3665,16 +3665,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3685,9 +3685,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3706,10 +3706,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3754,9 +3754,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3773,9 +3773,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -18,8 +18,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -55,8 +55,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -92,8 +92,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -129,8 +129,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -166,8 +166,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -201,9 +201,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -226,9 +226,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -241,10 +241,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -302,9 +302,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -367,18 +367,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -393,9 +393,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -408,10 +408,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -470,9 +470,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -487,9 +487,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -508,10 +508,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -598,9 +598,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -619,10 +619,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -723,9 +723,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -742,8 +742,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -763,9 +763,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -784,10 +784,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -887,16 +887,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -907,8 +907,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -923,8 +923,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -935,9 +935,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -950,10 +950,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1030,9 +1030,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1053,9 +1053,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1073,18 +1073,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1099,8 +1099,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1112,9 +1112,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1133,10 +1133,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1179,9 +1179,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-storage
   spec:
     accessModes:
@@ -1197,9 +1197,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1216,9 +1216,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1235,9 +1235,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1254,9 +1254,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1276,9 +1276,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1298,9 +1298,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1320,9 +1320,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1339,9 +1339,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1358,9 +1358,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1423,8 +1423,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1439,9 +1439,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1460,17 +1460,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1712,10 +1712,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2498,9 +2498,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2519,10 +2519,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2804,9 +2804,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2825,10 +2825,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -2906,8 +2906,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -2918,8 +2918,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -2929,8 +2929,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -2942,8 +2942,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -2961,8 +2961,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -2973,8 +2973,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -2984,8 +2984,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -2995,8 +2995,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3008,9 +3008,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3099,9 +3099,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3114,10 +3114,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3181,8 +3181,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3199,9 +3199,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3218,8 +3218,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3232,9 +3232,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3256,10 +3256,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3348,9 +3348,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3372,10 +3372,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3477,9 +3477,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3500,9 +3500,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3523,9 +3523,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3545,9 +3545,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3571,16 +3571,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3591,9 +3591,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3612,10 +3612,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3660,9 +3660,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3679,9 +3679,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -18,8 +18,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -55,8 +55,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -92,8 +92,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -129,8 +129,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -166,8 +166,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -201,9 +201,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -226,9 +226,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 2
@@ -247,10 +247,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -343,9 +343,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 2
@@ -364,10 +364,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -474,9 +474,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -493,8 +493,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -514,9 +514,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 2
@@ -535,10 +535,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -644,16 +644,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -664,8 +664,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -680,8 +680,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -692,9 +692,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -713,10 +713,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -765,9 +765,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-storage
   spec:
     accessModes:
@@ -783,9 +783,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -802,9 +802,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -821,9 +821,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -840,9 +840,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -862,9 +862,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -884,9 +884,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -906,9 +906,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -925,9 +925,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -990,8 +990,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1006,9 +1006,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1027,17 +1027,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 2
@@ -1279,10 +1279,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2083,9 +2083,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 2
@@ -2104,10 +2104,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2395,9 +2395,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2416,10 +2416,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -2503,8 +2503,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -2515,8 +2515,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: ${SYSTEM_REDIS_URL}
@@ -2526,8 +2526,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -2539,8 +2539,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -2558,8 +2558,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -2570,8 +2570,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -2581,8 +2581,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -2592,8 +2592,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 2
@@ -2605,9 +2605,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -2702,9 +2702,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -2717,10 +2717,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -2790,8 +2790,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -2808,9 +2808,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -2827,8 +2827,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -2841,9 +2841,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 2
@@ -2865,10 +2865,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -2963,9 +2963,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 2
@@ -2987,10 +2987,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3098,9 +3098,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3121,9 +3121,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3144,9 +3144,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3166,9 +3166,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3192,16 +3192,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: ${APICAST_PRODUCTION_REDIS_URL}
@@ -3212,9 +3212,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 2
@@ -3233,10 +3233,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3287,9 +3287,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3306,9 +3306,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}
@@ -3329,8 +3329,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     URL: ${SYSTEM_DATABASE_URL}

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -19,8 +19,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -56,8 +56,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -93,8 +93,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -130,8 +130,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -167,8 +167,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -202,9 +202,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -227,9 +227,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -242,10 +242,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -309,9 +309,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -374,18 +374,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -400,9 +400,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -415,10 +415,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -483,9 +483,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -500,9 +500,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -521,10 +521,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -617,9 +617,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -638,10 +638,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -748,9 +748,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -767,8 +767,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -788,9 +788,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -809,10 +809,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -918,16 +918,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -938,8 +938,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -954,8 +954,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -966,9 +966,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -981,10 +981,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1066,9 +1066,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1089,9 +1089,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1109,18 +1109,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1135,8 +1135,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1148,9 +1148,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1169,10 +1169,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1221,9 +1221,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1240,9 +1240,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1259,9 +1259,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1278,9 +1278,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1300,9 +1300,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1322,9 +1322,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1344,9 +1344,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1363,9 +1363,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1382,9 +1382,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1447,8 +1447,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1463,9 +1463,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1487,17 +1487,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1762,10 +1762,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2631,9 +2631,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2652,10 +2652,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2963,9 +2963,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2984,10 +2984,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -3071,8 +3071,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -3083,8 +3083,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -3094,8 +3094,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -3107,8 +3107,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -3126,8 +3126,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -3138,8 +3138,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -3149,8 +3149,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3160,8 +3160,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3173,9 +3173,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3270,9 +3270,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3285,10 +3285,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3358,8 +3358,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3376,9 +3376,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3395,8 +3395,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3409,9 +3409,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3433,10 +3433,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3531,9 +3531,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3555,10 +3555,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3666,9 +3666,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3689,9 +3689,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3712,9 +3712,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3734,9 +3734,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3760,16 +3760,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3780,9 +3780,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3801,10 +3801,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3855,9 +3855,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3874,9 +3874,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -18,8 +18,8 @@ objects:
       openshift.io/display-name: AMP backend
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: amp-backend
   spec:
     lookupPolicy:
@@ -55,8 +55,8 @@ objects:
       openshift.io/display-name: AMP Zync
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: amp-zync
   spec:
     lookupPolicy:
@@ -92,8 +92,8 @@ objects:
       openshift.io/display-name: AMP APIcast
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: amp-apicast
   spec:
     lookupPolicy:
@@ -129,8 +129,8 @@ objects:
       openshift.io/display-name: AMP APIcast Wildcard Router
     creationTimestamp: null
     labels:
-      3scale.component: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: wildcard-router
     name: amp-wildcard-router
   spec:
     lookupPolicy:
@@ -166,8 +166,8 @@ objects:
       openshift.io/display-name: AMP System
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: amp-system
   spec:
     lookupPolicy:
@@ -201,9 +201,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: postgresql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
@@ -226,9 +226,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     replicas: 1
@@ -241,10 +241,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: backend-redis
+          threescale_component: backend
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -308,9 +308,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis
   spec:
     ports:
@@ -373,18 +373,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: redis-config
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: redis
     name: backend-redis-storage
   spec:
     accessModes:
@@ -399,9 +399,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     replicas: 1
@@ -414,10 +414,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: redis
           app: ${APP_LABEL}
           deploymentConfig: system-redis
+          threescale_component: system
+          threescale_component_element: redis
       spec:
         containers:
         - args:
@@ -482,9 +482,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis-storage
   spec:
     accessModes:
@@ -499,9 +499,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: cron
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: cron
     name: backend-cron
   spec:
     replicas: 1
@@ -520,10 +520,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: cron
           app: ${APP_LABEL}
           deploymentConfig: backend-cron
+          threescale_component: backend
+          threescale_component_element: cron
       spec:
         containers:
         - args:
@@ -616,9 +616,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     replicas: 1
@@ -637,10 +637,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: listener
           app: ${APP_LABEL}
           deploymentConfig: backend-listener
+          threescale_component: backend
+          threescale_component_element: listener
       spec:
         containers:
         - args:
@@ -747,9 +747,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: listener
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: listener
     name: backend-listener
   spec:
     ports:
@@ -766,8 +766,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend
   spec:
     host: backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -787,9 +787,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
-      3scale.component-element: worker
       app: ${APP_LABEL}
+      threescale_component: backend
+      threescale_component_element: worker
     name: backend-worker
   spec:
     replicas: 1
@@ -808,10 +808,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: backend
-          3scale.component-element: worker
           app: ${APP_LABEL}
           deploymentConfig: backend-worker
+          threescale_component: backend
+          threescale_component_element: worker
       spec:
         containers:
         - args:
@@ -917,16 +917,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-internal-api
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
@@ -937,8 +937,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-redis
   stringData:
     REDIS_QUEUES_SENTINEL_HOSTS: ""
@@ -953,8 +953,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: backend
       app: ${APP_LABEL}
+      threescale_component: backend
     name: backend-listener
   stringData:
     route_endpoint: https://backend-${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -965,9 +965,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     replicas: 1
@@ -980,10 +980,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: mysql
           app: ${APP_LABEL}
           deploymentConfig: system-mysql
+          threescale_component: system
+          threescale_component_element: mysql
       spec:
         containers:
         - env:
@@ -1065,9 +1065,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: system-mysql
   spec:
     ports:
@@ -1088,9 +1088,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-main-conf
 - apiVersion: v1
   data:
@@ -1108,18 +1108,18 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-extra-conf
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: mysql
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: mysql
     name: mysql-storage
   spec:
     accessModes:
@@ -1134,8 +1134,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-database
   stringData:
     DB_PASSWORD: ${MYSQL_PASSWORD}
@@ -1147,9 +1147,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     replicas: 1
@@ -1168,10 +1168,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: memcache
           app: ${APP_LABEL}
           deploymentConfig: system-memcache
+          threescale_component: system
+          threescale_component_element: memcache
       spec:
         containers:
         - command:
@@ -1220,9 +1220,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-storage
   spec:
     accessModes:
@@ -1238,9 +1238,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider
   spec:
     ports:
@@ -1257,9 +1257,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     ports:
@@ -1276,9 +1276,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     ports:
@@ -1295,9 +1295,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: provider-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: provider-ui
     name: system-provider-admin
   spec:
     host: ${TENANT_NAME}-admin.${WILDCARD_DOMAIN}
@@ -1317,9 +1317,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: master-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: master-ui
     name: system-master
   spec:
     host: ${MASTER_NAME}.${WILDCARD_DOMAIN}
@@ -1339,9 +1339,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: developer-ui
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: developer-ui
     name: system-developer
   spec:
     host: ${TENANT_NAME}.${WILDCARD_DOMAIN}
@@ -1361,9 +1361,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: redis
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: redis
     name: system-redis
   spec:
     ports:
@@ -1380,9 +1380,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     ports:
@@ -1399,9 +1399,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: memcache
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: memcache
     name: system-memcache
   spec:
     ports:
@@ -1464,8 +1464,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system
 - apiVersion: v1
   data:
@@ -1480,9 +1480,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: smtp
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
     name: smtp
 - apiVersion: v1
   data:
@@ -1501,17 +1501,17 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-environment
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: app
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: app
     name: system-app
   spec:
     replicas: 1
@@ -1753,10 +1753,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: app
           app: ${APP_LABEL}
           deploymentConfig: system-app
+          threescale_component: system
+          threescale_component_element: app
       spec:
         containers:
         - args:
@@ -2557,9 +2557,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sidekiq
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sidekiq
     name: system-sidekiq
   spec:
     replicas: 1
@@ -2578,10 +2578,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sidekiq
           app: ${APP_LABEL}
           deploymentConfig: system-sidekiq
+          threescale_component: system
+          threescale_component_element: sidekiq
       spec:
         containers:
         - args:
@@ -2869,9 +2869,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
-      3scale.component-element: sphinx
       app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: sphinx
     name: system-sphinx
   spec:
     replicas: 1
@@ -2890,10 +2890,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: system
-          3scale.component-element: sphinx
           app: ${APP_LABEL}
           deploymentConfig: system-sphinx
+          threescale_component: system
+          threescale_component_element: sphinx
       spec:
         containers:
         - args:
@@ -2977,8 +2977,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
@@ -2989,8 +2989,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-redis
   stringData:
     URL: redis://system-redis:6379/1
@@ -3000,8 +3000,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
@@ -3013,8 +3013,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-seed
   stringData:
     ADMIN_ACCESS_TOKEN: ${ADMIN_ACCESS_TOKEN}
@@ -3032,8 +3032,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-recaptcha
   stringData:
     PRIVATE_KEY: ${RECAPTCHA_PRIVATE_KEY}
@@ -3044,8 +3044,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-app
   stringData:
     SECRET_KEY_BASE: ${SYSTEM_APP_SECRET_KEY_BASE}
@@ -3055,8 +3055,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: system
       app: ${APP_LABEL}
+      threescale_component: system
     name: system-memcache
   stringData:
     SERVERS: system-memcache:11211
@@ -3066,8 +3066,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     replicas: 1
@@ -3079,9 +3079,9 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
           app: ${APP_LABEL}
           deploymentConfig: zync
+          threescale_component: zync
       spec:
         containers:
         - env:
@@ -3176,9 +3176,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     replicas: 1
@@ -3191,10 +3191,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: zync
-          3scale.component-element: database
           app: ${APP_LABEL}
           deploymentConfig: zync-database
+          threescale_component: zync
+          threescale_component_element: database
       spec:
         containers:
         - env:
@@ -3264,8 +3264,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   spec:
     ports:
@@ -3282,9 +3282,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
-      3scale.component-element: database
       app: ${APP_LABEL}
+      threescale_component: zync
+      threescale_component_element: database
     name: zync-database
   spec:
     ports:
@@ -3301,8 +3301,8 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: zync
       app: ${APP_LABEL}
+      threescale_component: zync
     name: zync
   stringData:
     DATABASE_URL: postgresql://zync:${ZYNC_DATABASE_PASSWORD}@zync-database:5432/zync_production
@@ -3315,9 +3315,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     replicas: 1
@@ -3339,10 +3339,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: staging
           app: ${APP_LABEL}
           deploymentConfig: apicast-staging
+          threescale_component: apicast
+          threescale_component_element: staging
       spec:
         containers:
         - env:
@@ -3437,9 +3437,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     replicas: 1
@@ -3461,10 +3461,10 @@ objects:
           prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: production
           app: ${APP_LABEL}
           deploymentConfig: apicast-production
+          threescale_component: apicast
+          threescale_component_element: production
       spec:
         containers:
         - env:
@@ -3572,9 +3572,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: apicast-staging
   spec:
     ports:
@@ -3595,9 +3595,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: apicast-production
   spec:
     ports:
@@ -3618,9 +3618,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: staging
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: staging
     name: api-apicast-staging
   spec:
     host: api-${TENANT_NAME}-apicast-staging.${WILDCARD_DOMAIN}
@@ -3640,9 +3640,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: production
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: production
     name: api-apicast-production
   spec:
     host: api-${TENANT_NAME}-apicast-production.${WILDCARD_DOMAIN}
@@ -3666,16 +3666,16 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-environment
 - apiVersion: v1
   kind: Secret
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
       app: ${APP_LABEL}
+      threescale_component: apicast
     name: apicast-redis
   stringData:
     PRODUCTION_URL: redis://system-redis:6379/1
@@ -3686,9 +3686,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     replicas: 1
@@ -3707,10 +3707,10 @@ objects:
       metadata:
         creationTimestamp: null
         labels:
-          3scale.component: apicast
-          3scale.component-element: wildcard-router
           app: ${APP_LABEL}
           deploymentConfig: apicast-wildcard-router
+          threescale_component: apicast
+          threescale_component_element: wildcard-router
       spec:
         containers:
         - env:
@@ -3761,9 +3761,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     ports:
@@ -3780,9 +3780,9 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
-      3scale.component: apicast
-      3scale.component-element: wildcard-router
       app: ${APP_LABEL}
+      threescale_component: apicast
+      threescale_component_element: wildcard-router
     name: apicast-wildcard-router
   spec:
     host: apicast-wildcard.${WILDCARD_DOMAIN}

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -184,7 +184,7 @@ func (ampImages *AmpImages) buildAmpBackendImageStream() *imagev1.ImageStream {
 			Name: "amp-backend",
 			Labels: map[string]string{
 				"app":              ampImages.Options.appLabel,
-				"3scale.component": "backend",
+				"threescale_component": "backend",
 			},
 			Annotations: map[string]string{
 				"openshift.io/display-name": "AMP backend",
@@ -229,7 +229,7 @@ func (ampImages *AmpImages) buildAmpZyncImageStream() *imagev1.ImageStream {
 			Name: "amp-zync",
 			Labels: map[string]string{
 				"app":              ampImages.Options.appLabel,
-				"3scale.component": "zync",
+				"threescale_component": "zync",
 			},
 			Annotations: map[string]string{
 				"openshift.io/display-name": "AMP Zync",
@@ -274,7 +274,7 @@ func (ampImages *AmpImages) buildApicastImageStream() *imagev1.ImageStream {
 			Name: "amp-apicast",
 			Labels: map[string]string{
 				"app":              ampImages.Options.appLabel,
-				"3scale.component": "apicast",
+				"threescale_component": "apicast",
 			},
 			Annotations: map[string]string{
 				"openshift.io/display-name": "AMP APIcast",
@@ -319,7 +319,7 @@ func (ampImages *AmpImages) buildWildcardRouterImageStream() *imagev1.ImageStrea
 			Name: "amp-wildcard-router",
 			Labels: map[string]string{
 				"app":              ampImages.Options.appLabel,
-				"3scale.component": "wildcard-router",
+				"threescale_component": "wildcard-router",
 			},
 			Annotations: map[string]string{
 				"openshift.io/display-name": "AMP APIcast Wildcard Router",
@@ -364,7 +364,7 @@ func (ampImages *AmpImages) buildAmpSystemImageStream() *imagev1.ImageStream {
 			Name: "amp-system",
 			Labels: map[string]string{
 				"app":              ampImages.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 			Annotations: map[string]string{
 				"openshift.io/display-name": "AMP System",
@@ -409,7 +409,7 @@ func (ampImages *AmpImages) buildPostgreSQLImageStream() *imagev1.ImageStream {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "postgresql",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "postgresql", "app": ampImages.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "postgresql", "app": ampImages.Options.appLabel},
 		},
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -246,7 +246,7 @@ func (apicast *Apicast) buildApicastStagingRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "api-apicast-staging",
-			Labels: map[string]string{"app": apicast.Options.appLabel, "3scale.component": "apicast", "3scale.component-element": "staging"},
+			Labels: map[string]string{"app": apicast.Options.appLabel, "threescale_component": "apicast", "threescale_component_element": "staging"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "api-" + apicast.Options.tenantName + "-apicast-staging." + apicast.Options.wildcardDomain,
@@ -274,8 +274,8 @@ func (apicast *Apicast) buildApicastStagingService() *v1.Service {
 			Name: "apicast-staging",
 			Labels: map[string]string{
 				"app":                      apicast.Options.appLabel,
-				"3scale.component":         "apicast",
-				"3scale.component-element": "staging",
+				"threescale_component":         "apicast",
+				"threescale_component_element": "staging",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -306,7 +306,7 @@ func (apicast *Apicast) buildApicastProductionRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "api-apicast-production",
-			Labels: map[string]string{"app": apicast.Options.appLabel, "3scale.component": "apicast", "3scale.component-element": "production"},
+			Labels: map[string]string{"app": apicast.Options.appLabel, "threescale_component": "apicast", "threescale_component_element": "production"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "api-" + apicast.Options.tenantName + "-apicast-production." + apicast.Options.wildcardDomain,
@@ -334,8 +334,8 @@ func (apicast *Apicast) buildApicastProductionService() *v1.Service {
 			Name: "apicast-production",
 			Labels: map[string]string{
 				"app":                      apicast.Options.appLabel,
-				"3scale.component":         "apicast",
-				"3scale.component-element": "production",
+				"threescale_component":         "apicast",
+				"threescale_component_element": "production",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -365,8 +365,8 @@ func (apicast *Apicast) buildApicastStagingDeploymentConfig() *appsv1.Deployment
 			Name: "apicast-staging",
 			Labels: map[string]string{
 				"app":                      apicast.Options.appLabel,
-				"3scale.component":         "apicast",
-				"3scale.component-element": "staging",
+				"threescale_component":         "apicast",
+				"threescale_component_element": "staging",
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -413,8 +413,8 @@ func (apicast *Apicast) buildApicastStagingDeploymentConfig() *appsv1.Deployment
 					Labels: map[string]string{
 						"deploymentConfig":         "apicast-staging",
 						"app":                      apicast.Options.appLabel,
-						"3scale.component":         "apicast",
-						"3scale.component-element": "staging",
+						"threescale_component":         "apicast",
+						"threescale_component_element": "staging",
 					},
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -487,8 +487,8 @@ func (apicast *Apicast) buildApicastProductionDeploymentConfig() *appsv1.Deploym
 			Name: "apicast-production",
 			Labels: map[string]string{
 				"app":                      apicast.Options.appLabel,
-				"3scale.component":         "apicast",
-				"3scale.component-element": "production",
+				"threescale_component":         "apicast",
+				"threescale_component_element": "production",
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -536,8 +536,8 @@ func (apicast *Apicast) buildApicastProductionDeploymentConfig() *appsv1.Deploym
 					Labels: map[string]string{
 						"deploymentConfig":         "apicast-production",
 						"app":                      apicast.Options.appLabel,
-						"3scale.component":         "apicast",
-						"3scale.component-element": "production",
+						"threescale_component":         "apicast",
+						"threescale_component_element": "production",
 					},
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -658,7 +658,7 @@ func (apicast *Apicast) buildApicastEnvConfigMap() *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-environment",
-			Labels: map[string]string{"3scale.component": "apicast", "app": apicast.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "apicast", "app": apicast.Options.appLabel},
 		},
 		Data: map[string]string{
 			"APICAST_MANAGEMENT_API": apicast.Options.managementAPI,
@@ -678,7 +678,7 @@ func (apicast *Apicast) buildApicastRedisSecrets() *v1.Secret {
 			Name: ApicastSecretRedisSecretName,
 			Labels: map[string]string{
 				"app":              apicast.Options.appLabel,
-				"3scale.component": "apicast",
+				"threescale_component": "apicast",
 			},
 		},
 		StringData: map[string]string{

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -281,7 +281,7 @@ func (backend *Backend) buildBackendWorkerDeploymentConfig() *appsv1.DeploymentC
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-worker",
-			Labels: map[string]string{"3scale.component": "backend", "3scale.component-element": "worker", "app": backend.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "backend", "threescale_component_element": "worker", "app": backend.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -317,7 +317,7 @@ func (backend *Backend) buildBackendWorkerDeploymentConfig() *appsv1.DeploymentC
 			Selector: map[string]string{"deploymentConfig": "backend-worker"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "backend", "3scale.component-element": "worker", "app": backend.Options.appLabel, "deploymentConfig": "backend-worker"},
+					Labels: map[string]string{"threescale_component": "backend", "threescale_component_element": "worker", "app": backend.Options.appLabel, "deploymentConfig": "backend-worker"},
 				},
 				Spec: v1.PodSpec{InitContainers: []v1.Container{
 					v1.Container{
@@ -366,7 +366,7 @@ func (backend *Backend) buildBackendCronDeploymentConfig() *appsv1.DeploymentCon
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-cron",
-			Labels: map[string]string{"3scale.component": "backend", "3scale.component-element": "cron", "app": backend.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "backend", "threescale_component_element": "cron", "app": backend.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -402,7 +402,7 @@ func (backend *Backend) buildBackendCronDeploymentConfig() *appsv1.DeploymentCon
 			Selector: map[string]string{"deploymentConfig": "backend-cron"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "backend", "3scale.component-element": "cron", "app": backend.Options.appLabel, "deploymentConfig": "backend-cron"},
+					Labels: map[string]string{"threescale_component": "backend", "threescale_component_element": "cron", "app": backend.Options.appLabel, "deploymentConfig": "backend-cron"},
 				},
 				Spec: v1.PodSpec{InitContainers: []v1.Container{
 					v1.Container{
@@ -453,7 +453,7 @@ func (backend *Backend) buildBackendListenerDeploymentConfig() *appsv1.Deploymen
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-listener",
-			Labels: map[string]string{"3scale.component": "backend", "3scale.component-element": "listener", "app": backend.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "backend", "threescale_component_element": "listener", "app": backend.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -489,7 +489,7 @@ func (backend *Backend) buildBackendListenerDeploymentConfig() *appsv1.Deploymen
 			Selector: map[string]string{"deploymentConfig": "backend-listener"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "backend", "3scale.component-element": "listener", "app": backend.Options.appLabel, "deploymentConfig": "backend-listener"},
+					Labels: map[string]string{"threescale_component": "backend", "threescale_component_element": "listener", "app": backend.Options.appLabel, "deploymentConfig": "backend-listener"},
 				},
 				Spec: v1.PodSpec{Containers: []v1.Container{
 					v1.Container{
@@ -556,8 +556,8 @@ func (backend *Backend) buildBackendListenerService() *v1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "backend-listener",
 			Labels: map[string]string{
-				"3scale.component":         "backend",
-				"3scale.component-element": "listener",
+				"threescale_component":         "backend",
+				"threescale_component_element": "listener",
 				"app":                      backend.Options.appLabel,
 			},
 		},
@@ -586,7 +586,7 @@ func (backend *Backend) buildBackendListenerRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend",
-			Labels: map[string]string{"app": backend.Options.appLabel, "3scale.component": "backend"},
+			Labels: map[string]string{"app": backend.Options.appLabel, "threescale_component": "backend"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "backend-" + backend.Options.tenantName + "." + backend.Options.wildcardDomain,
@@ -612,7 +612,7 @@ func (backend *Backend) buildBackendEnvConfigMap() *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-environment",
-			Labels: map[string]string{"3scale.component": "backend", "app": backend.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "backend", "app": backend.Options.appLabel},
 		},
 		Data: map[string]string{
 			"RACK_ENV": "production",
@@ -630,7 +630,7 @@ func (backend *Backend) buildBackendRedisSecrets() *v1.Secret {
 			Name: BackendSecretBackendRedisSecretName,
 			Labels: map[string]string{
 				"app":              backend.Options.appLabel,
-				"3scale.component": "backend",
+				"threescale_component": "backend",
 			},
 		},
 		StringData: map[string]string{
@@ -694,7 +694,7 @@ func (backend *Backend) buildBackendInternalApiCredsForSystem() *v1.Secret {
 			Name: BackendSecretInternalApiSecretName,
 			Labels: map[string]string{
 				"app":              backend.Options.appLabel,
-				"3scale.component": "backend",
+				"threescale_component": "backend",
 			},
 		},
 		StringData: map[string]string{
@@ -715,7 +715,7 @@ func (backend *Backend) buildBackendListenerSecrets() *v1.Secret {
 			Name: BackendSecretBackendListenerSecretName,
 			Labels: map[string]string{
 				"app":              backend.Options.appLabel,
-				"3scale.component": "backend",
+				"threescale_component": "backend",
 			},
 		},
 		StringData: map[string]string{

--- a/pkg/3scale/amp/component/buildconfigs.go
+++ b/pkg/3scale/amp/component/buildconfigs.go
@@ -123,7 +123,7 @@ func (bcs *BuildConfigs) buildBackendBuildConfig() *buildv1.BuildConfig {
 			Name: "backend",
 			Labels: map[string]string{
 				"app":              bcs.Options.appLabel,
-				"3scale.component": "backend",
+				"threescale_component": "backend",
 			},
 		},
 		Spec: buildv1.BuildConfigSpec{
@@ -173,7 +173,7 @@ func (bcs *BuildConfigs) buildZyncBuildConfig() *buildv1.BuildConfig {
 			Name: "zync",
 			Labels: map[string]string{
 				"app":              bcs.Options.appLabel,
-				"3scale.component": "zync",
+				"threescale_component": "zync",
 			},
 		},
 		Spec: buildv1.BuildConfigSpec{
@@ -223,7 +223,7 @@ func (bcs *BuildConfigs) buildApicastBuildConfig() *buildv1.BuildConfig {
 			Name: "apicast",
 			Labels: map[string]string{
 				"app":              bcs.Options.appLabel,
-				"3scale.component": "apicast",
+				"threescale_component": "apicast",
 			},
 		},
 		Spec: buildv1.BuildConfigSpec{
@@ -276,7 +276,7 @@ func (bcs *BuildConfigs) buildWildcardRouterBuildConfig() *buildv1.BuildConfig {
 			Name: "wildcard-router",
 			Labels: map[string]string{
 				"app":              bcs.Options.appLabel,
-				"3scale.component": "wildcard-router",
+				"threescale_component": "wildcard-router",
 			},
 		},
 		Spec: buildv1.BuildConfigSpec{
@@ -328,7 +328,7 @@ func (bcs *BuildConfigs) buildSystemBuildConfig() *buildv1.BuildConfig {
 			Name: "system",
 			Labels: map[string]string{
 				"app":              bcs.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		Spec: buildv1.BuildConfigSpec{
@@ -374,7 +374,7 @@ func (bcs *BuildConfigs) buildRubyCentosSevenImageStream() *imagev1.ImageStream 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "ruby-24-centos7",
-			Labels: map[string]string{"3scale.component": "zync", "app": bcs.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "zync", "app": bcs.Options.appLabel},
 		},
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
@@ -398,7 +398,7 @@ func (bcs *BuildConfigs) buildOpenrestyCentosSevenImageStream() *imagev1.ImageSt
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "s2i-openresty-centos7",
-			Labels: map[string]string{"3scale.component": "apicast", "app": bcs.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "apicast", "app": bcs.Options.appLabel},
 		},
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{

--- a/pkg/3scale/amp/component/highavailability.go
+++ b/pkg/3scale/amp/component/highavailability.go
@@ -208,7 +208,7 @@ func (ha *HighAvailability) createSystemDatabaseSecret() *v1.Secret {
 			Name: SystemSecretSystemDatabaseSecretName,
 			Labels: map[string]string{
 				"app":              ha.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{

--- a/pkg/3scale/amp/component/memcached.go
+++ b/pkg/3scale/amp/component/memcached.go
@@ -164,7 +164,7 @@ func (m *Memcached) buildSystemMemcachedDeploymentConfig() *appsv1.DeploymentCon
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-memcache",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "memcache", "app": m.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "memcache", "app": m.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -190,7 +190,7 @@ func (m *Memcached) buildSystemMemcachedDeploymentConfig() *appsv1.DeploymentCon
 			Selector: map[string]string{"deploymentConfig": "system-memcache"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "memcache", "app": m.Options.appLabel, "deploymentConfig": "system-memcache"},
+					Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "memcache", "app": m.Options.appLabel, "deploymentConfig": "system-memcache"},
 				},
 				Spec: v1.PodSpec{Containers: []v1.Container{
 					v1.Container{

--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -229,8 +229,8 @@ func (mysql *Mysql) buildSystemMysqlService() *v1.Service {
 			Name: "system-mysql",
 			Labels: map[string]string{
 				"app":                      mysql.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "mysql",
+				"threescale_component":         "system",
+				"threescale_component_element": "mysql",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -256,7 +256,7 @@ func (mysql *Mysql) buildSystemMysqlMainConfigConfigMap() *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "mysql-main-conf",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "mysql", "app": mysql.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "mysql", "app": mysql.Options.appLabel},
 		},
 		Data: map[string]string{"my.cnf": "!include /etc/my.cnf\n!includedir /etc/my-extra.d\n"}}
 }
@@ -269,7 +269,7 @@ func (mysql *Mysql) buildSystemMysqlExtraConfigConfigMap() *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "mysql-extra-conf",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "mysql", "app": mysql.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "mysql", "app": mysql.Options.appLabel},
 		},
 		Data: map[string]string{"mysql-charset.cnf": "[client]\ndefault-character-set = utf8\n\n[mysql]\ndefault-character-set = utf8\n\n[mysqld]\ncharacter-set-server = utf8\ncollation-server = utf8_unicode_ci\n"}}
 }
@@ -282,7 +282,7 @@ func (mysql *Mysql) buildSystemMysqlPersistentVolumeClaim() *v1.PersistentVolume
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "mysql-storage",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "mysql", "app": mysql.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "mysql", "app": mysql.Options.appLabel},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{
@@ -299,7 +299,7 @@ func (mysql *Mysql) buildSystemMysqlDeploymentConfig() *appsv1.DeploymentConfig 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-mysql",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "mysql", "app": mysql.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "mysql", "app": mysql.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -313,7 +313,7 @@ func (mysql *Mysql) buildSystemMysqlDeploymentConfig() *appsv1.DeploymentConfig 
 			Selector: map[string]string{"deploymentConfig": "system-mysql"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "mysql", "app": mysql.Options.appLabel, "deploymentConfig": "system-mysql"},
+					Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "mysql", "app": mysql.Options.appLabel, "deploymentConfig": "system-mysql"},
 				},
 				Spec: v1.PodSpec{
 					Volumes: []v1.Volume{
@@ -419,7 +419,7 @@ func (mysql *Mysql) buildSystemDatabaseSecrets() *v1.Secret {
 			Name: SystemSecretSystemDatabaseSecretName,
 			Labels: map[string]string{
 				"app":              mysql.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -205,8 +205,8 @@ const (
 func (redis *Redis) buildLabelsForDeploymentConfigObjectMeta() map[string]string {
 	return map[string]string{
 		"app":                      redis.Options.appLabel,
-		"3scale.component":         backendComponentNameLabel,
-		"3scale.component-element": backendComponentElementLabel,
+		"threescale_component":         backendComponentNameLabel,
+		"threescale_component_element": backendComponentElementLabel,
 	}
 }
 
@@ -260,8 +260,8 @@ func (redis *Redis) buildPodObjectMeta() metav1.ObjectMeta {
 		Labels: map[string]string{
 			"deploymentConfig":         backendRedisDCSelectorName,
 			"app":                      redis.Options.appLabel,
-			"3scale.component":         backendComponentNameLabel,
-			"3scale.component-element": backendComponentElementLabel,
+			"threescale_component":         backendComponentNameLabel,
+			"threescale_component_element": backendComponentElementLabel,
 		},
 	}
 }
@@ -399,8 +399,8 @@ func (redis *Redis) buildServiceObjectMeta() metav1.ObjectMeta {
 func (redis *Redis) buildLabelsForServiceObjectMeta() map[string]string {
 	return map[string]string{
 		"app":                      redis.Options.appLabel,
-		"3scale.component":         "backend",
-		"3scale.component-element": "redis",
+		"threescale_component":         "backend",
+		"threescale_component_element": "redis",
 	}
 }
 
@@ -452,8 +452,8 @@ func (redis *Redis) buildConfigMapObjectMeta() metav1.ObjectMeta {
 func (redis *Redis) buildLabelsForConfigMapObjectMeta() map[string]string {
 	return map[string]string{
 		"app":                      redis.Options.appLabel,
-		"3scale.component":         "system", // TODO should also be redis???
-		"3scale.component-element": "redis",
+		"threescale_component":         "system", // TODO should also be redis???
+		"threescale_component_element": "redis",
 	}
 }
 
@@ -538,8 +538,8 @@ func (redis *Redis) buildPVCObjectMeta() metav1.ObjectMeta {
 func (redis *Redis) buildLabelsForPVCObjectMeta() map[string]string {
 	return map[string]string{
 		"app":                      redis.Options.appLabel,
-		"3scale.component":         "backend",
-		"3scale.component-element": "redis",
+		"threescale_component":         "backend",
+		"threescale_component_element": "redis",
 	}
 }
 
@@ -574,7 +574,7 @@ func (redis *Redis) buildSystemRedisObjects() []runtime.RawExtension {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-redis",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "redis", "app": redis.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "redis", "app": redis.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -589,7 +589,7 @@ func (redis *Redis) buildSystemRedisObjects() []runtime.RawExtension {
 			Selector: map[string]string{"deploymentConfig": "system-redis"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "redis", "app": redis.Options.appLabel, "deploymentConfig": "system-redis"},
+					Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "redis", "app": redis.Options.appLabel, "deploymentConfig": "system-redis"},
 				},
 				Spec: v1.PodSpec{
 					Volumes: []v1.Volume{
@@ -674,8 +674,8 @@ func (redis *Redis) buildSystemRedisObjects() []runtime.RawExtension {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "system-redis-storage",
 			Labels: map[string]string{
-				"3scale.component":         "system",
-				"3scale.component-element": "redis",
+				"threescale_component":         "system",
+				"threescale_component_element": "redis",
 				"app":                      redis.Options.appLabel,
 			},
 		},

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -647,7 +647,7 @@ func (system *System) buildSystemEnvironmentConfigMap() *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-environment",
-			Labels: map[string]string{"3scale.component": "system", "app": system.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "app": system.Options.appLabel},
 		},
 		Data: map[string]string{
 			"RAILS_ENV":              "production",
@@ -675,7 +675,7 @@ func (system *System) buildSystemMemcachedSecrets() *v1.Secret {
 			Name: SystemSecretSystemMemcachedSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -695,7 +695,7 @@ func (system *System) buildSystemRecaptchaSecrets() *v1.Secret {
 			Name: SystemSecretSystemRecaptchaSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -716,7 +716,7 @@ func (system *System) buildSystemEventsHookSecrets() *v1.Secret {
 			Name: SystemSecretSystemEventsHookSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -737,7 +737,7 @@ func (system *System) buildSystemRedisSecrets() *v1.Secret {
 			Name: SystemSecretSystemRedisSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -757,7 +757,7 @@ func (system *System) buildSystemAppSecrets() *v1.Secret {
 			Name: SystemSecretSystemAppSecretName, // TODO sure this should be a secret on its own?? maybe can join different secrets into one with more values?
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -777,7 +777,7 @@ func (system *System) buildSystemSeedSecrets() *v1.Secret {
 			Name: SystemSecretSystemSeedSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -805,7 +805,7 @@ func (system *System) buildSystemMasterApicastSecrets() *v1.Secret {
 			Name: SystemSecretSystemMasterApicastSecretName,
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		StringData: map[string]string{
@@ -825,7 +825,7 @@ func (system *System) buildSystemAppDeploymentConfig() *appsv1.DeploymentConfig 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-app",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "app", "app": system.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "app", "app": system.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -877,7 +877,7 @@ func (system *System) buildSystemAppDeploymentConfig() *appsv1.DeploymentConfig 
 			Selector: map[string]string{"deploymentConfig": "system-app"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "app", "app": system.Options.appLabel, "deploymentConfig": "system-app"},
+					Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "app", "app": system.Options.appLabel, "deploymentConfig": "system-app"},
 				},
 				Spec: v1.PodSpec{
 					Volumes: []v1.Volume{
@@ -1128,7 +1128,7 @@ func (system *System) buildSystemSidekiqDeploymentConfig() *appsv1.DeploymentCon
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-sidekiq",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "sidekiq", "app": system.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "sidekiq", "app": system.Options.appLabel},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Strategy: appsv1.DeploymentStrategy{
@@ -1164,7 +1164,7 @@ func (system *System) buildSystemSidekiqDeploymentConfig() *appsv1.DeploymentCon
 			Selector: map[string]string{"deploymentConfig": "system-sidekiq"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "sidekiq", "app": system.Options.appLabel, "deploymentConfig": "system-sidekiq"},
+					Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "sidekiq", "app": system.Options.appLabel, "deploymentConfig": "system-sidekiq"},
 				},
 				Spec: v1.PodSpec{
 					Volumes: []v1.Volume{
@@ -1261,8 +1261,8 @@ func (system *System) buildSystemSharedPVC() *v1.PersistentVolumeClaim {
 			Name: "system-storage",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "app",
+				"threescale_component":         "system",
+				"threescale_component_element": "app",
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
@@ -1288,8 +1288,8 @@ func (system *System) buildSystemProviderService() *v1.Service {
 			Name: "system-provider",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "provider-ui",
+				"threescale_component":         "system",
+				"threescale_component_element": "provider-ui",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -1316,8 +1316,8 @@ func (system *System) buildSystemMasterService() *v1.Service {
 			Name: "system-master",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "master-ui",
+				"threescale_component":         "system",
+				"threescale_component_element": "master-ui",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -1344,8 +1344,8 @@ func (system *System) buildSystemDeveloperService() *v1.Service {
 			Name: "system-developer",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "developer-ui",
+				"threescale_component":         "system",
+				"threescale_component_element": "developer-ui",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -1371,8 +1371,8 @@ func (system *System) buildSystemRedisService() *v1.Service {
 			Name: "system-redis",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "redis",
+				"threescale_component":         "system",
+				"threescale_component_element": "redis",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -1399,8 +1399,8 @@ func (system *System) buildSystemSphinxService() *v1.Service {
 			Name: "system-sphinx",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "sphinx",
+				"threescale_component":         "system",
+				"threescale_component_element": "sphinx",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -1427,8 +1427,8 @@ func (system *System) buildSystemMemcachedService() *v1.Service {
 			Name: "system-memcache",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "memcache",
+				"threescale_component":         "system",
+				"threescale_component_element": "memcache",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -1453,7 +1453,7 @@ func (system *System) buildSystemSmtpConfigMap() *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "smtp",
-			Labels: map[string]string{"3scale.component": "system", "3scale.component-element": "smtp", "app": system.Options.appLabel},
+			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "smtp", "app": system.Options.appLabel},
 		},
 		Data: map[string]string{"address": "", "authentication": "", "domain": "", "openssl.verify.mode": "", "password": "", "port": "", "username": ""}}
 }
@@ -1466,7 +1466,7 @@ func (system *System) buildSystemProviderRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-provider-admin",
-			Labels: map[string]string{"app": system.Options.appLabel, "3scale.component": "system", "3scale.component-element": "provider-ui"},
+			Labels: map[string]string{"app": system.Options.appLabel, "threescale_component": "system", "threescale_component_element": "provider-ui"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: system.Options.tenantName + "-admin." + system.Options.wildcardDomain,
@@ -1492,7 +1492,7 @@ func (system *System) buildSystemMasterRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-master",
-			Labels: map[string]string{"app": system.Options.appLabel, "3scale.component": "system", "3scale.component-element": "master-ui"},
+			Labels: map[string]string{"app": system.Options.appLabel, "threescale_component": "system", "threescale_component_element": "master-ui"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: system.Options.masterName + "." + system.Options.wildcardDomain,
@@ -1518,7 +1518,7 @@ func (system *System) buildSystemDeveloperRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-developer",
-			Labels: map[string]string{"app": system.Options.appLabel, "3scale.component": "system", "3scale.component-element": "developer-ui"},
+			Labels: map[string]string{"app": system.Options.appLabel, "threescale_component": "system", "threescale_component_element": "developer-ui"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: system.Options.tenantName + "." + system.Options.wildcardDomain,
@@ -1542,7 +1542,7 @@ func (system *System) buildSystemConfigMap() *v1.ConfigMap {
 			Name: "system",
 			Labels: map[string]string{
 				"app":              system.Options.appLabel,
-				"3scale.component": "system",
+				"threescale_component": "system",
 			},
 		},
 		TypeMeta: metav1.TypeMeta{
@@ -1621,8 +1621,8 @@ func (system *System) buildSystemSphinxDeploymentConfig() *appsv1.DeploymentConf
 			Name: "system-sphinx",
 			Labels: map[string]string{
 				"app":                      system.Options.appLabel,
-				"3scale.component":         "system",
-				"3scale.component-element": "sphinx",
+				"threescale_component":         "system",
+				"threescale_component_element": "sphinx",
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -1668,8 +1668,8 @@ func (system *System) buildSystemSphinxDeploymentConfig() *appsv1.DeploymentConf
 					Labels: map[string]string{
 						"app":                      system.Options.appLabel,
 						"deploymentConfig":         "system-sphinx",
-						"3scale.component":         "system",
-						"3scale.component-element": "sphinx",
+						"threescale_component":         "system",
+						"threescale_component_element": "sphinx",
 					},
 				},
 				Spec: v1.PodSpec{

--- a/pkg/3scale/amp/component/wildcardrouter.go
+++ b/pkg/3scale/amp/component/wildcardrouter.go
@@ -166,7 +166,7 @@ func (wr *WildcardRouter) buildWildcardRouterRoute() *routev1.Route {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-wildcard-router",
-			Labels: map[string]string{"app": wr.Options.appLabel, "3scale.component": "apicast", "3scale.component-element": "wildcard-router"},
+			Labels: map[string]string{"app": wr.Options.appLabel, "threescale_component": "apicast", "threescale_component_element": "wildcard-router"},
 		},
 		Spec: routev1.RouteSpec{
 			Host: "apicast-wildcard." + wr.Options.wildcardDomain,
@@ -195,8 +195,8 @@ func (wr *WildcardRouter) buildWildcardRouterService() *v1.Service {
 			Name: "apicast-wildcard-router",
 			Labels: map[string]string{
 				"app":                      wr.Options.appLabel,
-				"3scale.component":         "apicast",
-				"3scale.component-element": "wildcard-router",
+				"threescale_component":         "apicast",
+				"threescale_component_element": "wildcard-router",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -220,8 +220,8 @@ func (wr *WildcardRouter) buildWildcardRouterDeploymentConfig() *appsv1.Deployme
 			Name: "apicast-wildcard-router",
 			Labels: map[string]string{
 				"app":                      wr.Options.appLabel,
-				"3scale.component":         "apicast",
-				"3scale.component-element": "wildcard-router",
+				"threescale_component":         "apicast",
+				"threescale_component_element": "wildcard-router",
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -268,8 +268,8 @@ func (wr *WildcardRouter) buildWildcardRouterDeploymentConfig() *appsv1.Deployme
 					Labels: map[string]string{
 						"deploymentConfig":         "apicast-wildcard-router",
 						"app":                      wr.Options.appLabel,
-						"3scale.component":         "apicast",
-						"3scale.component-element": "wildcard-router",
+						"threescale_component":         "apicast",
+						"threescale_component_element": "wildcard-router",
 					},
 				},
 				Spec: v1.PodSpec{

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -203,7 +203,7 @@ func (zync *Zync) buildZyncSecret() *v1.Secret {
 			Name: ZyncSecretName,
 			Labels: map[string]string{
 				"app":              zync.Options.appLabel,
-				"3scale.component": "zync",
+				"threescale_component": "zync",
 			},
 		},
 		StringData: map[string]string{
@@ -311,7 +311,7 @@ func (zync *Zync) buildZyncDeploymentConfig() *appsv1.DeploymentConfig {
 			Name: "zync",
 			Labels: map[string]string{
 				"app":              zync.Options.appLabel,
-				"3scale.component": "zync",
+				"threescale_component": "zync",
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -341,7 +341,7 @@ func (zync *Zync) buildZyncDeploymentConfig() *appsv1.DeploymentConfig {
 					Labels: map[string]string{
 						"app":              zync.Options.appLabel,
 						"deploymentConfig": "zync",
-						"3scale.component": "zync",
+						"threescale_component": "zync",
 					},
 				},
 				Spec: v1.PodSpec{
@@ -477,8 +477,8 @@ func (zync *Zync) buildZyncDatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 			Name: "zync-database",
 			Labels: map[string]string{
 				"app":                      zync.Options.appLabel,
-				"3scale.component":         "zync",
-				"3scale.component-element": "database",
+				"threescale_component":         "zync",
+				"threescale_component_element": "database",
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -510,8 +510,8 @@ func (zync *Zync) buildZyncDatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 					Labels: map[string]string{
 						"deploymentConfig":         "zync-database",
 						"app":                      zync.Options.appLabel,
-						"3scale.component":         "zync",
-						"3scale.component-element": "database",
+						"threescale_component":         "zync",
+						"threescale_component_element": "database",
 					},
 				},
 				Spec: v1.PodSpec{
@@ -607,7 +607,7 @@ func (zync *Zync) buildZyncService() *v1.Service {
 			Name: "zync",
 			Labels: map[string]string{
 				"app":              zync.Options.appLabel,
-				"3scale.component": "zync",
+				"threescale_component": "zync",
 			},
 		},
 		Spec: v1.ServiceSpec{
@@ -634,8 +634,8 @@ func (zync *Zync) buildZyncDatabaseService() *v1.Service {
 			Name: "zync-database",
 			Labels: map[string]string{
 				"app":                      zync.Options.appLabel,
-				"3scale.component":         "zync",
-				"3scale.component-element": "database",
+				"threescale_component":         "zync",
+				"threescale_component_element": "database",
 			},
 		},
 		Spec: v1.ServiceSpec{


### PR DESCRIPTION
This comes from the issue https://github.com/3scale/3scale-operator/issues/31.

This change renames the 3scale.component and 3scale.component-element labels to threescale_component and threescale_component_element labels to be compatible with Prometheus labels datamodel.

Adding this would make those labels compatible with prometheus. However, as you can see in the following Kubernetes link https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set , some automated Kubernetes elements/controllers add labels that use / as some part of the label, which is incompatible with the Prometheus data model. Our operator (which has controllers )also  might need (and probably will) to add labels to perform object management.
So in my opinion what really solves the reported problem in #31 is applying the appropiate relabel scrape config depending on the desired needs. I have no problem in applying this PR but that would not really solve the reported problem because potentially labels incompatible with the Prometheus datamodel could appear as explained.

Also cc @slopezz