### PR TITLE
Create ProductVersion 2.5 for the Operator

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -21,7 +21,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 
 | **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
 | --- | --- | --- | --- | --- | --- |
-| ProductVersion | `productVersion` | ProductVersion | Yes | N/A | 3Scale API Management solution release version. Currently the values "2.4" and "upstream" are supported. **Warning**, "upstream" uses 3scale unstable nightly images and it is intended only for development purposes and to be used in non-productive environments |
+| ProductVersion | `productVersion` | ProductVersion | Yes | N/A | 3Scale API Management solution release version. Currently the values "2.5" and "upstream" are supported. **Warning**, "upstream" uses 3scale unstable nightly images and it is intended only for development purposes and to be used in non-productive environments |
 | WildcardDomain | `wildcardDomain` | string | Yes | N/A | Root domain for the wildcard routes. Eg. example.com will generate 3scale-admin.example.com. |
 | AppLabel | `appLabel` | string | No | `3scale-api-management` | The value of the `app` label that will be applied to the API management solution
 | TenantName | `tenantName` | string | No | `3scale` | Tenant name under the root that Admin UI will be available with -admin suffix.

--- a/pkg/3scale/amp/product/images.go
+++ b/pkg/3scale/amp/product/images.go
@@ -14,6 +14,8 @@ func NewImageProvider(productVersion Version) (ImageProvider, error) {
 	switch productVersion {
 	case ProductRelease_2_4:
 		return &release_2_4{}, nil
+	case ProductRelease_2_5:
+		return &release_2_5{}, nil
 	case ProductUpstream:
 		return &upstream{}, nil
 	default:

--- a/pkg/3scale/amp/product/release_2_5.go
+++ b/pkg/3scale/amp/product/release_2_5.go
@@ -1,0 +1,47 @@
+package product
+
+type release_2_5 struct{}
+
+func (p *release_2_5) GetApicastImage() string {
+	return "registry.access.redhat.com/3scale-amp25/apicast-gateway"
+}
+
+func (p *release_2_5) GetBackendImage() string {
+	return "registry.access.redhat.com/3scale-amp25/backend"
+}
+
+func (p *release_2_5) GetBackendRedisImage() string {
+	return "registry.access.redhat.com/rhscl/redis-32-rhel7:3.2"
+}
+
+func (p *release_2_5) GetSystemImage() string {
+	return "registry.access.redhat.com/3scale-amp25/system"
+}
+
+func (p *release_2_5) GetSystemRedisImage() string {
+	return "registry.access.redhat.com/rhscl/redis-32-rhel7:3.2"
+}
+
+func (p *release_2_5) GetSystemMySQLImage() string {
+	return "registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7"
+}
+
+func (p *release_2_5) GetSystemPostgreSQLImage() string {
+	return "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5"
+}
+
+func (p *release_2_5) GetSystemMemcachedImage() string {
+	return "registry.access.redhat.com/3scale-amp20/memcached"
+}
+
+func (p *release_2_5) GetWildcardRouterImage() string {
+	return "registry.access.redhat.com/3scale-amp22/wildcard-router"
+}
+
+func (p *release_2_5) GetZyncImage() string {
+	return "registry.access.redhat.com/3scale-amp25/zync"
+}
+
+func (p *release_2_5) GetZyncPostgreSQLImage() string {
+	return "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5"
+}


### PR DESCRIPTION
This PR adds a new ProductVersion for the 3scale API Management 2.5 release in the Operator productVersion field.

The possible update to PostgreSQL 10 will be added in another PR and the change in the templates too