### PR TITLE
Remove unneeded NodePort and let use the zero-value in components

### DIFF
--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -168,7 +168,6 @@ func (mysql *Mysql) buildSystemMysqlService() *v1.Service {
 					Protocol:   v1.Protocol("TCP"),
 					Port:       3306,
 					TargetPort: intstr.FromInt(3306),
-					NodePort:   0,
 				},
 			},
 			Selector: map[string]string{"deploymentConfig": "system-mysql"},

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -586,7 +586,6 @@ func (zync *Zync) buildZyncDatabaseService() *v1.Service {
 					Protocol:   v1.Protocol("TCP"),
 					Port:       5432,
 					TargetPort: intstr.FromInt(5432),
-					NodePort:   0,
 				},
 			},
 			Selector: map[string]string{"deploymentConfig": "zync-database"},


### PR DESCRIPTION
This PR removes unneeded NodePort fields in some services because the zero-value of NodePort is already 0 so there's no need to specify it.