### PR TITLE
Increase no_output_timeout in 3scale template deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ commands:
 
             oc get events | egrep ' Failed ' || :
             oc get events -o json | jq '[.items[] | select(.reason == "Failed") | debug ] | length == 0'  --exit-status
+          no_output_timeout: 1800
 
   push-3scale-images-to-quay:
     steps:


### PR DESCRIPTION
Sometimes the 10m with no output default limit was reached when deploying 3scale template which is too little sometimes. This PR increases it.