### PR TITLE
Migrate dbs to imagestreams

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -200,24 +200,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -261,7 +421,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -299,6 +459,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -429,7 +597,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -454,6 +622,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -467,6 +636,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -987,7 +1164,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1017,6 +1194,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1030,6 +1208,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1155,7 +1341,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1176,9 +1362,18 @@ objects:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3266,6 +3461,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3278,7 +3474,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -199,24 +199,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -260,7 +420,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -298,6 +458,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -428,7 +596,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -453,6 +621,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -466,6 +635,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -986,7 +1163,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1016,6 +1193,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1029,6 +1207,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1154,7 +1340,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1175,9 +1361,18 @@ objects:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3172,6 +3367,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3184,7 +3380,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -199,24 +199,73 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -733,7 +782,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -760,9 +809,18 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -2780,6 +2838,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -2792,7 +2851,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -200,24 +200,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -261,7 +421,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -305,6 +465,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -435,7 +603,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -466,6 +634,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -479,6 +648,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1017,7 +1194,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1052,6 +1229,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1065,6 +1243,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1190,7 +1376,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1217,9 +1403,18 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3349,6 +3544,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3361,7 +3557,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -199,24 +199,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -260,7 +420,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -304,6 +464,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -434,7 +602,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -465,6 +633,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -478,6 +647,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1016,7 +1193,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1051,6 +1228,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1064,6 +1242,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1189,7 +1375,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1216,9 +1402,18 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3255,6 +3450,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3267,7 +3463,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -200,24 +200,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -254,7 +414,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -291,6 +451,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -421,7 +589,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -459,6 +627,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -976,7 +1152,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1019,6 +1195,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1144,7 +1328,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1168,6 +1352,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3263,7 +3455,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -199,24 +199,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -253,7 +413,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -290,6 +450,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -420,7 +588,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -458,6 +626,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -975,7 +1151,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1018,6 +1194,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1143,7 +1327,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1167,6 +1351,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3169,7 +3361,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -199,24 +199,73 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -723,7 +772,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -753,6 +802,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -2778,7 +2835,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -200,24 +200,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -254,7 +414,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -297,6 +457,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -427,7 +595,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -471,6 +639,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1006,7 +1182,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1054,6 +1230,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1179,7 +1363,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1209,6 +1393,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3346,7 +3538,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -199,24 +199,184 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Zync database
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-      threescale_component_element: postgresql
     name: postgresql
   spec:
     lookupPolicy:
       local: false
     tags:
-    - annotations: null
+    - annotations:
+        openshift.io/display-name: Zync PostgreSQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
         name: ${POSTGRESQL_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
-      name: "10"
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: Backend Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: Backend Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: Backend ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Redis
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Redis (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Redis
+      from:
+        kind: DockerImage
+        name: ${REDIS_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System Memcached
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-memcached
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System Memcached (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} Memcached
+      from:
+        kind: DockerImage
+        name: ${MEMCACHED_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: System MySQL
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-mysql
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/display-name: System MySQL (latest)
+      from:
+        kind: ImageStreamTag
+        name: ${AMP_RELEASE}
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+    - annotations:
+        openshift.io/display-name: System ${AMP_RELEASE} MySQL
+      from:
+        kind: DockerImage
+        name: ${MYSQL_IMAGE}
+      generation: null
+      importPolicy:
+        insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
+      name: ${AMP_RELEASE}
       referencePolicy:
         type: ""
   status:
@@ -253,7 +413,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -296,6 +456,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - backend-redis
+        from:
+          kind: ImageStreamTag
+          name: backend-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -426,7 +594,7 @@ objects:
           - "no"
           command:
           - /opt/rh/rh-redis32/root/usr/bin/redis-server
-          image: ${REDIS_IMAGE}
+          image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -470,6 +638,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-redis
+        from:
+          kind: ImageStreamTag
+          name: system-redis:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1005,7 +1181,7 @@ objects:
             value: "1"
           - name: MYSQL_DEFAULTS_FILE
             value: /etc/my-extra/my.cnf
-          image: ${MYSQL_IMAGE}
+          image: system-mysql:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 30
@@ -1053,6 +1229,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - system-mysql
+        from:
+          kind: ImageStreamTag
+          name: system-mysql:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -1178,7 +1362,7 @@ objects:
           - memcached
           - -m
           - "64"
-          image: ${MEMCACHED_IMAGE}
+          image: system-memcached:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 10
@@ -1208,6 +1392,14 @@ objects:
     test: false
     triggers:
     - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - memcache
+        from:
+          kind: ImageStreamTag
+          name: system-memcached:latest
+      type: ImageChange
   status:
     availableReplicas: 0
     latestVersion: 0
@@ -3252,7 +3444,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:10
+          name: postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/cmd/template.go
+++ b/pkg/3scale/amp/cmd/template.go
@@ -164,7 +164,7 @@ func addDoubleBraceExpansionFieldsToResult(serializedResult map[string]interface
 			for _, intobjtag := range objspec["tags"].([]interface{}) {
 				objtag := intobjtag.(map[string]interface{})
 				objtagname := objtag["name"].(string)
-				if objtagname == "${AMP_RELEASE}" || objtagname == "9.5" || objtagname == "10" {
+				if objtagname == "${AMP_RELEASE}" {
 					if _, ok := objtag["importPolicy"]; ok {
 						importPolicyFields := objtag["importPolicy"].(map[string]interface{})
 						importPolicyFields["insecure"] = "${{IMAGESTREAM_TAG_IMPORT_INSECURE}}"

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -351,26 +351,45 @@ func (ampImages *AmpImages) buildAmpSystemImageStream() *imagev1.ImageStream {
 
 func (ampImages *AmpImages) buildPostgreSQLImageStream() *imagev1.ImageStream {
 	return &imagev1.ImageStream{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ImageStream",
-			APIVersion: "image.openshift.io/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "postgresql",
-			Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "postgresql", "app": ampImages.Options.appLabel},
+			Name: "postgresql",
+			Labels: map[string]string{
+				"app":                  ampImages.Options.appLabel,
+				"threescale_component": "system",
+			},
+			Annotations: map[string]string{
+				"openshift.io/display-name": "Zync database",
+			},
 		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "image.openshift.io/v1", Kind: "ImageStream"},
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "10",
+					Name: "latest",
+					Annotations: map[string]string{
+						"openshift.io/display-name": "Zync PostgreSQL (latest)",
+					},
+					From: &v1.ObjectReference{
+						Kind: "ImageStreamTag",
+						Name: ampImages.Options.ampRelease,
+					},
+				},
+				imagev1.TagReference{
+					Name: ampImages.Options.ampRelease,
+					Annotations: map[string]string{
+						"openshift.io/display-name": "Zync " + ampImages.Options.ampRelease + " PostgreSQL",
+					},
 					From: &v1.ObjectReference{
 						Kind: "DockerImage",
 						Name: ampImages.Options.postgreSQLImage,
 					},
-					Reference: false,
 					ImportPolicy: imagev1.TagImportPolicy{
-						Insecure: false,
-					}}}}}
+						Insecure: insecureImportPolicy,
+					},
+				},
+			},
+		},
+	}
 }
 
 func (ampImages *AmpImages) buildBackendRedisImageStream() *imagev1.ImageStream {

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -31,6 +31,7 @@ type AmpImagesOptions struct {
 	backendRedisImage    string
 	systemRedisImage     string
 	systemMemcachedImage string
+	systemMySQLImage     string
 	insecureImportPolicy bool
 }
 
@@ -60,6 +61,7 @@ func (o *CLIAmpImagesOptionsProvider) GetAmpImagesOptions() (*AmpImagesOptions, 
 	aob.BackendRedisImage("${REDIS_IMAGE}")
 	aob.SystemRedisImage("${REDIS_IMAGE}")
 	aob.SystemMemcachedImage("${MEMCACHED_IMAGE}")
+	aob.SystemMySQLImage("${MYSQL_IMAGE}")
 
 	aob.InsecureImportPolicy(false)
 
@@ -104,6 +106,7 @@ func (ampImages *AmpImages) buildObjects() []runtime.RawExtension {
 	backendRedisImageStream := ampImages.buildBackendRedisImageStream()
 	systemRedisImageStream := ampImages.buildSystemRedisImageStream()
 	systemMemcachedImageStream := ampImages.buildSystemMemcachedImageStream()
+	systemMySQLImageStream := ampImages.buildSystemMySQLImageStream()
 
 	quayServiceAccount := ampImages.buildQuayServiceAccount()
 
@@ -117,6 +120,7 @@ func (ampImages *AmpImages) buildObjects() []runtime.RawExtension {
 		runtime.RawExtension{Object: backendRedisImageStream},
 		runtime.RawExtension{Object: systemRedisImageStream},
 		runtime.RawExtension{Object: systemMemcachedImageStream},
+		runtime.RawExtension{Object: systemMySQLImageStream},
 		runtime.RawExtension{Object: quayServiceAccount},
 	}
 	return objects
@@ -488,6 +492,49 @@ func (ampImages *AmpImages) buildSystemMemcachedImageStream() *imagev1.ImageStre
 					From: &v1.ObjectReference{
 						Kind: "DockerImage",
 						Name: ampImages.Options.systemMemcachedImage,
+					},
+					ImportPolicy: imagev1.TagImportPolicy{
+						Insecure: insecureImportPolicy,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (ampImages *AmpImages) buildSystemMySQLImageStream() *imagev1.ImageStream {
+	return &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system-mysql",
+			Labels: map[string]string{
+				"app":                  ampImages.Options.appLabel,
+				"threescale_component": "system",
+			},
+			Annotations: map[string]string{
+				"openshift.io/display-name": "System MySQL",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "image.openshift.io/v1", Kind: "ImageStream"},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				imagev1.TagReference{
+					Name: "latest",
+					Annotations: map[string]string{
+						"openshift.io/display-name": "System MySQL (latest)",
+					},
+					From: &v1.ObjectReference{
+						Kind: "ImageStreamTag",
+						Name: ampImages.Options.ampRelease,
+					},
+				},
+				imagev1.TagReference{
+					Name: ampImages.Options.ampRelease,
+					Annotations: map[string]string{
+						"openshift.io/display-name": "System " + ampImages.Options.ampRelease + " MySQL",
+					},
+					From: &v1.ObjectReference{
+						Kind: "DockerImage",
+						Name: ampImages.Options.systemMySQLImage,
 					},
 					ImportPolicy: imagev1.TagImportPolicy{
 						Insecure: insecureImportPolicy,

--- a/pkg/3scale/amp/component/ampimages_options_builder.go
+++ b/pkg/3scale/amp/component/ampimages_options_builder.go
@@ -42,6 +42,10 @@ func (ampImages *AmpImagesOptionsBuilder) BackendRedisImage(image string) {
 	ampImages.options.backendRedisImage = image
 }
 
+func (ampImages *AmpImagesOptionsBuilder) SystemRedisImage(image string) {
+	ampImages.options.systemRedisImage = image
+}
+
 func (ampImages *AmpImagesOptionsBuilder) InsecureImportPolicy(insecureImportPolicy bool) {
 	ampImages.options.insecureImportPolicy = insecureImportPolicy
 }
@@ -73,6 +77,9 @@ func (ampImages *AmpImagesOptionsBuilder) Build() (*AmpImagesOptions, error) {
 	}
 	if ampImages.options.backendRedisImage == "" {
 		return nil, fmt.Errorf("no Backend Redis image has been provided")
+	}
+	if ampImages.options.systemRedisImage == "" {
+		return nil, fmt.Errorf("no System Redis image has been provided")
 	}
 
 	return &ampImages.options, nil

--- a/pkg/3scale/amp/component/ampimages_options_builder.go
+++ b/pkg/3scale/amp/component/ampimages_options_builder.go
@@ -50,6 +50,10 @@ func (ampImages *AmpImagesOptionsBuilder) SystemMemcachedImage(image string) {
 	ampImages.options.systemMemcachedImage = image
 }
 
+func (ampImages *AmpImagesOptionsBuilder) SystemMySQLImage(image string) {
+	ampImages.options.systemMySQLImage = image
+}
+
 func (ampImages *AmpImagesOptionsBuilder) InsecureImportPolicy(insecureImportPolicy bool) {
 	ampImages.options.insecureImportPolicy = insecureImportPolicy
 }
@@ -87,6 +91,9 @@ func (ampImages *AmpImagesOptionsBuilder) Build() (*AmpImagesOptions, error) {
 	}
 	if ampImages.options.systemMemcachedImage == "" {
 		return nil, fmt.Errorf("no System Memcached image has been provided")
+	}
+	if ampImages.options.systemMySQLImage == "" {
+		return nil, fmt.Errorf("no System MySQL image has been provided")
 	}
 
 	return &ampImages.options, nil

--- a/pkg/3scale/amp/component/ampimages_options_builder.go
+++ b/pkg/3scale/amp/component/ampimages_options_builder.go
@@ -46,6 +46,10 @@ func (ampImages *AmpImagesOptionsBuilder) SystemRedisImage(image string) {
 	ampImages.options.systemRedisImage = image
 }
 
+func (ampImages *AmpImagesOptionsBuilder) SystemMemcachedImage(image string) {
+	ampImages.options.systemMemcachedImage = image
+}
+
 func (ampImages *AmpImagesOptionsBuilder) InsecureImportPolicy(insecureImportPolicy bool) {
 	ampImages.options.insecureImportPolicy = insecureImportPolicy
 }
@@ -80,6 +84,9 @@ func (ampImages *AmpImagesOptionsBuilder) Build() (*AmpImagesOptions, error) {
 	}
 	if ampImages.options.systemRedisImage == "" {
 		return nil, fmt.Errorf("no System Redis image has been provided")
+	}
+	if ampImages.options.systemMemcachedImage == "" {
+		return nil, fmt.Errorf("no System Memcached image has been provided")
 	}
 
 	return &ampImages.options, nil

--- a/pkg/3scale/amp/component/ampimages_options_builder.go
+++ b/pkg/3scale/amp/component/ampimages_options_builder.go
@@ -38,6 +38,10 @@ func (ampImages *AmpImagesOptionsBuilder) PostgreSQLImage(postgreSQLImage string
 	ampImages.options.postgreSQLImage = postgreSQLImage
 }
 
+func (ampImages *AmpImagesOptionsBuilder) BackendRedisImage(image string) {
+	ampImages.options.backendRedisImage = image
+}
+
 func (ampImages *AmpImagesOptionsBuilder) InsecureImportPolicy(insecureImportPolicy bool) {
 	ampImages.options.insecureImportPolicy = insecureImportPolicy
 }
@@ -66,6 +70,9 @@ func (ampImages *AmpImagesOptionsBuilder) Build() (*AmpImagesOptions, error) {
 	}
 	if ampImages.options.postgreSQLImage == "" {
 		return nil, fmt.Errorf("no PostgreSQL image has been provided")
+	}
+	if ampImages.options.backendRedisImage == "" {
+		return nil, fmt.Errorf("no Backend Redis image has been provided")
 	}
 
 	return &ampImages.options, nil

--- a/pkg/3scale/amp/component/highavailability.go
+++ b/pkg/3scale/amp/component/highavailability.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	appsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -185,6 +186,10 @@ func (ha *HighAvailability) deleteInternalDatabasesObjects(objects []runtime.Raw
 		case *v1.ConfigMap:
 			if obj.ObjectMeta.Name != "mysql-main-conf" && obj.ObjectMeta.Name != "mysql-extra-conf" &&
 				obj.ObjectMeta.Name != "redis-config" {
+				keepObjects = append(keepObjects, objects[rawExtIdx])
+			}
+		case *imagev1.ImageStream:
+			if _, ok := highlyAvailableExternalDatabases[obj.ObjectMeta.Name]; !ok {
 				keepObjects = append(keepObjects, objects[rawExtIdx])
 			}
 		default:

--- a/pkg/3scale/amp/component/memcached_options_builder.go
+++ b/pkg/3scale/amp/component/memcached_options_builder.go
@@ -10,10 +10,6 @@ func (m *MemcachedOptionsBuilder) AppLabel(appLabel string) {
 	m.options.appLabel = appLabel
 }
 
-func (m *MemcachedOptionsBuilder) Image(image string) {
-	m.options.image = image
-}
-
 func (m *MemcachedOptionsBuilder) Build() (*MemcachedOptions, error) {
 	err := m.setRequiredOptions()
 	if err != nil {
@@ -28,9 +24,6 @@ func (m *MemcachedOptionsBuilder) Build() (*MemcachedOptions, error) {
 func (m *MemcachedOptionsBuilder) setRequiredOptions() error {
 	if m.options.appLabel == "" {
 		return fmt.Errorf("no AppLabel has been provided")
-	}
-	if m.options.image == "" {
-		return fmt.Errorf("no Memcached Image has been provided")
 	}
 
 	return nil

--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -28,7 +28,6 @@ type MysqlOptions struct {
 type mysqlRequiredOptions struct {
 	appLabel     string
 	databaseName string
-	image        string
 	user         string
 	password     string
 	rootPassword string
@@ -48,7 +47,6 @@ func (o *CLIMysqlOptionsProvider) GetMysqlOptions() (*MysqlOptions, error) {
 	mob := MysqlOptionsBuilder{}
 	mob.AppLabel("${APP_LABEL}")
 	mob.DatabaseName("${MYSQL_DATABASE}")
-	mob.Image("${MYSQL_IMAGE}")
 	mob.User("${MYSQL_USER}")
 	mob.Password("${MYSQL_PASSWORD}")
 	mob.RootPassword("${MYSQL_ROOT_PASSWORD}")
@@ -235,6 +233,19 @@ func (mysql *Mysql) buildSystemMysqlDeploymentConfig() *appsv1.DeploymentConfig 
 			Triggers: appsv1.DeploymentTriggerPolicies{
 				appsv1.DeploymentTriggerPolicy{
 					Type: appsv1.DeploymentTriggerOnConfigChange},
+				appsv1.DeploymentTriggerPolicy{
+					Type: appsv1.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
+						Automatic: true,
+						ContainerNames: []string{
+							"system-mysql",
+						},
+						From: v1.ObjectReference{
+							Kind: "ImageStreamTag",
+							Name: "system-mysql:latest",
+						},
+					},
+				},
 			},
 			Replicas: 1,
 			Selector: map[string]string{"deploymentConfig": "system-mysql"},
@@ -264,7 +275,7 @@ func (mysql *Mysql) buildSystemMysqlDeploymentConfig() *appsv1.DeploymentConfig 
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "system-mysql",
-							Image: mysql.Options.image,
+							Image: "system-mysql:latest",
 							Ports: []v1.ContainerPort{
 								v1.ContainerPort{HostPort: 0,
 									ContainerPort: 3306,

--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -243,6 +243,7 @@ func (mysql *Mysql) buildSystemMysqlDeploymentConfig() *appsv1.DeploymentConfig 
 					Labels: map[string]string{"threescale_component": "system", "threescale_component_element": "mysql", "app": mysql.Options.appLabel, "deploymentConfig": "system-mysql"},
 				},
 				Spec: v1.PodSpec{
+					ServiceAccountName: "amp", //TODO make this configurable via flag
 					Volumes: []v1.Volume{
 						v1.Volume{
 							Name: "mysql-storage",

--- a/pkg/3scale/amp/component/mysql_options_builder.go
+++ b/pkg/3scale/amp/component/mysql_options_builder.go
@@ -14,10 +14,6 @@ func (m *MysqlOptionsBuilder) DatabaseName(databaseName string) {
 	m.options.databaseName = databaseName
 }
 
-func (m *MysqlOptionsBuilder) Image(image string) {
-	m.options.image = image
-}
-
 func (m *MysqlOptionsBuilder) User(user string) {
 	m.options.user = user
 }
@@ -51,9 +47,6 @@ func (m *MysqlOptionsBuilder) setRequiredOptions() error {
 	}
 	if m.options.databaseName == "" {
 		return fmt.Errorf("no Database Name has been provided")
-	}
-	if m.options.image == "" {
-		return fmt.Errorf("no Database Image has been provided")
 	}
 	if m.options.user == "" {
 		return fmt.Errorf("no User has been provided")

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -26,9 +26,8 @@ type RedisOptions struct {
 }
 
 type redisRequiredOptions struct {
-	appLabel     string
-	backendImage string
-	systemImage  string
+	appLabel    string
+	systemImage string
 }
 
 type redisNonRequiredOptions struct {
@@ -51,7 +50,6 @@ type CLIRedisOptionsProvider struct {
 func (o *CLIRedisOptionsProvider) GetRedisOptions() (*RedisOptions, error) {
 	rob := RedisOptionsBuilder{}
 	rob.AppLabel("${APP_LABEL}")
-	rob.BackendImage("${REDIS_IMAGE}")
 	rob.SystemImage("${REDIS_IMAGE}")
 
 	res, err := rob.Build()
@@ -195,6 +193,19 @@ func (redis *Redis) buildDeploymentConfigTriggers() appsv1.DeploymentTriggerPoli
 		appsv1.DeploymentTriggerPolicy{
 			Type: appsv1.DeploymentTriggerOnConfigChange,
 		},
+		appsv1.DeploymentTriggerPolicy{
+			Type: appsv1.DeploymentTriggerOnImageChange,
+			ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
+				Automatic: true,
+				ContainerNames: []string{
+					"backend-redis",
+				},
+				From: v1.ObjectReference{
+					Kind: "ImageStreamTag",
+					Name: "backend-redis:latest",
+				},
+			},
+		},
 	}
 }
 
@@ -252,7 +263,7 @@ func (redis *Redis) buildPodVolumes() []v1.Volume {
 func (redis *Redis) buildPodContainers() []v1.Container {
 	return []v1.Container{
 		v1.Container{
-			Image:           redis.Options.backendImage,
+			Image:           "backend-redis:latest",
 			ImagePullPolicy: v1.PullIfNotPresent,
 			Name:            backendRedisContainerName,
 			Command:         redis.buildPodContainerCommand(),

--- a/pkg/3scale/amp/component/redis_options_builder.go
+++ b/pkg/3scale/amp/component/redis_options_builder.go
@@ -10,10 +10,6 @@ func (r *RedisOptionsBuilder) AppLabel(appLabel string) {
 	r.options.appLabel = appLabel
 }
 
-func (r *RedisOptionsBuilder) SystemImage(image string) {
-	r.options.systemImage = image
-}
-
 func (r *RedisOptionsBuilder) Build() (*RedisOptions, error) {
 	err := r.setRequiredOptions()
 	if err != nil {
@@ -28,10 +24,6 @@ func (r *RedisOptionsBuilder) Build() (*RedisOptions, error) {
 func (r *RedisOptionsBuilder) setRequiredOptions() error {
 	if r.options.appLabel == "" {
 		return fmt.Errorf("no AppLabel has been provided")
-	}
-
-	if r.options.systemImage == "" {
-		return fmt.Errorf("no Redis System Image has been provided")
 	}
 
 	return nil

--- a/pkg/3scale/amp/component/redis_options_builder.go
+++ b/pkg/3scale/amp/component/redis_options_builder.go
@@ -10,10 +10,6 @@ func (r *RedisOptionsBuilder) AppLabel(appLabel string) {
 	r.options.appLabel = appLabel
 }
 
-func (r *RedisOptionsBuilder) BackendImage(image string) {
-	r.options.backendImage = image
-}
-
 func (r *RedisOptionsBuilder) SystemImage(image string) {
 	r.options.systemImage = image
 }
@@ -32,9 +28,6 @@ func (r *RedisOptionsBuilder) Build() (*RedisOptions, error) {
 func (r *RedisOptionsBuilder) setRequiredOptions() error {
 	if r.options.appLabel == "" {
 		return fmt.Errorf("no AppLabel has been provided")
-	}
-	if r.options.backendImage == "" {
-		return fmt.Errorf("no Redis Backend Image has been provided")
 	}
 
 	if r.options.systemImage == "" {

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -434,7 +434,7 @@ func (zync *Zync) buildZyncDatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "postgresql:10",
+							Name: "postgresql:latest",
 						},
 					},
 				},
@@ -454,7 +454,8 @@ func (zync *Zync) buildZyncDatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 					},
 				},
 				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyAlways,
+					RestartPolicy:      v1.RestartPolicyAlways,
+					ServiceAccountName: "amp",
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "postgresql",

--- a/pkg/3scale/amp/operator/ampimages.go
+++ b/pkg/3scale/amp/operator/ampimages.go
@@ -61,6 +61,12 @@ func (o *OperatorAmpImagesOptionsProvider) GetAmpImagesOptions() (*component.Amp
 		optProv.BackendRedisImage(imageProvider.GetBackendRedisImage())
 	}
 
+	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.RedisImage != nil {
+		optProv.SystemRedisImage(*o.APIManagerSpec.SystemSpec.RedisImage)
+	} else {
+		optProv.SystemRedisImage(imageProvider.GetSystemRedisImage())
+	}
+
 	optProv.InsecureImportPolicy(*o.APIManagerSpec.ImageStreamTagImportInsecure)
 	res, err := optProv.Build()
 	if err != nil {

--- a/pkg/3scale/amp/operator/ampimages.go
+++ b/pkg/3scale/amp/operator/ampimages.go
@@ -73,6 +73,14 @@ func (o *OperatorAmpImagesOptionsProvider) GetAmpImagesOptions() (*component.Amp
 		optProv.SystemMemcachedImage(imageProvider.GetSystemMemcachedImage())
 	}
 
+	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.DatabaseSpec != nil &&
+		o.APIManagerSpec.SystemSpec.DatabaseSpec.MySQLSpec != nil &&
+		o.APIManagerSpec.SystemSpec.DatabaseSpec.MySQLSpec.Image != nil {
+		optProv.SystemMySQLImage(*o.APIManagerSpec.SystemSpec.DatabaseSpec.MySQLSpec.Image)
+	} else {
+		optProv.SystemMySQLImage(imageProvider.GetSystemMySQLImage())
+	}
+
 	optProv.InsecureImportPolicy(*o.APIManagerSpec.ImageStreamTagImportInsecure)
 	res, err := optProv.Build()
 	if err != nil {

--- a/pkg/3scale/amp/operator/ampimages.go
+++ b/pkg/3scale/amp/operator/ampimages.go
@@ -55,6 +55,12 @@ func (o *OperatorAmpImagesOptionsProvider) GetAmpImagesOptions() (*component.Amp
 		optProv.PostgreSQLImage(imageProvider.GetZyncPostgreSQLImage())
 	}
 
+	if o.APIManagerSpec.BackendSpec != nil && o.APIManagerSpec.BackendSpec.RedisImage != nil {
+		optProv.BackendRedisImage(*o.APIManagerSpec.BackendSpec.RedisImage)
+	} else {
+		optProv.BackendRedisImage(imageProvider.GetBackendRedisImage())
+	}
+
 	optProv.InsecureImportPolicy(*o.APIManagerSpec.ImageStreamTagImportInsecure)
 	res, err := optProv.Build()
 	if err != nil {

--- a/pkg/3scale/amp/operator/ampimages.go
+++ b/pkg/3scale/amp/operator/ampimages.go
@@ -67,6 +67,12 @@ func (o *OperatorAmpImagesOptionsProvider) GetAmpImagesOptions() (*component.Amp
 		optProv.SystemRedisImage(imageProvider.GetSystemRedisImage())
 	}
 
+	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.MemcachedImage != nil {
+		optProv.SystemMemcachedImage(*o.APIManagerSpec.SystemSpec.MemcachedImage)
+	} else {
+		optProv.SystemMemcachedImage(imageProvider.GetSystemMemcachedImage())
+	}
+
 	optProv.InsecureImportPolicy(*o.APIManagerSpec.ImageStreamTagImportInsecure)
 	res, err := optProv.Build()
 	if err != nil {

--- a/pkg/3scale/amp/operator/memcached.go
+++ b/pkg/3scale/amp/operator/memcached.go
@@ -4,24 +4,11 @@ import (
 	"fmt"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 )
 
 func (o *OperatorMemcachedOptionsProvider) GetMemcachedOptions() (*component.MemcachedOptions, error) {
-
-	productVersion := o.APIManagerSpec.ProductVersion
-	imageProvider, err := product.NewImageProvider(productVersion)
-	if err != nil {
-		return nil, err
-	}
-
 	optProv := component.MemcachedOptionsBuilder{}
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
-	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.MemcachedImage != nil {
-		optProv.Image(*o.APIManagerSpec.SystemSpec.MemcachedImage)
-	} else {
-		optProv.Image(imageProvider.GetSystemMemcachedImage())
-	}
 
 	res, err := optProv.Build()
 	if err != nil {

--- a/pkg/3scale/amp/operator/mysql.go
+++ b/pkg/3scale/amp/operator/mysql.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -14,21 +13,8 @@ import (
 func (o *OperatorMysqlOptionsProvider) GetMysqlOptions() (*component.MysqlOptions, error) {
 	optProv := component.MysqlOptionsBuilder{}
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
-	productVersion := o.APIManagerSpec.ProductVersion
-	imageProvider, err := product.NewImageProvider(productVersion)
-	if err != nil {
-		return nil, err
-	}
 
-	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
-	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.DatabaseSpec != nil &&
-		o.APIManagerSpec.SystemSpec.DatabaseSpec.MySQLSpec != nil && o.APIManagerSpec.SystemSpec.DatabaseSpec.MySQLSpec.Image != nil {
-		optProv.Image(*o.APIManagerSpec.SystemSpec.DatabaseSpec.MySQLSpec.Image)
-	} else {
-		optProv.Image(imageProvider.GetSystemMySQLImage())
-	}
-
-	err = o.setSecretBasedOptions(&optProv)
+	err := o.setSecretBasedOptions(&optProv)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/3scale/amp/operator/redis.go
+++ b/pkg/3scale/amp/operator/redis.go
@@ -17,11 +17,6 @@ func (o *OperatorRedisOptionsProvider) GetRedisOptions() (*component.RedisOption
 
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 
-	if o.APIManagerSpec.BackendSpec != nil && o.APIManagerSpec.BackendSpec.RedisImage != nil {
-		optProv.BackendImage(*o.APIManagerSpec.BackendSpec.RedisImage)
-	} else {
-		optProv.BackendImage(imageProvider.GetBackendRedisImage())
-	}
 	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.RedisImage != nil {
 		optProv.SystemImage(*o.APIManagerSpec.SystemSpec.RedisImage)
 	} else {

--- a/pkg/3scale/amp/operator/redis.go
+++ b/pkg/3scale/amp/operator/redis.go
@@ -4,25 +4,12 @@ import (
 	"fmt"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 )
 
 func (o *OperatorRedisOptionsProvider) GetRedisOptions() (*component.RedisOptions, error) {
 	optProv := component.RedisOptionsBuilder{}
-	productVersion := o.APIManagerSpec.ProductVersion
-	imageProvider, err := product.NewImageProvider(productVersion)
-	if err != nil {
-		return nil, err
-	}
 
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
-
-	if o.APIManagerSpec.SystemSpec != nil && o.APIManagerSpec.SystemSpec.RedisImage != nil {
-		optProv.SystemImage(*o.APIManagerSpec.SystemSpec.RedisImage)
-	} else {
-		optProv.SystemImage(imageProvider.GetSystemRedisImage())
-	}
-
 	res, err := optProv.Build()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Redis Options - %s", err)


### PR DESCRIPTION
This PR makes the following DeploymentConfig elements use ImageStreams:
 * backend-redis
 * system-redis
 * system-mysql
 * system-memcache

This makes all DeploymentConfigs of the platform use ImageStreams so we have a more homogeneous way of handling the image changes and has the following advantages:
 * Allow easier updates of the Images (with import-image command)
 * All elements of our platform would use the same method to obtain the images. This should simplify tasks like management of them and the 3scale-operator source code
 * It will be easier to start the steps of probably finally remove ImageStreams in a future step so the platform is compatible with Kubernetes (instead of starting with different scenarios and situations), so I think is a good first step to prepare for that if the need arises.
 * It will allows us to perform image tag management with ImageStream tags at this moment (create floating tags in ImageStreams, etc...)

For each DeploymentConfig element that has been modified we have:
 * Added it the 'amp' ServiceAccount to be used
 * Added it an ImageChange trigger
 * Created an ImageStream for it. The ImageStream has two tags: <3scale-release-version> and "latest" (floating tag that points to <3scale-release-version>
 * Set imagePullPolicy to IfNotPresent (if it was not already there)
 * Updated the image value to use the imagestreamname:latest

Important design decisions:
 * Even though Redis is used by both backend-redis and system-redis we have created two different ImageStreams for them. The reason for this is allowing us to independently change the image at different moments
 *** The versioned ImageStream tag for databases is the 3scale release version number instead of the version number of the database**. This has several consequences: Ideally for every new release we should update the tag version name and update the latest tag to point to the new version tag name, even if the database does not change. This would trigger reboots on the databases I think as with any other image change. Another option would be using the database version number as the tag name as we did with PostgreSQL for example (where we had tag '10' instead of 2.5). However the consequence of that is that for database the tag naming convention would be different for each database and we would need to have different code logic to handle it for each database and we would need to find a way to find the tag name (not sure how we would be able to do that without hardcoding it). What do you think @eguzki ? If we decide to use the 3scale release version for every element included databases I'll also update the PR to modify how PostgreSQL works and use the 3scaleversion number instead of "10" as it is done right now

also I understand that changing the image of an existing system-redis, system-mysql and system-memcache DeploymentConfig (it will trigger a redeploy of the pods) will not be a problem because before this changes we could already be doing it statically if we wanted (for an upgrade for example). Can someone from @3scale/system confirm this? Thank you.