### PR TITLE
Consolidated status subresource 

### DIFF
--- a/pkg/controller/binding/binding_controller.go
+++ b/pkg/controller/binding/binding_controller.go
@@ -207,9 +207,9 @@ func ReconcileBindingFunc(binding apiv1alpha1.Binding, c client.Client, log logr
 
 			// Add a list of the previous APIs.
 			consolidatedStatus := apiv1alpha1.ConsolidatedStatus{}
-			consolidatedStatus.PreviousVersion =  string(previousVersion)
+			consolidatedStatus.PreviousVersion = string(previousVersion)
 			desiredConsolidated.Status = consolidatedStatus
-			err = c.Status().Update(context.TODO(),desiredConsolidated)
+			err = c.Status().Update(context.TODO(), desiredConsolidated)
 			if err != nil {
 				// Something went wrong when trying to update the actual consolidated object.
 				log.Error(err, "error")

--- a/pkg/controller/consolidated/consolidated_controller.go
+++ b/pkg/controller/consolidated/consolidated_controller.go
@@ -130,19 +130,18 @@ func (r *ReconcileConsolidated) Reconcile(request reconcile.Request) (reconcile.
 			apisDiff := apiv1alpha1.DiffAPIs(consolidated.Spec.APIs, previousConsolidated.Spec.APIs)
 			for _, api := range apisDiff.MissingFromA {
 				err = apiv1alpha1.DeleteInternalAPIFrom3scale(consolidated.Spec.Credentials, api)
-				if err != nil {
 
+				if err != nil {
 					reqLogger.Error(err, "Error deleting non desired API")
 					return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, err
+				}
 
-				} else {
-					consolidated.Status.PreviousVersion = ""
-					err = r.client.Status().Update(context.TODO(), consolidated)
+				consolidated.Status.PreviousVersion = ""
+				err = r.client.Status().Update(context.TODO(), consolidated)
 
-					if err != nil {
-						reqLogger.Error(err, "Failed to update consolidated status")
-						return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, err
-					}
+				if err != nil {
+					reqLogger.Error(err, "Failed to update consolidated status")
+					return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, err
 				}
 			}
 		}

--- a/test/e2e/manifests/apis.yml
+++ b/test/e2e/manifests/apis.yml
@@ -8,10 +8,6 @@ items:
     labels:
       environment: production
     name: api01
-    namespace: operator-test
-    resourceVersion: "1364154"
-    selfLink: /apis/capabilities.3scale.net/v1alpha1/namespaces/operator-test/apis/myapi
-    uid: 21a5eafc-20a5-11e9-b8c6-0e4109beb104
   spec:
     planSelector:
       matchLabels:
@@ -51,10 +47,6 @@ items:
     labels:
       environment: staging
     name: api02
-    namespace: operator-test
-    resourceVersion: "1364154"
-    selfLink: /apis/capabilities.3scale.net/v1alpha1/namespaces/operator-test/apis/myapi
-    uid: 21a5eafc-20a5-11e9-b8c6-0e4109beb104
   spec:
     planSelector:
       matchLabels:
@@ -96,10 +88,6 @@ items:
     labels:
       environment: devel
     name: api03
-    namespace: operator-test
-    resourceVersion: "1364154"
-    selfLink: /apis/capabilities.3scale.net/v1alpha1/namespaces/operator-test/apis/myapi
-    uid: 21a5eafc-20a5-11e9-b8c6-0e4109beb104
   spec:
     planSelector:
       matchLabels:


### PR DESCRIPTION
Due to changes in the latest operator-sdk, the status subresource was not working, this PR fixes by using the specific status client. 