### PR TITLE
Add state comparison to validate tests

### DIFF
--- a/pkg/apis/capabilities/v1alpha1/limit_types.go
+++ b/pkg/apis/capabilities/v1alpha1/limit_types.go
@@ -77,7 +77,7 @@ func newInternalLimitFromLimit(limit Limit, c client.Client) (*InternalLimit, er
 		Name:      limit.Spec.Metric.Name,
 	}
 	if limit.Spec.Metric.Name == "Hits" || limit.Spec.Metric.Name == "hits" {
-		metric.Name = "hits"
+		metric.Name = "Hits"
 	} else {
 		err := c.Get(context.TODO(), reference, metric)
 		if err != nil {

--- a/pkg/apis/capabilities/v1alpha1/mappingrule_types.go
+++ b/pkg/apis/capabilities/v1alpha1/mappingrule_types.go
@@ -131,7 +131,7 @@ func newInternalMappingRuleFromMappingRule(mappingRule MappingRule, c client.Cli
 	// Handle metrics Hits.
 	if mappingRule.Spec.MetricRef.Name == "Hits" ||
 		mappingRule.Spec.MetricRef.Name == "hits" {
-		metric.Name = "hits"
+		metric.Name = "Hits"
 
 		// Handle metrics Hits.
 

--- a/pkg/controller/binding/binding_controller.go
+++ b/pkg/controller/binding/binding_controller.go
@@ -228,6 +228,7 @@ func ReconcileBindingFunc(binding apiv1alpha1.Binding, c client.Client, log logr
 	// if it's not in sync, we reconcile the APIs and mark the object for update
 	if binding.StateInSync() {
 		log.Info("State is in sync")
+
 	} else {
 		log.Info("State is not in sync, reconciling APIs")
 		apisDiff := apiv1alpha1.DiffAPIs(desiredState.APIs, currentState.APIs)
@@ -246,9 +247,12 @@ func ReconcileBindingFunc(binding apiv1alpha1.Binding, c client.Client, log logr
 			log.Error(err, "Error Reconciling APIs")
 		}
 
-		// Update the LastSync field.
-		binding.SetLastSuccessfulSync()
+		if binding.StateInSync() {
+			// Update the LastSync field.
+			binding.SetLastSuccessfulSync()
+		}
 		UpdateRequired = true
+
 		log.Info("Reconciliation finished.")
 	}
 

--- a/test/e2e/full_test.go
+++ b/test/e2e/full_test.go
@@ -313,8 +313,8 @@ func TestFullHappyPath(t *testing.T) {
 				TrialPeriod:      0,
 				ApprovalRequired: false,
 				Costs: apiv1alpha1.PlanCost{
-					SetupFee:  0,
-					CostMonth: 0,
+					SetupFee:  1,
+					CostMonth: 1,
 				},
 			},
 			PlanSelectors: apiv1alpha1.PlanSelectors{
@@ -371,7 +371,7 @@ func TestFullHappyPath(t *testing.T) {
 			LimitObjectRef: apiv1alpha1.LimitObjectRef{
 				Metric: v1.ObjectReference{
 					Namespace: namespace,
-					Name:      "hits",
+					Name:      "Hits",
 				},
 			},
 		},
@@ -474,6 +474,23 @@ func TestFullHappyPath(t *testing.T) {
 
 	elapsed = time.Since(start)
 	t.Logf("Binding in sync took %s seconds", elapsed)
+
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: binding.Name}, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	currentState, err := binding.GetCurrentState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	desiredState, err := binding.GetDesiredState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !apiv1alpha1.CompareStates(*currentState, *desiredState) {
+		t.Fatalf("States are not in sync: \n\ncurrent: %#v\n\ndesired: %#v\n\n", *currentState, *desiredState)
+	}
 
 }
 

--- a/test/e2e/full_test.go
+++ b/test/e2e/full_test.go
@@ -265,7 +265,7 @@ func TestFullHappyPath(t *testing.T) {
 
 	metric01 := &apiv1alpha1.Metric{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "metric01",
+			Name:      "metric01-test",
 			Namespace: namespace,
 			Labels:    map[string]string{"environment": "testing"},
 		},
@@ -345,7 +345,7 @@ func TestFullHappyPath(t *testing.T) {
 			LimitObjectRef: apiv1alpha1.LimitObjectRef{
 				Metric: v1.ObjectReference{
 					Namespace: namespace,
-					Name:      "metric01",
+					Name:      "metric01-test",
 				},
 			},
 		},
@@ -425,7 +425,7 @@ func TestFullHappyPath(t *testing.T) {
 			MappingRuleMetricRef: apiv1alpha1.MappingRuleMetricRef{
 				MetricRef: v1.ObjectReference{
 					Namespace: namespace,
-					Name:      "metric01",
+					Name:      "metric01-test",
 				},
 			},
 		},


### PR DESCRIPTION
* Improve tests by making sure the state is in sync.
* The lastSync field now it's only updated/added when the state is in sync.
* Fixed an issue with detecting the default "Hits" metric in porta.