### PR TITLE
Upgrade template images to 2.5

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3823,7 +3823,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3720,7 +3720,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -3357,7 +3357,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3924,7 +3924,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3821,7 +3821,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -3805,7 +3805,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3817,19 +3817,19 @@ parameters:
   value: 3scale
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/backend
+  value: registry.access.redhat.com/3scale-amp25/backend
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/zync
+  value: registry.access.redhat.com/3scale-amp25/zync
 - name: AMP_APICAST_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/apicast-gateway
+  value: registry.access.redhat.com/3scale-amp25/apicast-gateway
 - name: AMP_ROUTER_IMAGE
   required: true
   value: registry.access.redhat.com/3scale-amp22/wildcard-router
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/system
+  value: registry.access.redhat.com/3scale-amp25/system
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -3702,7 +3702,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3717,19 +3717,19 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/backend
+  value: registry.access.redhat.com/3scale-amp25/backend
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/zync
+  value: registry.access.redhat.com/3scale-amp25/zync
 - name: AMP_APICAST_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/apicast-gateway
+  value: registry.access.redhat.com/3scale-amp25/apicast-gateway
 - name: AMP_ROUTER_IMAGE
   required: true
   value: registry.access.redhat.com/3scale-amp22/wildcard-router
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/system
+  value: registry.access.redhat.com/3scale-amp25/system
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -3340,7 +3340,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3355,19 +3355,19 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/backend
+  value: registry.access.redhat.com/3scale-amp25/backend
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/zync
+  value: registry.access.redhat.com/3scale-amp25/zync
 - name: AMP_APICAST_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/apicast-gateway
+  value: registry.access.redhat.com/3scale-amp25/apicast-gateway
 - name: AMP_ROUTER_IMAGE
   required: true
   value: registry.access.redhat.com/3scale-amp22/wildcard-router
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/system
+  value: registry.access.redhat.com/3scale-amp25/system
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -3906,7 +3906,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3918,19 +3918,19 @@ parameters:
   value: 3scale
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/backend
+  value: registry.access.redhat.com/3scale-amp25/backend
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/zync
+  value: registry.access.redhat.com/3scale-amp25/zync
 - name: AMP_APICAST_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/apicast-gateway
+  value: registry.access.redhat.com/3scale-amp25/apicast-gateway
 - name: AMP_ROUTER_IMAGE
   required: true
   value: registry.access.redhat.com/3scale-amp22/wildcard-router
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/system
+  value: registry.access.redhat.com/3scale-amp25/system
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -3803,7 +3803,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.4.0
+  value: 2.5.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3818,19 +3818,19 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/backend
+  value: registry.access.redhat.com/3scale-amp25/backend
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/zync
+  value: registry.access.redhat.com/3scale-amp25/zync
 - name: AMP_APICAST_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/apicast-gateway
+  value: registry.access.redhat.com/3scale-amp25/apicast-gateway
 - name: AMP_ROUTER_IMAGE
   required: true
   value: registry.access.redhat.com/3scale-amp22/wildcard-router
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp24/system
+  value: registry.access.redhat.com/3scale-amp25/system
 - description: Postgresql image to use
   name: POSTGRESQL_IMAGE
   required: true

--- a/pkg/3scale/amp/cmd/template.go
+++ b/pkg/3scale/amp/cmd/template.go
@@ -258,7 +258,7 @@ func buildTemplateParameters() []templatev1.Parameter {
 			Name:        "AMP_RELEASE",
 			Description: "AMP release tag.",
 			Required:    true,
-			Value:       "2.4.0",
+			Value:       "2.5.0",
 		},
 		templatev1.Parameter{
 			Name:        "APP_LABEL",

--- a/pkg/3scale/amp/component/productized.go
+++ b/pkg/3scale/amp/component/productized.go
@@ -117,15 +117,15 @@ func (productized *Productized) updateAmpImagesParameters(template *templatev1.T
 		param := &template.Parameters[paramIdx]
 		switch param.Name {
 		case "AMP_SYSTEM_IMAGE":
-			param.Value = "registry.access.redhat.com/3scale-amp24/system"
+			param.Value = "registry.access.redhat.com/3scale-amp25/system"
 		case "AMP_BACKEND_IMAGE":
-			param.Value = "registry.access.redhat.com/3scale-amp24/backend"
+			param.Value = "registry.access.redhat.com/3scale-amp25/backend"
 		case "AMP_APICAST_IMAGE":
-			param.Value = "registry.access.redhat.com/3scale-amp24/apicast-gateway"
+			param.Value = "registry.access.redhat.com/3scale-amp25/apicast-gateway"
 		case "AMP_ROUTER_IMAGE":
 			param.Value = "registry.access.redhat.com/3scale-amp22/wildcard-router"
 		case "AMP_ZYNC_IMAGE":
-			param.Value = "registry.access.redhat.com/3scale-amp24/zync"
+			param.Value = "registry.access.redhat.com/3scale-amp25/zync"
 		}
 	}
 }

--- a/pkg/3scale/amp/manual-templates/amp/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/amp/apicast.yml
@@ -120,7 +120,7 @@ objects:
 parameters:
 - name: AMP_RELEASE
   description: "AMP release tag."
-  value: "2.4.0"
+  value: "2.5.0"
   required: true
 - name: AMP_APICAST_IMAGE
   value: "quay.io/3scale/amp:apicast-master"

--- a/pkg/3scale/amp/manual-templates/productized-templates/apicast-gateway/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/productized-templates/apicast-gateway/apicast.yml
@@ -121,7 +121,7 @@ parameters:
   value: "2.4.0"
   required: true
 - name: AMP_APICAST_IMAGE
-  value: "registry.access.redhat.com/3scale-amp24/apicast-gateway"
+  value: "registry.access.redhat.com/3scale-amp25/apicast-gateway"
   required: true
 - description: "Name of the secret containing the THREESCALE_PORTAL_ENDPOINT with the access-token or provider key"
   value: apicast-configuration-url-secret

--- a/pkg/3scale/amp/manual-templates/productized-templates/apicast-gateway/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/productized-templates/apicast-gateway/apicast.yml
@@ -118,7 +118,7 @@ objects:
 parameters:
 - name: AMP_RELEASE
   description: "AMP release tag."
-  value: "2.4.0"
+  value: "2.5.0"
   required: true
 - name: AMP_APICAST_IMAGE
   value: "registry.access.redhat.com/3scale-amp25/apicast-gateway"


### PR DESCRIPTION
This PR upgrades the templates contents to use AMP 2.5.0 preparing it for the upcoming changes.
This assumes correct image URLs, although changes might be needed if was not the case.