### PR TITLE
resource limits tweaks

### DIFF
--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -282,6 +282,7 @@ func (mysql *Mysql) buildSystemMysqlDeploymentConfig() *appsv1.DeploymentConfig 
 							},
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
 									v1.ResourceMemory: resource.MustParse("2Gi"),
 								},
 								Requests: v1.ResourceList{

--- a/pkg/3scale/amp/component/redis_options_builder.go
+++ b/pkg/3scale/amp/component/redis_options_builder.go
@@ -18,6 +18,13 @@ func (r *RedisOptionsBuilder) SystemImage(image string) {
 	r.options.systemImage = image
 }
 
+func (r *RedisOptionsBuilder) BackendMemoryLimit(memoryLimit string) {
+	r.options.backendMemoryLimit = memoryLimit
+}
+func (r *RedisOptionsBuilder) SystemMemoryLimit(memoryLimit string) {
+	r.options.systemMemoryLimit = memoryLimit
+}
+
 func (r *RedisOptionsBuilder) Build() (*RedisOptions, error) {
 	err := r.setRequiredOptions()
 	if err != nil {
@@ -38,7 +45,14 @@ func (r *RedisOptionsBuilder) setRequiredOptions() error {
 	}
 
 	if r.options.systemImage == "" {
-		return fmt.Errorf("no Redis System Image has been provided")
+		return fmt.Errorf("no System Redis Image has been provided")
+	}
+
+	if r.options.backendMemoryLimit == "" {
+		return fmt.Errorf("No Backend Redis Memory Limit has been provided")
+	}
+	if r.options.systemMemoryLimit == "" {
+		return fmt.Errorf("No Redis System Memory Limit has been provided")
 	}
 
 	return nil

--- a/pkg/3scale/amp/operator/redis.go
+++ b/pkg/3scale/amp/operator/redis.go
@@ -28,6 +28,17 @@ func (o *OperatorRedisOptionsProvider) GetRedisOptions() (*component.RedisOption
 		optProv.SystemImage(imageProvider.GetSystemRedisImage())
 	}
 
+	if o.APIManagerSpec.BackendSpec != nil && o.APIManagerSpec.BackendSpec.MemoryLimit != nil {
+		optProv.BackendMemoryLimit(*o.APIManagerSpec.BackendSpec.MemoryLimit)
+	} else {
+		optProv.BackendMemoryLimit("32Gi")
+	}
+	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.MemoryLimit != nil {
+		optProv.SystemMemoryLimit(*o.APIManagerSpec.SystemSpec.MemoryLimit)
+	} else {
+		optProv.SystemMemoryLimit("32Gi")
+	}
+
 	res, err := optProv.Build()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Redis Options - %s", err)

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -129,6 +129,9 @@ type BackendSpec struct {
 
 	// +optional
 	RedisImage *string `json:"redisImage,omitempty"`
+
+	// +optional
+	MemoryLimit *string `json:"memoryLimit,omitempty"`
 }
 
 type SystemSpec struct {
@@ -153,6 +156,9 @@ type SystemSpec struct {
 	// TODO should union fields be optional?
 	// +optional
 	DatabaseSpec *SystemDatabaseSpec `json:"database,omitempty"`
+
+	// +optional
+	MemoryLimit *string `json:"memoryLimit,omitempty"`
 }
 
 type SystemFileStorageSpec struct {


### PR DESCRIPTION
These resource limit tweaks allow the API Manager to start up more smoothly in an OCP environment where cluster quotas and limit ranges are in effect.  RHT's  Global Partner Enablement Team (GPTE) always uses cluster quotas and limit ranges (both of which use settings dialed down fairly low for training and demo purposes).

The tweaks in this commit include the following:

1)  memory limits on both redis instances are now configurable (default remains 32Gi)  as options in  both BackendSpec and SystemSpec.

2)  cpu limit on mysql now set with a default of 1 core