### PR TITLE
Prepare usage of registry.redhat.io registry

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -384,7 +384,7 @@ objects:
     dockerImageRepository: ""
 - apiVersion: v1
   imagePullSecrets:
-  - name: quay-auth
+  - name: threescale-registry-auth
   kind: ServiceAccount
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -383,7 +383,7 @@ objects:
     dockerImageRepository: ""
 - apiVersion: v1
   imagePullSecrets:
-  - name: quay-auth
+  - name: threescale-registry-auth
   kind: ServiceAccount
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -272,7 +272,7 @@ objects:
     dockerImageRepository: ""
 - apiVersion: v1
   imagePullSecrets:
-  - name: quay-auth
+  - name: threescale-registry-auth
   kind: ServiceAccount
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -384,7 +384,7 @@ objects:
     dockerImageRepository: ""
 - apiVersion: v1
   imagePullSecrets:
-  - name: quay-auth
+  - name: threescale-registry-auth
   kind: ServiceAccount
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -383,7 +383,7 @@ objects:
     dockerImageRepository: ""
 - apiVersion: v1
   imagePullSecrets:
-  - name: quay-auth
+  - name: threescale-registry-auth
   kind: ServiceAccount
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -382,6 +382,13 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  imagePullSecrets:
+  - name: threescale-registry-auth
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: amp
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -438,6 +445,7 @@ objects:
             name: backend-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: backend-redis-storage
           persistentVolumeClaim:
@@ -614,6 +622,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -751,6 +760,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -877,6 +887,7 @@ objects:
             initialDelaySeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1038,6 +1049,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1182,6 +1194,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1349,6 +1362,7 @@ objects:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -2730,6 +2744,7 @@ objects:
           volumeMounts:
           - mountPath: /opt/system-extra-configs
             name: system-config
+        serviceAccountName: amp
         volumes:
         - configMap:
             items:
@@ -3054,6 +3069,7 @@ objects:
           image: amp-system:latest
           name: check-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir:
             medium: Memory
@@ -3167,6 +3183,7 @@ objects:
           image: amp-system:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: system-sphinx-database
@@ -3363,6 +3380,7 @@ objects:
           image: amp-zync:latest
           name: zync-db-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3443,6 +3461,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3608,6 +3627,7 @@ objects:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3731,6 +3751,7 @@ objects:
           image: amp-apicast:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3903,6 +3924,7 @@ objects:
             name: http
             protocol: TCP
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -381,6 +381,13 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  imagePullSecrets:
+  - name: threescale-registry-auth
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: amp
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -437,6 +444,7 @@ objects:
             name: backend-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: backend-redis-storage
           persistentVolumeClaim:
@@ -613,6 +621,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -750,6 +759,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -876,6 +886,7 @@ objects:
             initialDelaySeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1037,6 +1048,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1181,6 +1193,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1348,6 +1361,7 @@ objects:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -2653,6 +2667,7 @@ objects:
             readOnly: true
           - mountPath: /opt/system-extra-configs
             name: system-config
+        serviceAccountName: amp
         volumes:
         - name: system-storage
           persistentVolumeClaim:
@@ -2957,6 +2972,7 @@ objects:
           image: amp-system:latest
           name: check-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir:
             medium: Memory
@@ -3073,6 +3089,7 @@ objects:
           image: amp-system:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: system-sphinx-database
@@ -3269,6 +3286,7 @@ objects:
           image: amp-zync:latest
           name: zync-db-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3349,6 +3367,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3514,6 +3533,7 @@ objects:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3637,6 +3657,7 @@ objects:
           image: amp-apicast:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3809,6 +3830,7 @@ objects:
             name: http
             protocol: TCP
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -270,6 +270,13 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  imagePullSecrets:
+  - name: threescale-registry-auth
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: amp
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -368,6 +375,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -500,6 +508,7 @@ objects:
             requests:
               cpu: 500m
               memory: 550Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -667,6 +676,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -799,6 +809,7 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -2103,6 +2114,7 @@ objects:
             readOnly: true
           - mountPath: /opt/system-extra-configs
             name: system-config
+        serviceAccountName: amp
         volumes:
         - name: system-storage
           persistentVolumeClaim:
@@ -2413,6 +2425,7 @@ objects:
           image: amp-system:latest
           name: check-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir:
             medium: Memory
@@ -2535,6 +2548,7 @@ objects:
           image: amp-system:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: system-sphinx-database
@@ -2737,6 +2751,7 @@ objects:
           image: amp-zync:latest
           name: zync-db-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -2823,6 +2838,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -2994,6 +3010,7 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3123,6 +3140,7 @@ objects:
           image: amp-apicast:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3301,6 +3319,7 @@ objects:
             requests:
               cpu: 120m
               memory: 32Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -382,6 +382,13 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  imagePullSecrets:
+  - name: threescale-registry-auth
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: amp
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -444,6 +451,7 @@ objects:
             name: backend-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: backend-redis-storage
           persistentVolumeClaim:
@@ -626,6 +634,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -769,6 +778,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -901,6 +911,7 @@ objects:
             requests:
               cpu: 500m
               memory: 550Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1068,6 +1079,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1217,6 +1229,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1390,6 +1403,7 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -2789,6 +2803,7 @@ objects:
           volumeMounts:
           - mountPath: /opt/system-extra-configs
             name: system-config
+        serviceAccountName: amp
         volumes:
         - configMap:
             items:
@@ -3119,6 +3134,7 @@ objects:
           image: amp-system:latest
           name: check-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir:
             medium: Memory
@@ -3238,6 +3254,7 @@ objects:
           image: amp-system:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: system-sphinx-database
@@ -3440,6 +3457,7 @@ objects:
           image: amp-zync:latest
           name: zync-db-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3526,6 +3544,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3697,6 +3716,7 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3826,6 +3846,7 @@ objects:
           image: amp-apicast:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -4004,6 +4025,7 @@ objects:
             requests:
               cpu: 120m
               memory: 32Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -381,6 +381,13 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  imagePullSecrets:
+  - name: threescale-registry-auth
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    name: amp
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -443,6 +450,7 @@ objects:
             name: backend-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: backend-redis-storage
           persistentVolumeClaim:
@@ -625,6 +633,7 @@ objects:
             name: system-redis-storage
           - mountPath: /etc/redis.d/
             name: redis-config
+        serviceAccountName: amp
         volumes:
         - name: system-redis-storage
           persistentVolumeClaim:
@@ -768,6 +777,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -900,6 +910,7 @@ objects:
             requests:
               cpu: 500m
               memory: 550Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1067,6 +1078,7 @@ objects:
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -1216,6 +1228,7 @@ objects:
             name: mysql-extra-conf
           - mountPath: /etc/my-extra
             name: mysql-main-conf
+        serviceAccountName: amp
         volumes:
         - name: mysql-storage
           persistentVolumeClaim:
@@ -1389,6 +1402,7 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -2712,6 +2726,7 @@ objects:
             readOnly: true
           - mountPath: /opt/system-extra-configs
             name: system-config
+        serviceAccountName: amp
         volumes:
         - name: system-storage
           persistentVolumeClaim:
@@ -3022,6 +3037,7 @@ objects:
           image: amp-system:latest
           name: check-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir:
             medium: Memory
@@ -3144,6 +3160,7 @@ objects:
           image: amp-system:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: system-sphinx-database
@@ -3346,6 +3363,7 @@ objects:
           image: amp-zync:latest
           name: zync-db-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3432,6 +3450,7 @@ objects:
           - mountPath: /var/lib/pgsql/data
             name: zync-database-data
         restartPolicy: Always
+        serviceAccountName: amp
         volumes:
         - emptyDir: {}
           name: zync-database-data
@@ -3603,6 +3622,7 @@ objects:
             requests:
               cpu: 50m
               memory: 64Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3732,6 +3752,7 @@ objects:
           image: amp-apicast:latest
           name: system-master-svc
           resources: {}
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange
@@ -3910,6 +3931,7 @@ objects:
             requests:
               cpu: 120m
               memory: 32Mi
+        serviceAccountName: amp
     test: false
     triggers:
     - type: ConfigChange

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -108,7 +108,7 @@ func (ampImages *AmpImages) buildObjects() []runtime.RawExtension {
 	systemMemcachedImageStream := ampImages.buildSystemMemcachedImageStream()
 	systemMySQLImageStream := ampImages.buildSystemMySQLImageStream()
 
-	quayServiceAccount := ampImages.buildQuayServiceAccount()
+	deploymentsServiceAccount := ampImages.buildDeploymentsServiceAccount()
 
 	objects := []runtime.RawExtension{
 		runtime.RawExtension{Object: backendImageStream},
@@ -121,7 +121,7 @@ func (ampImages *AmpImages) buildObjects() []runtime.RawExtension {
 		runtime.RawExtension{Object: systemRedisImageStream},
 		runtime.RawExtension{Object: systemMemcachedImageStream},
 		runtime.RawExtension{Object: systemMySQLImageStream},
-		runtime.RawExtension{Object: quayServiceAccount},
+		runtime.RawExtension{Object: deploymentsServiceAccount},
 	}
 	return objects
 }
@@ -564,7 +564,7 @@ func (ampImages *AmpImages) buildSystemMySQLImageStream() *imagev1.ImageStream {
 	}
 }
 
-func (ampImages *AmpImages) buildQuayServiceAccount() *v1.ServiceAccount {
+func (ampImages *AmpImages) buildDeploymentsServiceAccount() *v1.ServiceAccount {
 	return &v1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceAccount",
@@ -575,7 +575,7 @@ func (ampImages *AmpImages) buildQuayServiceAccount() *v1.ServiceAccount {
 		},
 		ImagePullSecrets: []v1.LocalObjectReference{
 			v1.LocalObjectReference{
-				Name: "quay-auth"}}}
+				Name: "threescale-registry-auth"}}}
 }
 
 func (ampImages *AmpImages) buildParameters(template *templatev1.Template) {

--- a/pkg/3scale/amp/component/productized.go
+++ b/pkg/3scale/amp/component/productized.go
@@ -3,10 +3,8 @@ package component
 import (
 	"fmt"
 
-	appsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -69,45 +67,13 @@ func (productized *Productized) PostProcess(template *templatev1.Template, other
 	_ = err
 	productized.Options = productizedOpts
 	res := template.Objects
-	res = productized.removeAmpServiceAccount(res)
-	res = productized.removeAmpServiceAccountReferences(res)
 	productized.updateAmpImagesParameters(template)
 	template.Objects = res
 }
 
 func (productized *Productized) PostProcessObjects(objects []runtime.RawExtension) []runtime.RawExtension {
 	res := objects
-	res = productized.removeAmpServiceAccount(res)
-	res = productized.removeAmpServiceAccountReferences(res)
 	res = productized.updateAmpImagesURIs(res)
-
-	return res
-}
-
-func (productized *Productized) removeAmpServiceAccount(objects []runtime.RawExtension) []runtime.RawExtension {
-	res := objects
-	for idx, rawExtension := range res {
-		obj := rawExtension.Object
-		sa, ok := obj.(*v1.ServiceAccount)
-		if ok {
-			if sa.ObjectMeta.Name == "amp" {
-				res = append(res[:idx], res[idx+1:]...) // This deletes the element in the array
-				break
-			}
-		}
-	}
-	return res
-}
-
-func (productized *Productized) removeAmpServiceAccountReferences(objects []runtime.RawExtension) []runtime.RawExtension {
-	res := objects
-	for _, rawExtension := range res {
-		obj := rawExtension.Object
-		dc, ok := obj.(*appsv1.DeploymentConfig)
-		if ok {
-			dc.Spec.Template.Spec.ServiceAccountName = ""
-		}
-	}
 
 	return res
 }


### PR DESCRIPTION
PR to prepare for the use of registry.redhat.io in the images for 2.6 releases and newer ones.

The old RedHat registry access.redhat.com will be deprecated and newer images are not going to be published on it. New images are going to be published in registry.redhat.io. This registry requires authentication.

This PR allows configuring the authentication credentials for the registry.redhat.io via a secret called 'threescale-registry-auth'. This secret is associated to the "amp" ServiceAccount that has been assigned to all the DeploymentConfig elements of the platform.
The final user is the only one that knows the credentials it has so the secret must be created by them with the specific fields needed and values needed before deploying the APIManager/the templates. Otherwise, the deploy will fail.
We can think of making the secret name configurable, but for the moment to already have something we can merge it this way.

In case of making it configurable I would:
In the templates we could:
 * Request the secret name (or have a hardcoded one) to be used via a new required parameter. The user should manually create the secret with the expected fields and values before deploying the templates

In the operator we could:
 * Have a required field in the CR that is the secret/set of secrets to be used by the ServiceAccount(s) that we assign to the DeploymentConfig pods (or have a hardcoded secret name). The user should manually create the secret with the expected fields and values before deploying the 3scale operator CR