### PR TITLE
Improve tests stability

### DIFF
--- a/test/e2e/apimanager_controller_test.go
+++ b/test/e2e/apimanager_controller_test.go
@@ -43,7 +43,7 @@ func newAPIManagerCluster(t *testing.T) (*framework.Framework, *framework.TestCt
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: 5 * time.Minute, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}
@@ -69,7 +69,7 @@ func productizedUnconstrainedDeploymentSubtest(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: 5 * time.Minute, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}
@@ -108,7 +108,7 @@ func productizedUnconstrainedDeploymentSubtest(t *testing.T) {
 
 	start = time.Now()
 
-	err = f.Client.Create(goctx.TODO(), apimanager, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = f.Client.Create(goctx.TODO(), apimanager, &framework.CleanupOptions{TestContext: ctx, Timeout: 5 * time.Minute, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/apimanager_controller_test.go
+++ b/test/e2e/apimanager_controller_test.go
@@ -103,6 +103,11 @@ func productizedUnconstrainedDeploymentSubtest(t *testing.T) {
 		},
 	}
 
+	var start time.Time
+	var elapsed time.Duration
+
+	start = time.Now()
+
 	err = f.Client.Create(goctx.TODO(), apimanager, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
@@ -117,6 +122,9 @@ func productizedUnconstrainedDeploymentSubtest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	elapsed = time.Since(start)
+	t.Logf("APIManager creation and availability took %s seconds", elapsed)
 }
 
 func waitForAllApiManagerStandardDeploymentConfigs(t *testing.T, kubeclient kubernetes.Interface, osAppsV1Client clientappsv1.AppsV1Interface, namespace, name string, retryInterval, timeout time.Duration) error {

--- a/test/e2e/full_test.go
+++ b/test/e2e/full_test.go
@@ -48,7 +48,7 @@ func TestFullHappyPath(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: 5 * time.Minute, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestFullHappyPath(t *testing.T) {
 
 	start = time.Now()
 
-	err = f.Client.Create(goctx.TODO(), apimanager, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	err = f.Client.Create(goctx.TODO(), apimanager, &framework.CleanupOptions{TestContext: ctx, Timeout: 5 * time.Minute, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/full_test.go
+++ b/test/e2e/full_test.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/apis"
-	apiv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/capabilities/v1alpha1"
 	appsgroup "github.com/3scale/3scale-operator/pkg/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	apiv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/capabilities/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/controller/tenant"
 	"github.com/3scale/3scale-operator/test/e2e/e2eutil"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -97,6 +97,11 @@ func TestFullHappyPath(t *testing.T) {
 		},
 	}
 
+	var start time.Time
+	var elapsed time.Duration
+
+	start = time.Now()
+
 	err = f.Client.Create(goctx.TODO(), apimanager, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
 		t.Fatal(err)
@@ -112,6 +117,10 @@ func TestFullHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	elapsed = time.Since(start)
+	t.Logf("APIManager creation and availability took %s seconds", elapsed)
+
+	start = time.Now()
 	// Deploy Tenant resource
 	// - Deploy AdminPass secret
 	adminPassSecretName := "tenant01adminsecretname"
@@ -187,6 +196,10 @@ func TestFullHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("Tenant reconciliation DONE")
+	elapsed = time.Since(start)
+	t.Logf("Tenant creation and availability took %s seconds", elapsed)
+
+	start = time.Now()
 
 	api := &apiv1alpha1.API{
 		ObjectMeta: metav1.ObjectMeta{
@@ -466,6 +479,8 @@ func TestFullHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	elapsed = time.Since(start)
+	t.Logf("Creation consolidated took %s seconds", elapsed)
 	//	retries := 0
 	//RETRY:
 	//


### PR DESCRIPTION
Increases Cleanup timeout to try to solve cleanup problems between tests.
Also adds some elapsed time logging in some parts of the tests