### PR TITLE
Remove apicast redis secret

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -137,9 +137,6 @@ pre-created by the user:
 * [system-redis](#system-redis) with the `URL` field with the value pointing to the
   desired external database. The database should be configured
   in high-availability mode
-* [apicast-redis](#apicast-redis) with the `PRODUCTION_URL` and `STAGING_URL` fields
-  pointing to the  desired external databases. The databases should be configured
-  in high-availability mode
 
 #### APIManagerStatus
 
@@ -157,13 +154,6 @@ can be controlled by pre-creating some Kubernetes secrets before deploying the
 APIManager Custom Resource.
 
 The available configurable secrets are:
-
-#### apicast-redis
-
-| **Field** | **Description** | **Default value** |
-| --- | --- | --- |
-| PRODUCTION_URL | Redis database connection URL to be used by production apicast | `redis://system-redis:6379/1` |
-| STAGING_URL | Redis database connection URL to be used by staging apicast | `redis://system-redis:6379/2` |
 
 #### backend-internal-api
 

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3404,11 +3404,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3521,11 +3516,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3686,18 +3676,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3310,11 +3310,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3427,11 +3422,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3592,18 +3582,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2918,11 +2918,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3041,11 +3036,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3212,18 +3202,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: ${APICAST_PRODUCTION_REDIS_URL}
-    STAGING_URL: ${APICAST_STAGING_REDIS_URL}
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -3499,12 +3477,6 @@ parameters:
   required: true
 - description: Define the external system-redis to connect to
   name: SYSTEM_REDIS_URL
-  required: true
-- description: Define the external apicast-staging redis to connect to
-  name: APICAST_STAGING_REDIS_URL
-  required: true
-- description: Define the external apicast-staging redis to connect to
-  name: APICAST_PRODUCTION_REDIS_URL
   required: true
 - description: Define the external system-mysql to connect to
   name: SYSTEM_DATABASE_URL

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3487,11 +3487,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3610,11 +3605,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3781,18 +3771,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3393,11 +3393,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3516,11 +3511,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3687,18 +3677,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -3389,11 +3389,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3505,11 +3500,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3669,18 +3659,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -3295,11 +3295,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3411,11 +3406,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3575,18 +3565,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -2904,11 +2904,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3026,11 +3021,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3196,18 +3186,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: ${APICAST_PRODUCTION_REDIS_URL}
-    STAGING_URL: ${APICAST_STAGING_REDIS_URL}
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -3482,12 +3460,6 @@ parameters:
   required: true
 - description: Define the external system-redis to connect to
   name: SYSTEM_REDIS_URL
-  required: true
-- description: Define the external apicast-staging redis to connect to
-  name: APICAST_STAGING_REDIS_URL
-  required: true
-- description: Define the external apicast-staging redis to connect to
-  name: APICAST_PRODUCTION_REDIS_URL
   required: true
 - description: Define the external system-mysql to connect to
   name: SYSTEM_DATABASE_URL

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -3472,11 +3472,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3594,11 +3589,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3764,18 +3754,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -3378,11 +3378,6 @@ objects:
             value: "0"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: staging
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: STAGING_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3500,11 +3495,6 @@ objects:
             value: "300"
           - name: THREESCALE_DEPLOYMENT_ENV
             value: production
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: PRODUCTION_URL
-                name: apicast-redis
           image: amp-apicast:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3670,18 +3660,6 @@ objects:
       app: ${APP_LABEL}
       threescale_component: apicast
     name: apicast-environment
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: apicast
-    name: apicast-redis
-  stringData:
-    PRODUCTION_URL: redis://system-redis:6379/1
-    STAGING_URL: redis://system-redis:6379/2
-  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/pkg/3scale/amp/component/apicast_options_builder.go
+++ b/pkg/3scale/amp/component/apicast_options_builder.go
@@ -30,21 +30,11 @@ func (a *ApicastOptionsBuilder) WildcardDomain(wildcardDomain string) {
 	a.options.wildcardDomain = wildcardDomain
 }
 
-func (a *ApicastOptionsBuilder) RedisProductionURL(url string) {
-	a.options.redisProductionURL = &url
-}
-
-func (a *ApicastOptionsBuilder) RedisStagingURL(url string) {
-	a.options.redisStagingURL = &url
-}
-
 func (a *ApicastOptionsBuilder) Build() (*ApicastOptions, error) {
 	err := a.setRequiredOptions()
 	if err != nil {
 		return nil, err
 	}
-
-	a.setNonRequiredOptions()
 
 	return &a.options, nil
 }
@@ -70,17 +60,4 @@ func (a *ApicastOptionsBuilder) setRequiredOptions() error {
 	}
 
 	return nil
-}
-
-func (a *ApicastOptionsBuilder) setNonRequiredOptions() {
-	defaultRedisProductionURL := "redis://system-redis:6379/1"
-	defaultRedisStagingURL := "redis://system-redis:6379/2"
-
-	if a.options.redisProductionURL == nil {
-		a.options.redisProductionURL = &defaultRedisProductionURL
-	}
-
-	if a.options.redisStagingURL == nil {
-		a.options.redisStagingURL = &defaultRedisStagingURL
-	}
 }

--- a/pkg/3scale/amp/component/highavailability.go
+++ b/pkg/3scale/amp/component/highavailability.go
@@ -22,8 +22,6 @@ type HighAvailabilityOptions struct {
 
 type requiredHighAvailabilityOptions struct {
 	appLabel                    string
-	apicastProductionRedisURL   string
-	apicastStagingRedisURL      string
 	backendRedisQueuesEndpoint  string
 	backendRedisStorageEndpoint string
 	systemDatabaseURL           string
@@ -59,8 +57,6 @@ type CLIHighAvailabilityOptionsProvider struct {
 func (o *CLIHighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (*HighAvailabilityOptions, error) {
 	hob := HighAvailabilityOptionsBuilder{}
 	hob.AppLabel("${APP_LABEL}")
-	hob.ApicastProductionRedisURL("${APICAST_PRODUCTION_REDIS_URL}")
-	hob.ApicastStagingRedisURL("${APICAST_STAGING_REDIS_URL}")
 	hob.BackendRedisQueuesEndpoint("${BACKEND_REDIS_QUEUES_ENDPOINT}")
 	hob.BackendRedisStorageEndpoint("${BACKEND_REDIS_STORAGE_ENDPOINT}")
 	hob.SystemDatabaseURL("${SYSTEM_DATABASE_URL}")
@@ -228,9 +224,6 @@ func (ha *HighAvailability) updateDatabasesURLS(objects []runtime.RawExtension) 
 			switch secret.Name {
 			case "system-redis":
 				secret.StringData["URL"] = ha.Options.systemRedisURL
-			case "apicast-redis":
-				secret.StringData["PRODUCTION_URL"] = ha.Options.apicastProductionRedisURL
-				secret.StringData["STAGING_URL"] = ha.Options.apicastStagingRedisURL
 			case "backend-redis":
 				secret.StringData["REDIS_STORAGE_URL"] = ha.Options.backendRedisStorageEndpoint
 				secret.StringData["REDIS_QUEUES_URL"] = ha.Options.backendRedisQueuesEndpoint
@@ -254,16 +247,6 @@ func (ha *HighAvailability) buildParameters(template *templatev1.Template) {
 		templatev1.Parameter{
 			Name:        "SYSTEM_REDIS_URL",
 			Description: "Define the external system-redis to connect to",
-			Required:    true,
-		},
-		templatev1.Parameter{
-			Name:        "APICAST_STAGING_REDIS_URL",
-			Description: "Define the external apicast-staging redis to connect to",
-			Required:    true,
-		},
-		templatev1.Parameter{
-			Name:        "APICAST_PRODUCTION_REDIS_URL",
-			Description: "Define the external apicast-staging redis to connect to",
 			Required:    true,
 		},
 		templatev1.Parameter{

--- a/pkg/3scale/amp/component/highavailability_options_builder.go
+++ b/pkg/3scale/amp/component/highavailability_options_builder.go
@@ -10,14 +10,6 @@ func (ha *HighAvailabilityOptionsBuilder) AppLabel(appLabel string) {
 	ha.options.appLabel = appLabel
 }
 
-func (ha *HighAvailabilityOptionsBuilder) ApicastProductionRedisURL(apicastProductionRedisURL string) {
-	ha.options.apicastProductionRedisURL = apicastProductionRedisURL
-}
-
-func (ha *HighAvailabilityOptionsBuilder) ApicastStagingRedisURL(apicastStagingRedisURL string) {
-	ha.options.apicastStagingRedisURL = apicastStagingRedisURL
-}
-
 func (ha *HighAvailabilityOptionsBuilder) BackendRedisQueuesEndpoint(backendRedisQueuesEndpoint string) {
 	ha.options.backendRedisQueuesEndpoint = backendRedisQueuesEndpoint
 }
@@ -47,12 +39,6 @@ func (ha *HighAvailabilityOptionsBuilder) Build() (*HighAvailabilityOptions, err
 }
 
 func (ha *HighAvailabilityOptionsBuilder) setRequiredOptions() error {
-	if ha.options.apicastProductionRedisURL == "" {
-		return fmt.Errorf("no Apicast production URL has been provided")
-	}
-	if ha.options.apicastStagingRedisURL == "" {
-		return fmt.Errorf("no Apicast staging redis URL has been provided")
-	}
 	if ha.options.backendRedisQueuesEndpoint == "" {
 		return fmt.Errorf("no Backend Redis queues endpoint option has been provided")
 	}

--- a/pkg/3scale/amp/operator/apicast.go
+++ b/pkg/3scale/amp/operator/apicast.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 func (o *OperatorApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions, error) {
@@ -17,46 +16,9 @@ func (o *OperatorApicastOptionsProvider) GetApicastOptions() (*component.Apicast
 	optProv.OpenSSLVerify(strconv.FormatBool(*o.APIManagerSpec.ApicastSpec.OpenSSLVerify))        // TODO is this a good place to make the conversion?
 	optProv.ResponseCodes(strconv.FormatBool(*o.APIManagerSpec.ApicastSpec.IncludeResponseCodes)) // TODO is this a good place to make the conversion?
 
-	err := o.setSecretBasedOptions(&optProv)
-	if err != nil {
-		return nil, err
-	}
-
 	res, err := optProv.Build()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Apicast Options - %s", err)
 	}
 	return res, nil
-}
-
-func (o *OperatorApicastOptionsProvider) setSecretBasedOptions(aob *component.ApicastOptionsBuilder) error {
-	err := o.setApicastRedisOptions(aob)
-	if err != nil {
-		return fmt.Errorf("unable to create Apicast Redis Secret Options - %s", err)
-	}
-
-	return nil
-}
-
-func (o *OperatorApicastOptionsProvider) setApicastRedisOptions(aob *component.ApicastOptionsBuilder) error {
-	currSecret, err := getSecret(component.ApicastSecretRedisSecretName, o.Namespace, o.Client)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	} else {
-		// If a field of a secret already exists in the deployed secret then
-		// We do not modify it.
-		secretData := currSecret.Data
-		var result *string
-		result = getSecretDataValue(secretData, component.ApicastSecretRedisProductionURLFieldName)
-		if result != nil {
-			aob.RedisProductionURL(*result)
-		}
-		result = getSecretDataValue(secretData, component.ApicastSecretRedisStagingURLFieldName)
-		if result != nil {
-			aob.RedisStagingURL(*result)
-		}
-	}
-	return nil
 }

--- a/pkg/3scale/amp/operator/highavailability.go
+++ b/pkg/3scale/amp/operator/highavailability.go
@@ -9,11 +9,7 @@ import (
 func (o *OperatorHighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (*component.HighAvailabilityOptions, error) {
 	hob := component.HighAvailabilityOptionsBuilder{}
 
-	err := o.setApicastRedisOptions(&hob)
-	if err != nil {
-		return nil, err
-	}
-	err = o.setBackendRedisOptions(&hob)
+	err := o.setBackendRedisOptions(&hob)
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +19,7 @@ func (o *OperatorHighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (
 	}
 	err = o.setSystemDatabaseOptions(&hob)
 	if err != nil {
-
+		return nil, err
 	}
 
 	res, err := hob.Build()
@@ -31,29 +27,6 @@ func (o *OperatorHighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (
 		return nil, fmt.Errorf("unable to create HighAvailability Options - %s", err)
 	}
 	return res, nil
-}
-
-func (o *OperatorHighAvailabilityOptionsProvider) setApicastRedisOptions(builder *component.HighAvailabilityOptionsBuilder) error {
-	currSecret, err := getSecret(component.ApicastSecretRedisSecretName, o.Namespace, o.Client)
-	if err != nil {
-		return err
-	}
-
-	secretData := currSecret.Data
-	var result *string
-	result = getSecretDataValue(secretData, component.ApicastSecretRedisProductionURLFieldName)
-	if result == nil {
-		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.ApicastSecretRedisProductionURLFieldName, component.ApicastSecretRedisSecretName)
-	}
-	builder.ApicastProductionRedisURL(*result)
-
-	result = getSecretDataValue(secretData, component.ApicastSecretRedisStagingURLFieldName)
-	if result == nil {
-		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.S3SecretAWSSecretAccessKeyFieldName, component.ApicastSecretRedisSecretName)
-	}
-	builder.ApicastStagingRedisURL(*result)
-
-	return nil
 }
 
 func (o *OperatorHighAvailabilityOptionsProvider) setBackendRedisOptions(builder *component.HighAvailabilityOptionsBuilder) error {


### PR DESCRIPTION
This PR removes the apicast-redis secret, that contained redis URLs for apicast production and apicast staging.
The removal is done both in the operator and in the templates.
It also removes the environment variables created in the apicast-staging and apicast-production DeploymentConfigs that referenced the apicast-redis secret fields respectively