### PR TITLE
Configurable system redis urls

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -131,12 +131,12 @@ pre-created by the user:
   `REDIS_QUEUES_URL` fields with values pointing to the desired external
   databases. The databases should be configured
   in high-availability mode
-* [system-database](#system-database) with the `URL` field with the value pointing to the
-  desired external database. The database should be configured
+* [system-database](#system-database) with the `URL` field with the value
+  pointing to the desired external database. The database should be configured
   in high-availability mode
-* [system-redis](#system-redis) with the `URL` field with the value pointing to the
-  desired external database. The database should be configured
-  in high-availability mode
+* [system-redis](#system-redis) with the `URL` and `MESSAGE_BUS_URL` fields
+  with the value pointing to the desired external databases. The databases
+  should be configured in high-availability mode
 
 #### APIManagerStatus
 
@@ -227,6 +227,9 @@ The available configurable secrets are:
 | **Field** | **Description** | **Default value** |
 | --- | --- | --- |
 | URL | System's Redis database URL | `redis://system-redis:6379/1` |
+| MESSAGE_BUS_URL | System's Message Bus Redis database URL | `redis://system-redis:6379/8` |
+| NAMESPACE | Define the namespace to be used by System's Redis Database. The empty value means not namespaced | `""` |
+| MESSAGE_BUS_NAMESPACE | Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced | `""` |
 
 #### system-seed
 

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1876,11 +1876,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1891,6 +1886,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2130,11 +2145,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2145,6 +2155,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2400,11 +2430,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2415,6 +2440,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2669,11 +2714,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2684,6 +2724,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2997,11 +3057,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -3012,6 +3067,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3126,6 +3201,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3219,6 +3309,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3287,7 +3397,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4177,6 +4290,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1890,11 +1890,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1905,6 +1900,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2121,11 +2136,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2136,6 +2146,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2368,11 +2398,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2383,6 +2408,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2614,11 +2659,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2629,6 +2669,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2923,11 +2983,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2938,6 +2993,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3028,6 +3103,21 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           image: amp-system:latest
           name: check-svc
@@ -3125,6 +3215,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3193,7 +3303,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4077,6 +4190,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -1319,11 +1319,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1334,6 +1329,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -1550,11 +1565,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -1565,6 +1575,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -1803,11 +1833,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -1818,6 +1843,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2055,11 +2100,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2070,6 +2110,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2370,11 +2430,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2385,6 +2440,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2482,6 +2557,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -2578,6 +2668,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2652,6 +2762,9 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
@@ -3546,6 +3659,19 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'
@@ -3594,9 +3720,6 @@ parameters:
   required: true
 - description: Define the external backend-redis queues endpoint to connect to
   name: BACKEND_REDIS_QUEUES_ENDPOINT
-  required: true
-- description: Define the external system-redis to connect to
-  name: SYSTEM_REDIS_URL
   required: true
 - description: Define the external system-mysql to connect to
   name: SYSTEM_DATABASE_URL

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1882,11 +1882,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1897,6 +1892,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2113,11 +2128,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2128,6 +2138,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2366,11 +2396,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2381,6 +2406,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2618,11 +2663,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2633,6 +2673,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2933,11 +2993,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2948,6 +3003,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3045,6 +3120,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3141,6 +3231,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3215,7 +3325,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4122,6 +4235,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1917,11 +1917,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1932,6 +1927,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2171,11 +2186,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2186,6 +2196,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2447,11 +2477,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2462,6 +2487,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2722,11 +2767,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2737,6 +2777,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3056,11 +3116,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -3071,6 +3126,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3191,6 +3266,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3284,6 +3374,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3358,7 +3468,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4278,6 +4391,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1931,11 +1931,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1946,6 +1941,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2162,11 +2177,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2177,6 +2187,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2415,11 +2445,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2430,6 +2455,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2667,11 +2712,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2682,6 +2722,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2982,11 +3042,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2997,6 +3052,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3094,6 +3169,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3190,6 +3280,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3264,7 +3374,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4178,6 +4291,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -1876,11 +1876,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1891,6 +1886,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2130,11 +2145,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2145,6 +2155,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2400,11 +2430,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2415,6 +2440,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2669,11 +2714,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2684,6 +2724,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2997,11 +3057,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -3012,6 +3067,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3126,6 +3201,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3219,6 +3309,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3287,7 +3397,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4177,6 +4290,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -1890,11 +1890,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1905,6 +1900,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2121,11 +2136,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2136,6 +2146,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2368,11 +2398,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2383,6 +2408,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2614,11 +2659,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2629,6 +2669,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2923,11 +2983,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2938,6 +2993,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3028,6 +3103,21 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           image: amp-system:latest
           name: check-svc
@@ -3125,6 +3215,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3193,7 +3303,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4077,6 +4190,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -1319,11 +1319,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1334,6 +1329,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -1550,11 +1565,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -1565,6 +1575,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -1803,11 +1833,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -1818,6 +1843,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2055,11 +2100,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2070,6 +2110,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2370,11 +2430,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2385,6 +2440,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2482,6 +2557,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -2578,6 +2668,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2652,6 +2762,9 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
@@ -3546,6 +3659,19 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'
@@ -3594,9 +3720,6 @@ parameters:
   required: true
 - description: Define the external backend-redis queues endpoint to connect to
   name: BACKEND_REDIS_QUEUES_ENDPOINT
-  required: true
-- description: Define the external system-redis to connect to
-  name: SYSTEM_REDIS_URL
   required: true
 - description: Define the external system-mysql to connect to
   name: SYSTEM_DATABASE_URL

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
@@ -1882,11 +1882,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1897,6 +1892,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2113,11 +2128,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2128,6 +2138,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2366,11 +2396,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2381,6 +2406,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2618,11 +2663,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2633,6 +2673,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2933,11 +2993,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2948,6 +3003,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3045,6 +3120,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3141,6 +3231,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3215,7 +3325,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4122,6 +4235,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -1917,11 +1917,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1932,6 +1927,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2171,11 +2186,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2186,6 +2196,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2447,11 +2477,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2462,6 +2487,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2722,11 +2767,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2737,6 +2777,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3056,11 +3116,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -3071,6 +3126,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3191,6 +3266,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3284,6 +3374,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3358,7 +3468,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4278,6 +4391,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -1931,11 +1931,6 @@ objects:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
                   name: system-app
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: URL
-                  name: system-redis
             - name: MEMCACHE_SERVERS
               valueFrom:
                 secretKeyRef:
@@ -1946,6 +1941,26 @@ objects:
                 secretKeyRef:
                   key: REDIS_STORAGE_URL
                   name: backend-redis
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: URL
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_URL
+                  name: system-redis
+            - name: REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: NAMESPACE
+                  name: system-redis
+            - name: MESSAGE_BUS_REDIS_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  key: MESSAGE_BUS_NAMESPACE
+                  name: system-redis
             - name: APICAST_BACKEND_ROOT_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -2162,11 +2177,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2177,6 +2187,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2415,11 +2445,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2430,6 +2455,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2667,11 +2712,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2682,6 +2722,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -2982,11 +3042,6 @@ objects:
               secretKeyRef:
                 key: SECRET_KEY_BASE
                 name: system-app
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: URL
-                name: system-redis
           - name: MEMCACHE_SERVERS
             valueFrom:
               secretKeyRef:
@@ -2997,6 +3052,26 @@ objects:
               secretKeyRef:
                 key: REDIS_STORAGE_URL
                 name: backend-redis
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           - name: APICAST_BACKEND_ROOT_ENDPOINT
             valueFrom:
               secretKeyRef:
@@ -3094,6 +3169,21 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           name: check-svc
           resources: {}
@@ -3190,6 +3280,26 @@ objects:
             value: "5"
           - name: FULL_REINDEX_INTERVAL
             value: "60"
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: URL
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_URL
+                name: system-redis
+          - name: REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: NAMESPACE
+                name: system-redis
+          - name: MESSAGE_BUS_REDIS_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                key: MESSAGE_BUS_NAMESPACE
+                name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -3264,7 +3374,10 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    URL: redis://system-redis:6379/1
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4178,6 +4291,20 @@ parameters:
   name: RECAPTCHA_PUBLIC_KEY
 - description: reCAPTCHA secret key (used in spam protection)
   name: RECAPTCHA_PRIVATE_KEY
+- description: Define the external system-redis to connect to
+  name: SYSTEM_REDIS_URL
+  required: true
+  value: redis://system-redis:6379/1
+- description: Define the external system-redis message bus to connect to. By default
+    the same value as SYSTEM_REDIS_URL but with the logical database incremented by
+    1 and the result applied mod 16
+  name: SYSTEM_MESSAGE_BUS_REDIS_URL
+- description: Define the namespace to be used by System's Redis Database. The empty
+    value means not namespaced
+  name: SYSTEM_REDIS_NAMESPACE
+- description: Define the namespace to be used by System's Message Bus Redis Database.
+    The empty value means not namespaced
+  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/component/highavailability_options_builder.go
+++ b/pkg/3scale/amp/component/highavailability_options_builder.go
@@ -26,6 +26,10 @@ func (ha *HighAvailabilityOptionsBuilder) SystemRedisURL(systemRedisURL string) 
 	ha.options.systemRedisURL = systemRedisURL
 }
 
+func (ha *HighAvailabilityOptionsBuilder) SystemMessageBusRedisURL(url string) {
+	ha.options.systemMessageBusRedisURL = url
+}
+
 func (ha *HighAvailabilityOptionsBuilder) Build() (*HighAvailabilityOptions, error) {
 
 	err := ha.setRequiredOptions()
@@ -50,6 +54,9 @@ func (ha *HighAvailabilityOptionsBuilder) setRequiredOptions() error {
 	}
 	if ha.options.systemRedisURL == "" {
 		return fmt.Errorf("no System redis URL has been provided")
+	}
+	if ha.options.systemMessageBusRedisURL == "" {
+		return fmt.Errorf("no System Message Bus redis URL has been provided")
 	}
 
 	return nil

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -408,6 +408,19 @@ func (system *System) buildSystemSphinxEnv() []v1.EnvVar {
 		envVarFromValue("DELTA_INDEX_INTERVAL", "5"),
 		envVarFromValue("FULL_REINDEX_INTERVAL", "60"),
 	)
+	result = append(result, system.SystemRedisEnvVars()...)
+	return result
+}
+
+func (system *System) SystemRedisEnvVars() []v1.EnvVar {
+	result := []v1.EnvVar{}
+
+	result = append(result,
+		envVarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
+		envVarFromSecret("MESSAGE_BUS_REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisURLFieldName),
+		envVarFromSecret("REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisNamespace),
+		envVarFromSecret("MESSAGE_BUS_REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisNamespace),
+	)
 	return result
 }
 
@@ -440,16 +453,12 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 
 		envVarFromSecret("SECRET_KEY_BASE", SystemSecretSystemAppSecretName, SystemSecretSystemAppSecretKeyBaseFieldName),
 
-		envVarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
-		envVarFromSecret("MESSAGE_BUS_REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisURLFieldName),
-		envVarFromSecret("REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisNamespace),
-		envVarFromSecret("MESSAGE_BUS_REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisNamespace),
-
 		envVarFromSecret("MEMCACHE_SERVERS", SystemSecretSystemMemcachedSecretName, SystemSecretSystemMemcachedServersFieldName),
 
 		envVarFromSecret("BACKEND_REDIS_URL", "backend-redis", "REDIS_STORAGE_URL"),
 	)
 
+	result = append(result, system.SystemRedisEnvVars()...)
 	bckListenerApicastRouteEnv := envVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", "backend-listener", "route_endpoint")
 	bckListenerRouteEnv := envVarFromSecret("BACKEND_ROUTE", "backend-listener", "route_endpoint")
 	result = append(result, bckListenerApicastRouteEnv, bckListenerRouteEnv)

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -41,8 +41,11 @@ const (
 )
 
 const (
-	SystemSecretSystemRedisSecretName   = "system-redis"
-	SystemSecretSystemRedisURLFieldName = "URL"
+	SystemSecretSystemRedisSecretName                  = "system-redis"
+	SystemSecretSystemRedisURLFieldName                = "URL"
+	SystemSecretSystemRedisMessageBusRedisURLFieldName = "MESSAGE_BUS_URL"
+	SystemSecretSystemRedisNamespace                   = "NAMESPACE"
+	SystemSecretSystemRedisMessageBusRedisNamespace    = "MESSAGE_BUS_NAMESPACE"
 )
 
 const (
@@ -105,6 +108,9 @@ type systemNonRequiredOptions struct {
 	memcachedServers                       *string
 	eventHooksURL                          *string
 	redisURL                               *string
+	redisNamespace                         *string
+	messageBusRedisNamespace               *string
+	messageBusRedisURL                     *string
 	apicastSystemMasterProxyConfigEndpoint *string
 	apicastSystemMasterBaseURL             *string
 	adminEmail                             *string
@@ -139,6 +145,10 @@ func (o *CLISystemOptionsProvider) GetSystemOptions() (*SystemOptions, error) {
 	sob.AppLabel("${APP_LABEL}")
 	sob.RecaptchaPublicKey("${RECAPTCHA_PUBLIC_KEY}")
 	sob.RecaptchaPrivateKey("${RECAPTCHA_PRIVATE_KEY}")
+	sob.RedisURL("${SYSTEM_REDIS_URL}")
+	sob.RedisNamespace("${SYSTEM_REDIS_NAMESPACE}")
+	sob.MessageBusRedisURL("${SYSTEM_MESSAGE_BUS_REDIS_URL}")
+	sob.MessageBusRedisNamespace("${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}")
 	sob.AppSecretKeyBase("${SYSTEM_APP_SECRET_KEY_BASE}")
 	sob.BackendSharedSecret("${SYSTEM_BACKEND_SHARED_SECRET}")
 	sob.TenantName("${TENANT_NAME}")
@@ -258,6 +268,24 @@ func (system *System) buildParameters(template *templatev1.Template) {
 			Name:        "RECAPTCHA_PRIVATE_KEY",
 			Description: "reCAPTCHA secret key (used in spam protection)",
 			Required:    false,
+		},
+		templatev1.Parameter{
+			Name:        "SYSTEM_REDIS_URL",
+			Description: "Define the external system-redis to connect to",
+			Required:    true,
+			Value:       "redis://system-redis:6379/1",
+		},
+		templatev1.Parameter{
+			Name:        "SYSTEM_MESSAGE_BUS_REDIS_URL",
+			Description: "Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16",
+		},
+		templatev1.Parameter{
+			Name:        "SYSTEM_REDIS_NAMESPACE",
+			Description: "Define the namespace to be used by System's Redis Database. The empty value means not namespaced",
+		},
+		templatev1.Parameter{
+			Name:        "SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE",
+			Description: "Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced",
 		},
 	}
 	template.Parameters = append(template.Parameters, parameters...)
@@ -413,6 +441,9 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 		envVarFromSecret("SECRET_KEY_BASE", SystemSecretSystemAppSecretName, SystemSecretSystemAppSecretKeyBaseFieldName),
 
 		envVarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
+		envVarFromSecret("MESSAGE_BUS_REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisURLFieldName),
+		envVarFromSecret("REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisNamespace),
+		envVarFromSecret("MESSAGE_BUS_REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisNamespace),
 
 		envVarFromSecret("MEMCACHE_SERVERS", SystemSecretSystemMemcachedSecretName, SystemSecretSystemMemcachedServersFieldName),
 
@@ -547,7 +578,10 @@ func (system *System) buildSystemRedisSecrets() *v1.Secret {
 			},
 		},
 		StringData: map[string]string{
-			SystemSecretSystemRedisURLFieldName: *system.Options.redisURL,
+			SystemSecretSystemRedisURLFieldName:                *system.Options.redisURL,
+			SystemSecretSystemRedisMessageBusRedisURLFieldName: *system.Options.messageBusRedisURL,
+			SystemSecretSystemRedisNamespace:                   *system.Options.redisNamespace,
+			SystemSecretSystemRedisMessageBusRedisNamespace:    *system.Options.messageBusRedisNamespace,
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -1005,6 +1039,9 @@ func (system *System) buildSystemSidekiqDeploymentConfig() *appsv1.DeploymentCon
 							Env: []v1.EnvVar{
 								envVarFromValue("SLEEP_SECONDS", "1"),
 								envVarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
+								envVarFromSecret("MESSAGE_BUS_REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisURLFieldName),
+								envVarFromSecret("REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisNamespace),
+								envVarFromSecret("MESSAGE_BUS_REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisNamespace),
 							},
 						},
 					},

--- a/pkg/3scale/amp/component/system_options_builder.go
+++ b/pkg/3scale/amp/component/system_options_builder.go
@@ -94,6 +94,18 @@ func (s *SystemOptionsBuilder) RedisURL(redisURL string) {
 	s.options.redisURL = &redisURL
 }
 
+func (s *SystemOptionsBuilder) MessageBusRedisURL(url string) {
+	s.options.messageBusRedisURL = &url
+}
+
+func (s *SystemOptionsBuilder) RedisNamespace(namespace string) {
+	s.options.redisNamespace = &namespace
+}
+
+func (s *SystemOptionsBuilder) MessageBusRedisNamespace(namespace string) {
+	s.options.messageBusRedisNamespace = &namespace
+}
+
 func (s *SystemOptionsBuilder) ApicastSystemMasterProxyConfigEndpoint(endpoint string) {
 	s.options.apicastSystemMasterProxyConfigEndpoint = &endpoint
 }
@@ -167,6 +179,10 @@ func (s *SystemOptionsBuilder) setNonRequiredOptions() {
 	defaultMemcachedServers := "system-memcache:11211"
 	defaultEventHooksURL := "http://system-master:3000/master/events/import"
 	defaultRedisURL := "redis://system-redis:6379/1"
+	defaultMessageBusRedisURL := ""
+	defaultRedisNamespace := ""
+	defaultMessageBusRedisNamespace := ""
+
 	defaultApicastSystemMasterProxyConfigEndpoint := "http://" + s.options.apicastAccessToken + "@system-master:3000/master/api/proxy/configs"
 	defaultApicastSystemMasterBaseURL := "http://" + s.options.apicastAccessToken + "@system-master:3000"
 	defaultAdminEmail := ""
@@ -181,6 +197,18 @@ func (s *SystemOptionsBuilder) setNonRequiredOptions() {
 
 	if s.options.redisURL == nil {
 		s.options.redisURL = &defaultRedisURL
+	}
+
+	if s.options.messageBusRedisURL == nil {
+		s.options.messageBusRedisURL = &defaultMessageBusRedisURL
+	}
+
+	if s.options.redisNamespace == nil {
+		s.options.redisNamespace = &defaultRedisNamespace
+	}
+
+	if s.options.messageBusRedisNamespace == nil {
+		s.options.messageBusRedisNamespace = &defaultMessageBusRedisNamespace
 	}
 
 	if s.options.apicastSystemMasterProxyConfigEndpoint == nil {

--- a/pkg/3scale/amp/operator/highavailability.go
+++ b/pkg/3scale/amp/operator/highavailability.go
@@ -66,6 +66,12 @@ func (o *OperatorHighAvailabilityOptionsProvider) setSystemRedisOptions(builder 
 	}
 	builder.SystemRedisURL(*result)
 
+	result = getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisURLFieldName)
+	if result == nil {
+		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.SystemSecretSystemRedisMessageBusRedisURLFieldName, component.SystemSecretSystemRedisSecretName)
+	}
+	builder.SystemMessageBusRedisURL(*result)
+
 	return nil
 }
 

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -143,7 +143,7 @@ func (o *OperatorSystemOptionsProvider) setSystemRedisOptions(builder *component
 
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Do nothing because there are no required options for related to the Memcached servers secret
+			// Do nothing because there are no required options for related to the System's Redis servers secret
 		} else {
 			return err
 		}
@@ -154,6 +154,22 @@ func (o *OperatorSystemOptionsProvider) setSystemRedisOptions(builder *component
 		if result != nil {
 			builder.RedisURL(*result)
 		}
+
+		result = getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisURLFieldName)
+		if result != nil {
+			builder.MessageBusRedisURL(*result)
+		}
+
+		result = getSecretDataValue(secretData, component.SystemSecretSystemRedisNamespace)
+		if result != nil {
+			builder.RedisNamespace(*result)
+		}
+
+		result = getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisNamespace)
+		if result != nil {
+			builder.MessageBusRedisNamespace(*result)
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
This PR:
 * Adds the SYSTEM_REDIS_URL parameter to all templates and not only to the HA one. Additionally Makes this parameter required without a default value only in the HA template.
 * Adds the SYSTEM_MESSAGE_BUS_REDIS_URL parameter to all templates. Additionally Makes this parameter required without a default value only in the HA template.
 * Sets the MESSAGE_BUS_URL attribute in the 'system-redis' secret gathering its value from the SYSTEM_MESSAGE_BUS_REDIS_URL in the case of templates. In the case of the operator it's also automatically generated if not specified
 * system's redis url is 'redis://system-redis:6379/1' by default (as before)
 * system's message bus redis url is 'redis://system-redis:6379/8' by default (as before)
 *  Adds the environment variable MESSAGE_BUS_REDIS_URL in the system-sidekiq and system-app pod's containers, gathering its value from the MESSAGE_BUS_URL attribute of the 'system-redis' secret
 * In the Operator side, adds reconciliation of the new MESSAGE_BUS_URL attribute of the 'system-redis' secret

The purpose of this changes is allowing a configuration of the system's message bus redis database and system's Redis database into the same logical database, to allow Redis Enterprise to work.