### PR TITLE
Uses ProductionPublicBaseURL field instead of incorrect PrivateBaseURL

### DIFF
--- a/pkg/apis/capabilities/v1alpha1/api_types.go
+++ b/pkg/apis/capabilities/v1alpha1/api_types.go
@@ -963,7 +963,7 @@ func newInternalApicastOnPremFromApicastOnPrem(namespace string, prem ApicastOnP
 			AuthenticationSettings: prem.AuthenticationSettings,
 		},
 		StagingPublicBaseURL:    prem.StagingPublicBaseURL,
-		ProductionPublicBaseURL: prem.PrivateBaseURL,
+		ProductionPublicBaseURL: prem.ProductionPublicBaseURL,
 		MappingRules:            nil,
 	}
 	// Get Mapping Rules


### PR DESCRIPTION
fixes https://github.com/3scale/3scale-operator/issues/98