### PR TITLE
Upgrade to postgresql10

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -217,7 +217,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3276,7 +3276,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3850,7 +3850,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -216,7 +216,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3182,7 +3182,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3750,7 +3750,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -216,7 +216,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -2790,7 +2790,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3387,7 +3387,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -217,7 +217,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3359,7 +3359,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3951,7 +3951,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -216,7 +216,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3265,7 +3265,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3851,7 +3851,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -217,7 +217,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3261,7 +3261,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3832,7 +3832,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -216,7 +216,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3167,7 +3167,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3732,7 +3732,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -216,7 +216,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -2776,7 +2776,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3370,7 +3370,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -217,7 +217,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3344,7 +3344,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3933,7 +3933,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -216,7 +216,7 @@ objects:
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "9.5"
+      name: "10"
       referencePolicy:
         type: ""
   status:
@@ -3250,7 +3250,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:10
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3833,7 +3833,7 @@ parameters:
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 - description: Mysql image to use
   name: MYSQL_IMAGE
   required: true

--- a/pkg/3scale/amp/cmd/template.go
+++ b/pkg/3scale/amp/cmd/template.go
@@ -164,7 +164,7 @@ func addDoubleBraceExpansionFieldsToResult(serializedResult map[string]interface
 			for _, intobjtag := range objspec["tags"].([]interface{}) {
 				objtag := intobjtag.(map[string]interface{})
 				objtagname := objtag["name"].(string)
-				if objtagname == "${AMP_RELEASE}" || objtagname == "9.5" {
+				if objtagname == "${AMP_RELEASE}" || objtagname == "9.5" || objtagname == "10" {
 					if _, ok := objtag["importPolicy"]; ok {
 						importPolicyFields := objtag["importPolicy"].(map[string]interface{})
 						importPolicyFields["insecure"] = "${{IMAGESTREAM_TAG_IMPORT_INSECURE}}"

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -345,7 +345,7 @@ func (ampImages *AmpImages) buildPostgreSQLImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "9.5",
+					Name: "10",
 					From: &v1.ObjectReference{
 						Kind: "DockerImage",
 						Name: ampImages.Options.postgreSQLImage,
@@ -400,7 +400,7 @@ func (ampImages *AmpImages) buildParameters(template *templatev1.Template) {
 		templatev1.Parameter{
 			Name:        "POSTGRESQL_IMAGE",
 			Description: "Postgresql image to use",
-			Value:       "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5",
+			Value:       "registry.access.redhat.com/rhscl/postgresql-10-rhel7",
 			Required:    true,
 		},
 		templatev1.Parameter{

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -434,7 +434,7 @@ func (zync *Zync) buildZyncDatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "postgresql:9.5",
+							Name: "postgresql:10",
 						},
 					},
 				},

--- a/pkg/3scale/amp/product/release_2_5.go
+++ b/pkg/3scale/amp/product/release_2_5.go
@@ -27,7 +27,7 @@ func (p *release_2_5) GetSystemMySQLImage() string {
 }
 
 func (p *release_2_5) GetSystemPostgreSQLImage() string {
-	return "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5"
+	return "registry.access.redhat.com/rhscl/postgresql-10-rhel7"
 }
 
 func (p *release_2_5) GetSystemMemcachedImage() string {
@@ -43,5 +43,5 @@ func (p *release_2_5) GetZyncImage() string {
 }
 
 func (p *release_2_5) GetZyncPostgreSQLImage() string {
-	return "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5"
+	return "registry.access.redhat.com/rhscl/postgresql-10-rhel7"
 }

--- a/pkg/3scale/amp/product/upstream.go
+++ b/pkg/3scale/amp/product/upstream.go
@@ -27,7 +27,7 @@ func (u *upstream) GetSystemMySQLImage() string {
 }
 
 func (u *upstream) GetSystemPostgreSQLImage() string {
-	return "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5"
+	return "registry.access.redhat.com/rhscl/postgresql-10-rhel7"
 }
 
 func (u *upstream) GetSystemMemcachedImage() string {
@@ -43,5 +43,5 @@ func (u *upstream) GetZyncImage() string {
 }
 
 func (u *upstream) GetZyncPostgreSQLImage() string {
-	return "registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5"
+	return "registry.access.redhat.com/rhscl/postgresql-10-rhel7"
 }


### PR DESCRIPTION
This PR upgrades the PostgreSQL present in operator/templates used by Zync from 9.5 to 10. The changes are:
 *  Remove ImageStreamTag "9.5" of the 'postgresql' ImageStream and replace it with a ImageStreamTag with the name "10". The tag name has the following image associated, using the 'latest' tag: registry.access.redhat.com/rhscl/postgresql-10-rhel7
 * Replace the ImageChange trigger in the 'zync-database' from postgresql:9 to postgresql:10 in order to use the new ImageStreamTag "10". This is done so the 'zync-database' DeploymentConfig gets the new tag name
 * Update the 'upstream' productVersion in the operator to use the new PostgreSQL 10 image (registry.access.redhat.com/rhscl/postgresql-10-rhel7), and also the '2.5' productVersion to use that new image too