### PR TITLE
Dockerfile to build operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.11.5 AS build
+
+ENV DEP_VERSION=v0.5.0
+
+RUN curl https://raw.githubusercontent.com/golang/dep/${DEP_VERSION}/install.sh | sh
+
+ENV WORKDIR=/go/src/github.com/3scale/3scale-operator
+ADD . ${WORKDIR}
+WORKDIR ${WORKDIR}
+
+RUN dep ensure -v
+
+ENV OOS=linux \
+    GOARCH=amd64 \
+    CGO_ENABLED=0
+
+RUN go build -o build/bin/3scale-operator cmd/manager/main.go
+
+FROM alpine:3.8
+
+ENV OPERATOR=/usr/local/bin/3scale-operator \
+    USER_UID=1001 \
+    USER_NAME=3scale-operator
+
+# install operator binary
+COPY --from=build /go/src/github.com/3scale/3scale-operator/build/bin/_output/3scale-operator ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ vendor Gopkg.lock: Gopkg.toml
 	dep ensure -v
 
 IMAGE ?= quay.io/3scale/3scale-operator
-VERSION ?= v0.0.1
+VERSION ?= master
 NAMESPACE ?= operator-test
 
-## build: Build operator
+## build: Build operator image
 build:
-	operator-sdk build $(IMAGE):$(VERSION)
+	docker build -t $(IMAGE):$(VERSION) .
 
 ## push: push operator docker image to remote repo
 push:


### PR DESCRIPTION
3scale operator image is build using our Dockerfile and Makefile target. Remove operator-sdk dependency for building docker images of the operator.


`/build/Dockerfile` has been left undeleted. This file was generated from operator-sdk scaffolding process and it might need it for some reason.

This PR allows Quay docker repo build images on each update in master branch and on new tags.