### PR TITLE
APIManager - rename sthree json field to amazonSimpleStorageService

### DIFF
--- a/deploy/crds/apps_v1alpha1_apimanager_cr_s3.yaml
+++ b/deploy/crds/apps_v1alpha1_apimanager_cr_s3.yaml
@@ -7,7 +7,7 @@ spec:
   wildcardDomain: <desired-domain>
   system:
     fileStorage:
-      sthree:
+      amazonSimpleStorageService:
         awsRegion: <region>
         awsBucket: <bucket-name>
         awsCredentialsSecret:

--- a/deploy/crds/apps_v1alpha1_apimanager_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_apimanager_crd.yaml
@@ -69,12 +69,7 @@ spec:
                   type: object
                 fileStorage:
                   properties:
-                    persistentVolumeClaim:
-                      properties:
-                        storageClassName:
-                          type: string
-                      type: object
-                    sthree:
+                    amazonSimpleStorageService:
                       properties:
                         awsBucket:
                           type: string
@@ -89,6 +84,11 @@ spec:
                       - awsRegion
                       - awsCredentialsSecret
                       - fileUploadStorage
+                      type: object
+                    persistentVolumeClaim:
+                      properties:
+                        storageClassName:
+                          type: string
                       type: object
                   type: object
                 image:

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -67,7 +67,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
 | --- | --- | --- | --- | --- | --- |
 | PVC | `persistentVolumeClaim` | \*SystemPVCSpec | No | nil | Used to use a PersistentVolumeClaim as the System's file storage. See [SystemPVCSpec](#SystemPVCSpec) |
-| S3  | `sthree` | \*SystemS3Spec | No | nil | Used to use S3 as the System's file storage. See [SystemS3Spec](#SystemS3Spec) |
+| S3  | `amazonSimpleStorageService` | \*SystemS3Spec | No | nil | Used to use S3 as the System's file storage. See [SystemS3Spec](#SystemS3Spec) |
 
 Only one of the fields can be chosen. If no field is specified then PVC is used.
 

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -160,7 +160,7 @@ type SystemFileStorageSpec struct {
 	// +optional
 	PVC *SystemPVCSpec `json:"persistentVolumeClaim,omitempty"`
 	// +optional
-	S3 *SystemS3Spec `json:"sthree,omitempty"`
+	S3 *SystemS3Spec `json:"amazonSimpleStorageService,omitempty"`
 }
 
 type SystemPVCSpec struct {


### PR DESCRIPTION
Due to the fact that the openapi generator does not correctly generate OpenAPI validation when the json field contains a number (see https://github.com/operator-framework/operator-sdk/issues/1120), the field was renamed to 'sthree', but I'm not totally convinced of that name.
This PR renames the json field to 'amazonSimpleStorageService'. Do you think this is a better/good name for this field?

I did not choose 'simpleStorageService' because I'd like to make explicit that it's an amazon service. S3 is clear enough that is an amazon service but 'simpleStorageService' seems lot more generic so that's why I added the amazon prefix.

What do you think?