### PR TITLE
Avoid frequent RawExtension conversions

### DIFF
--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -2,12 +2,13 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -80,21 +81,21 @@ func (ampImages *AmpImages) AssembleIntoTemplate(template *templatev1.Template, 
 	ampImages.addObjectsIntoTemplate(template)
 }
 
-func (ampImages *AmpImages) GetObjects() ([]runtime.RawExtension, error) {
+func (ampImages *AmpImages) GetObjects() ([]common.KubernetesObject, error) {
 	objects := ampImages.buildObjects()
 	return objects, nil
 }
 
 func (ampImages *AmpImages) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := ampImages.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (ampImages *AmpImages) PostProcess(template *templatev1.Template, otherComponents []Component) {
 
 }
 
-func (ampImages *AmpImages) buildObjects() []runtime.RawExtension {
+func (ampImages *AmpImages) buildObjects() []common.KubernetesObject {
 	backendImageStream := ampImages.buildAmpBackendImageStream()
 	zyncImageStream := ampImages.buildAmpZyncImageStream()
 	apicastImageStream := ampImages.buildApicastImageStream()
@@ -107,17 +108,17 @@ func (ampImages *AmpImages) buildObjects() []runtime.RawExtension {
 
 	deploymentsServiceAccount := ampImages.buildDeploymentsServiceAccount()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: backendImageStream},
-		runtime.RawExtension{Object: zyncImageStream},
-		runtime.RawExtension{Object: apicastImageStream},
-		runtime.RawExtension{Object: wildcardRouterImageStream},
-		runtime.RawExtension{Object: systemImageStream},
-		runtime.RawExtension{Object: postgreSQLImageStream},
-		runtime.RawExtension{Object: backendRedisImageStream},
-		runtime.RawExtension{Object: systemRedisImageStream},
-		runtime.RawExtension{Object: systemMemcachedImageStream},
-		runtime.RawExtension{Object: deploymentsServiceAccount},
+	objects := []common.KubernetesObject{
+		backendImageStream,
+		zyncImageStream,
+		apicastImageStream,
+		wildcardRouterImageStream,
+		systemImageStream,
+		postgreSQLImageStream,
+		backendRedisImageStream,
+		systemRedisImageStream,
+		systemMemcachedImageStream,
+		deploymentsServiceAccount,
 	}
 	return objects
 }

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -2,6 +2,8 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -9,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -69,14 +70,14 @@ func (apicast *Apicast) AssembleIntoTemplate(template *templatev1.Template, othe
 	apicast.addObjectsIntoTemplate(template)
 }
 
-func (apicast *Apicast) GetObjects() ([]runtime.RawExtension, error) {
+func (apicast *Apicast) GetObjects() ([]common.KubernetesObject, error) {
 	objects := apicast.buildObjects()
 	return objects, nil
 }
 
 func (apicast *Apicast) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := apicast.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (apicast *Apicast) PostProcess(template *templatev1.Template, otherComponents []Component) {
@@ -120,7 +121,7 @@ func (apicast *Apicast) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (apicast *Apicast) buildObjects() []runtime.RawExtension {
+func (apicast *Apicast) buildObjects() []common.KubernetesObject {
 	apicastStagingDeploymentConfig := apicast.buildApicastStagingDeploymentConfig()
 	apicastProductionDeploymentConfig := apicast.buildApicastProductionDeploymentConfig()
 	apicastStagingService := apicast.buildApicastStagingService()
@@ -129,14 +130,14 @@ func (apicast *Apicast) buildObjects() []runtime.RawExtension {
 	apicastProductionRoute := apicast.buildApicastProductionRoute()
 	apicastEnvConfigMap := apicast.buildApicastEnvConfigMap()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: apicastStagingDeploymentConfig},
-		runtime.RawExtension{Object: apicastProductionDeploymentConfig},
-		runtime.RawExtension{Object: apicastStagingService},
-		runtime.RawExtension{Object: apicastProductionService},
-		runtime.RawExtension{Object: apicastStagingRoute},
-		runtime.RawExtension{Object: apicastProductionRoute},
-		runtime.RawExtension{Object: apicastEnvConfigMap},
+	objects := []common.KubernetesObject{
+		apicastStagingDeploymentConfig,
+		apicastProductionDeploymentConfig,
+		apicastStagingService,
+		apicastProductionService,
+		apicastStagingRoute,
+		apicastProductionRoute,
+		apicastEnvConfigMap,
 	}
 	return objects
 }

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -2,6 +2,8 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -9,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -103,14 +104,14 @@ func (backend *Backend) AssembleIntoTemplate(template *templatev1.Template, othe
 	backend.addObjectsIntoTemplate(template)
 }
 
-func (backend *Backend) GetObjects() ([]runtime.RawExtension, error) {
+func (backend *Backend) GetObjects() ([]common.KubernetesObject, error) {
 	objects := backend.buildObjects()
 	return objects, nil
 }
 
 func (backend *Backend) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := backend.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (backend *Backend) PostProcess(template *templatev1.Template, otherComponents []Component) {
@@ -122,7 +123,7 @@ func (backend *Backend) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (backend *Backend) buildObjects() []runtime.RawExtension {
+func (backend *Backend) buildObjects() []common.KubernetesObject {
 	backendCronDeploymentConfig := backend.buildBackendCronDeploymentConfig()
 	backendListenerDeploymentConfig := backend.buildBackendListenerDeploymentConfig()
 	backendListenerService := backend.buildBackendListenerService()
@@ -134,16 +135,16 @@ func (backend *Backend) buildObjects() []runtime.RawExtension {
 	backendRedisSecrets := backend.buildBackendRedisSecrets()
 	backendListenerSecrets := backend.buildBackendListenerSecrets()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: backendCronDeploymentConfig},
-		runtime.RawExtension{Object: backendListenerDeploymentConfig},
-		runtime.RawExtension{Object: backendListenerService},
-		runtime.RawExtension{Object: backendListenerRoute},
-		runtime.RawExtension{Object: backendWorkerDeploymentConfig},
-		runtime.RawExtension{Object: backendEnvConfigMap},
-		runtime.RawExtension{Object: backendInternalApiCredsForSystem},
-		runtime.RawExtension{Object: backendRedisSecrets},
-		runtime.RawExtension{Object: backendListenerSecrets},
+	objects := []common.KubernetesObject{
+		backendCronDeploymentConfig,
+		backendListenerDeploymentConfig,
+		backendListenerService,
+		backendListenerRoute,
+		backendWorkerDeploymentConfig,
+		backendEnvConfigMap,
+		backendInternalApiCredsForSystem,
+		backendRedisSecrets,
+		backendListenerSecrets,
 	}
 	return objects
 }

--- a/pkg/3scale/amp/component/buildconfigs.go
+++ b/pkg/3scale/amp/component/buildconfigs.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type BuildConfigs struct {
@@ -55,21 +56,21 @@ func (bcs *BuildConfigs) AssembleIntoTemplate(template *templatev1.Template, oth
 	bcs.addObjectsIntoTemplate(template)
 }
 
-func (bcs *BuildConfigs) GetObjects() ([]runtime.RawExtension, error) {
+func (bcs *BuildConfigs) GetObjects() ([]common.KubernetesObject, error) {
 	objects := bcs.buildObjects()
 	return objects, nil
 }
 
 func (bcs *BuildConfigs) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := bcs.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (bcs *BuildConfigs) PostProcess(template *templatev1.Template, otherComponents []Component) {
 
 }
 
-func (bcs *BuildConfigs) buildObjects() []runtime.RawExtension {
+func (bcs *BuildConfigs) buildObjects() []common.KubernetesObject {
 	backendBuildConfig := bcs.buildBackendBuildConfig()
 	zyncBuildConfig := bcs.buildZyncBuildConfig()
 	apicastBuildConfig := bcs.buildApicastBuildConfig()
@@ -79,14 +80,14 @@ func (bcs *BuildConfigs) buildObjects() []runtime.RawExtension {
 	buildRubyCentosSevenImageStream := bcs.buildRubyCentosSevenImageStream()
 	buildOpenrestyCentosSevenImageStream := bcs.buildOpenrestyCentosSevenImageStream()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: backendBuildConfig},
-		runtime.RawExtension{Object: zyncBuildConfig},
-		runtime.RawExtension{Object: apicastBuildConfig},
-		runtime.RawExtension{Object: wildcardRouterBuildConfig},
-		runtime.RawExtension{Object: systemBuildConfig},
-		runtime.RawExtension{Object: buildRubyCentosSevenImageStream},
-		runtime.RawExtension{Object: buildOpenrestyCentosSevenImageStream},
+	objects := []common.KubernetesObject{
+		backendBuildConfig,
+		zyncBuildConfig,
+		apicastBuildConfig,
+		wildcardRouterBuildConfig,
+		systemBuildConfig,
+		buildRubyCentosSevenImageStream,
+		buildOpenrestyCentosSevenImageStream,
 	}
 	return objects
 }

--- a/pkg/3scale/amp/component/evaluation.go
+++ b/pkg/3scale/amp/component/evaluation.go
@@ -1,10 +1,11 @@
 package component
 
 import (
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	appsv1 "github.com/openshift/api/apps/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Evaluation struct {
@@ -25,16 +26,16 @@ func (evaluation *Evaluation) AssembleIntoTemplate(template *templatev1.Template
 }
 
 func (evaluation *Evaluation) PostProcess(template *templatev1.Template, otherComponents []Component) {
-	evaluation.removeContainersResourceRequestsAndLimits(template.Objects)
-}
-
-func (evaluation *Evaluation) PostProcessObjects(objects []runtime.RawExtension) {
+	objects := helper.UnwrapRawExtensions(template.Objects)
 	evaluation.removeContainersResourceRequestsAndLimits(objects)
 }
 
-func (evaluation *Evaluation) removeContainersResourceRequestsAndLimits(objects []runtime.RawExtension) {
-	for _, rawExtension := range objects {
-		obj := rawExtension.Object
+func (evaluation *Evaluation) PostProcessObjects(objects []common.KubernetesObject) {
+	evaluation.removeContainersResourceRequestsAndLimits(objects)
+}
+
+func (evaluation *Evaluation) removeContainersResourceRequestsAndLimits(objects []common.KubernetesObject) {
+	for _, obj := range objects {
 		dc, ok := obj.(*appsv1.DeploymentConfig)
 		if ok {
 			for containerIdx := range dc.Spec.Template.Spec.Containers {

--- a/pkg/3scale/amp/component/memcached.go
+++ b/pkg/3scale/amp/component/memcached.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -65,14 +66,14 @@ func (m *Memcached) AssembleIntoTemplate(template *templatev1.Template, otherCom
 	m.addObjectsIntoTemplate(template)
 }
 
-func (m *Memcached) GetObjects() ([]runtime.RawExtension, error) {
+func (m *Memcached) GetObjects() ([]common.KubernetesObject, error) {
 	objects := m.buildObjects()
 	return objects, nil
 }
 
 func (m *Memcached) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := m.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (m *Memcached) PostProcess(template *templatev1.Template, otherComponents []Component) {
@@ -107,11 +108,11 @@ func (m *Memcached) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (m *Memcached) buildObjects() []runtime.RawExtension {
+func (m *Memcached) buildObjects() []common.KubernetesObject {
 	systemMemcachedDeploymentConfig := m.buildSystemMemcachedDeploymentConfig()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: systemMemcachedDeploymentConfig},
+	objects := []common.KubernetesObject{
+		systemMemcachedDeploymentConfig,
 	}
 	return objects
 }

--- a/pkg/3scale/amp/component/mysql.go
+++ b/pkg/3scale/amp/component/mysql.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -75,14 +76,14 @@ func (mysql *Mysql) AssembleIntoTemplate(template *templatev1.Template, otherCom
 	mysql.addObjectsIntoTemplate(template)
 }
 
-func (mysql *Mysql) GetObjects() ([]runtime.RawExtension, error) {
+func (mysql *Mysql) GetObjects() ([]common.KubernetesObject, error) {
 	objects := mysql.buildObjects()
 	return objects, nil
 }
 
 func (mysql *Mysql) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := mysql.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (mysql *Mysql) PostProcess(template *templatev1.Template, otherComponents []Component) {
@@ -125,7 +126,7 @@ func (mysql *Mysql) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (mysql *Mysql) buildObjects() []runtime.RawExtension {
+func (mysql *Mysql) buildObjects() []common.KubernetesObject {
 	systemMysqlDeploymentConfig := mysql.buildSystemMysqlDeploymentConfig()
 	systemMysqlService := mysql.buildSystemMysqlService()
 	systemMysqlMainConfigConfigMap := mysql.buildSystemMysqlMainConfigConfigMap()
@@ -133,13 +134,13 @@ func (mysql *Mysql) buildObjects() []runtime.RawExtension {
 	systemMysqlPersistentVolumeClaim := mysql.buildSystemMysqlPersistentVolumeClaim()
 	systemDatabaseSecret := mysql.buildSystemDatabaseSecrets()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: systemMysqlDeploymentConfig},
-		runtime.RawExtension{Object: systemMysqlService},
-		runtime.RawExtension{Object: systemMysqlMainConfigConfigMap},
-		runtime.RawExtension{Object: systemMysqlExtraConfigConfigMap},
-		runtime.RawExtension{Object: systemMysqlPersistentVolumeClaim},
-		runtime.RawExtension{Object: systemDatabaseSecret},
+	objects := []common.KubernetesObject{
+		systemMysqlDeploymentConfig,
+		systemMysqlService,
+		systemMysqlMainConfigConfigMap,
+		systemMysqlExtraConfigConfigMap,
+		systemMysqlPersistentVolumeClaim,
+		systemDatabaseSecret,
 	}
 
 	return objects

--- a/pkg/3scale/amp/component/productized.go
+++ b/pkg/3scale/amp/component/productized.go
@@ -2,10 +2,10 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Productized struct {
@@ -71,7 +71,7 @@ func (productized *Productized) PostProcess(template *templatev1.Template, other
 	template.Objects = res
 }
 
-func (productized *Productized) PostProcessObjects(objects []runtime.RawExtension) []runtime.RawExtension {
+func (productized *Productized) PostProcessObjects(objects []common.KubernetesObject) []common.KubernetesObject {
 	res := objects
 	res = productized.updateAmpImagesURIs(res)
 
@@ -96,11 +96,10 @@ func (productized *Productized) updateAmpImagesParameters(template *templatev1.T
 	}
 }
 
-func (productized *Productized) updateAmpImagesURIs(objects []runtime.RawExtension) []runtime.RawExtension {
+func (productized *Productized) updateAmpImagesURIs(objects []common.KubernetesObject) []common.KubernetesObject {
 	res := objects
 
-	for _, rawExtension := range res {
-		obj := rawExtension.Object
+	for _, obj := range res {
 		is, ok := obj.(*imagev1.ImageStream)
 		if ok {
 			for tagIdx := range is.Spec.Tags {

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -2,6 +2,8 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"sort"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -10,7 +12,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -171,14 +172,14 @@ func (system *System) AssembleIntoTemplate(template *templatev1.Template, otherC
 	system.addObjectsIntoTemplate(template)
 }
 
-func (system *System) GetObjects() ([]runtime.RawExtension, error) {
+func (system *System) GetObjects() ([]common.KubernetesObject, error) {
 	objects := system.buildObjects()
 	return objects, nil
 }
 
 func (system *System) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := system.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (system *System) PostProcess(template *templatev1.Template, otherComponents []Component) {
@@ -291,7 +292,7 @@ func (system *System) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (system *System) buildObjects() []runtime.RawExtension {
+func (system *System) buildObjects() []common.KubernetesObject {
 	systemSharedStorage := system.buildSystemSharedPVC()
 	systemProviderService := system.buildSystemProviderService()
 	systemMasterService := system.buildSystemMasterService()
@@ -321,30 +322,30 @@ func (system *System) buildObjects() []runtime.RawExtension {
 	systemAppSecret := system.buildSystemAppSecrets()
 	systemMemcachedSecret := system.buildSystemMemcachedSecrets()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: systemSharedStorage},
-		runtime.RawExtension{Object: systemProviderService},
-		runtime.RawExtension{Object: systemMasterService},
-		runtime.RawExtension{Object: systemDeveloperService},
-		runtime.RawExtension{Object: systemProviderRoute},
-		runtime.RawExtension{Object: systemMasterRoute},
-		runtime.RawExtension{Object: systemDeveloperRoute},
-		runtime.RawExtension{Object: systemRedisService},
-		runtime.RawExtension{Object: systemSphinxService},
-		runtime.RawExtension{Object: systemMemcachedService},
-		runtime.RawExtension{Object: systemConfigMap},
-		runtime.RawExtension{Object: systemSmtpConfigMap},
-		runtime.RawExtension{Object: systemEnvironmentConfigMap},
-		runtime.RawExtension{Object: systemAppDeploymentConfig},
-		runtime.RawExtension{Object: systemSidekiqDeploymentConfig},
-		runtime.RawExtension{Object: systemSphinxDeploymentConfig},
-		runtime.RawExtension{Object: systemEventsHookSecret},
-		runtime.RawExtension{Object: systemRedisSecret},
-		runtime.RawExtension{Object: systemMasterApicastSecret},
-		runtime.RawExtension{Object: systemSeedSecret},
-		runtime.RawExtension{Object: systemRecaptchaSecret},
-		runtime.RawExtension{Object: systemAppSecret},
-		runtime.RawExtension{Object: systemMemcachedSecret},
+	objects := []common.KubernetesObject{
+		systemSharedStorage,
+		systemProviderService,
+		systemMasterService,
+		systemDeveloperService,
+		systemProviderRoute,
+		systemMasterRoute,
+		systemDeveloperRoute,
+		systemRedisService,
+		systemSphinxService,
+		systemMemcachedService,
+		systemConfigMap,
+		systemSmtpConfigMap,
+		systemEnvironmentConfigMap,
+		systemAppDeploymentConfig,
+		systemSidekiqDeploymentConfig,
+		systemSphinxDeploymentConfig,
+		systemEventsHookSecret,
+		systemRedisSecret,
+		systemMasterApicastSecret,
+		systemSeedSecret,
+		systemRecaptchaSecret,
+		systemAppSecret,
+		systemMemcachedSecret,
 	}
 	return objects
 }

--- a/pkg/3scale/amp/component/system_mysql_image.go
+++ b/pkg/3scale/amp/component/system_mysql_image.go
@@ -2,12 +2,13 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type SystemMySQLImage struct {
@@ -59,25 +60,25 @@ func (s *SystemMySQLImage) AssembleIntoTemplate(template *templatev1.Template, o
 	s.addObjectsIntoTemplate(template)
 }
 
-func (s *SystemMySQLImage) GetObjects() ([]runtime.RawExtension, error) {
+func (s *SystemMySQLImage) GetObjects() ([]common.KubernetesObject, error) {
 	objects := s.buildObjects()
 	return objects, nil
 }
 
 func (s *SystemMySQLImage) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := s.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (s *SystemMySQLImage) PostProcess(template *templatev1.Template, otherComponents []Component) {
 
 }
 
-func (s *SystemMySQLImage) buildObjects() []runtime.RawExtension {
+func (s *SystemMySQLImage) buildObjects() []common.KubernetesObject {
 	systemMySQLImageStream := s.buildSystemMySQLImageStream()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: systemMySQLImageStream},
+	objects := []common.KubernetesObject{
+		systemMySQLImageStream,
 	}
 
 	return objects

--- a/pkg/3scale/amp/component/system_postgresql.go
+++ b/pkg/3scale/amp/component/system_postgresql.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -77,14 +78,14 @@ func (p *SystemPostgreSQL) AssembleIntoTemplate(template *templatev1.Template, o
 	p.addObjectsIntoTemplate(template)
 }
 
-func (p *SystemPostgreSQL) GetObjects() ([]runtime.RawExtension, error) {
+func (p *SystemPostgreSQL) GetObjects() ([]common.KubernetesObject, error) {
 	objects := p.buildObjects()
 	return objects, nil
 }
 
 func (p *SystemPostgreSQL) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := p.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (p *SystemPostgreSQL) PostProcess(template *templatev1.Template, otherComponents []Component) {
@@ -119,17 +120,17 @@ func (p *SystemPostgreSQL) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (p *SystemPostgreSQL) buildObjects() []runtime.RawExtension {
+func (p *SystemPostgreSQL) buildObjects() []common.KubernetesObject {
 	postgreSQLDeploymentConfig := p.DeploymentConfig()
 	postgreSQLService := p.Service()
 	postgreSQLPersistentVolumeClaim := p.DataPersistentVolumeClaim()
 	systemDatabaseSecret := p.buildSystemDatabaseSecrets()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: postgreSQLDeploymentConfig},
-		runtime.RawExtension{Object: postgreSQLService},
-		runtime.RawExtension{Object: postgreSQLPersistentVolumeClaim},
-		runtime.RawExtension{Object: systemDatabaseSecret},
+	objects := []common.KubernetesObject{
+		postgreSQLDeploymentConfig,
+		postgreSQLService,
+		postgreSQLPersistentVolumeClaim,
+		systemDatabaseSecret,
 	}
 
 	return objects

--- a/pkg/3scale/amp/component/system_postgresql_image.go
+++ b/pkg/3scale/amp/component/system_postgresql_image.go
@@ -2,12 +2,13 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type SystemPostgreSQLImage struct {
@@ -59,25 +60,25 @@ func (s *SystemPostgreSQLImage) AssembleIntoTemplate(template *templatev1.Templa
 	s.addObjectsIntoTemplate(template)
 }
 
-func (s *SystemPostgreSQLImage) GetObjects() ([]runtime.RawExtension, error) {
+func (s *SystemPostgreSQLImage) GetObjects() ([]common.KubernetesObject, error) {
 	objects := s.buildObjects()
 	return objects, nil
 }
 
 func (s *SystemPostgreSQLImage) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := s.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (s *SystemPostgreSQLImage) PostProcess(template *templatev1.Template, otherComponents []Component) {
 
 }
 
-func (s *SystemPostgreSQLImage) buildObjects() []runtime.RawExtension {
+func (s *SystemPostgreSQLImage) buildObjects() []common.KubernetesObject {
 	systemPostgreSQLImageStream := s.buildSystemPostgreSQLImageStream()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: systemPostgreSQLImageStream},
+	objects := []common.KubernetesObject{
+		systemPostgreSQLImageStream,
 	}
 
 	return objects

--- a/pkg/3scale/amp/component/wildcardrouter.go
+++ b/pkg/3scale/amp/component/wildcardrouter.go
@@ -2,6 +2,8 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -9,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -70,10 +71,10 @@ func (wr *WildcardRouter) AssembleIntoTemplate(template *templatev1.Template, ot
 
 func (wr *WildcardRouter) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := wr.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
-func (wr *WildcardRouter) GetObjects() ([]runtime.RawExtension, error) {
+func (wr *WildcardRouter) GetObjects() ([]common.KubernetesObject, error) {
 	objects := wr.buildObjects()
 	return objects, nil
 }
@@ -99,15 +100,15 @@ func (wr *WildcardRouter) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (wr *WildcardRouter) buildObjects() []runtime.RawExtension {
+func (wr *WildcardRouter) buildObjects() []common.KubernetesObject {
 	wildcardRouterDeploymentConfig := wr.buildWildcardRouterDeploymentConfig()
 	wildcardRouterService := wr.buildWildcardRouterService()
 	wildcardRouterRoute := wr.buildWildcardRouterRoute()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: wildcardRouterDeploymentConfig},
-		runtime.RawExtension{Object: wildcardRouterService},
-		runtime.RawExtension{Object: wildcardRouterRoute},
+	objects := []common.KubernetesObject{
+		wildcardRouterDeploymentConfig,
+		wildcardRouterService,
+		wildcardRouterRoute,
 	}
 
 	return objects

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -77,19 +78,19 @@ func (zync *Zync) AssembleIntoTemplate(template *templatev1.Template, otherCompo
 	zync.addObjectsIntoTemplate(template)
 }
 
-func (zync *Zync) buildObjects() []runtime.RawExtension {
+func (zync *Zync) buildObjects() []common.KubernetesObject {
 	zyncDeploymentConfig := zync.buildZyncDeploymentConfig()
 	zyncDatabaseDeploymentConfig := zync.buildZyncDatabaseDeploymentConfig()
 	zyncService := zync.buildZyncService()
 	zyncDatabaseService := zync.buildZyncDatabaseService()
 	zyncSecret := zync.buildZyncSecret()
 
-	objects := []runtime.RawExtension{
-		runtime.RawExtension{Object: zyncDeploymentConfig},
-		runtime.RawExtension{Object: zyncDatabaseDeploymentConfig},
-		runtime.RawExtension{Object: zyncService},
-		runtime.RawExtension{Object: zyncDatabaseService},
-		runtime.RawExtension{Object: zyncSecret},
+	objects := []common.KubernetesObject{
+		zyncDeploymentConfig,
+		zyncDatabaseDeploymentConfig,
+		zyncService,
+		zyncDatabaseService,
+		zyncSecret,
 	}
 	return objects
 }
@@ -124,14 +125,14 @@ func (zync *Zync) buildParameters(template *templatev1.Template) {
 	template.Parameters = append(template.Parameters, parameters...)
 }
 
-func (zync *Zync) GetObjects() ([]runtime.RawExtension, error) {
+func (zync *Zync) GetObjects() ([]common.KubernetesObject, error) {
 	objects := zync.buildObjects()
 	return objects, nil
 }
 
 func (zync *Zync) addObjectsIntoTemplate(template *templatev1.Template) {
 	objects := zync.buildObjects()
-	template.Objects = append(template.Objects, objects...)
+	template.Objects = append(template.Objects, helper.WrapRawExtensions(objects)...)
 }
 
 func (zync *Zync) buildZyncSecret() *v1.Secret {

--- a/pkg/apis/common/kubernetes_types.go
+++ b/pkg/apis/common/kubernetes_types.go
@@ -1,0 +1,11 @@
+package common
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type KubernetesObject interface {
+	metav1.Object
+	runtime.Object
+}

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -3,6 +3,8 @@ package helper
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/apis/common"
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -61,4 +63,30 @@ func SetURLDefaultPort(rawurl string) string {
 
 	portNum := PortFromURL(urlObj)
 	return fmt.Sprintf("%s:%d", urlObj.String(), portNum)
+}
+
+func WrapRawExtensions(objects []common.KubernetesObject) []runtime.RawExtension {
+	var rawExtensions []runtime.RawExtension
+	for index := range objects {
+		rawExtensions = append(rawExtensions, WrapRawExtension(objects[index]))
+	}
+	return rawExtensions
+}
+
+func WrapRawExtension(object runtime.Object) runtime.RawExtension {
+	return runtime.RawExtension{Object: object}
+}
+
+func UnwrapRawExtensions(rawExts []runtime.RawExtension) []common.KubernetesObject {
+	var objects []common.KubernetesObject
+	for index := range rawExts {
+		rawObject := rawExts[index].Object
+		obj, ok := rawObject.(common.KubernetesObject)
+		if ok {
+			objects = append(objects, obj)
+		} else {
+			panic(fmt.Sprintf("Expected RawExtension to wrap a KubernetesObject, but instead found %v", rawObject))
+		}
+	}
+	return objects
 }


### PR DESCRIPTION
Avoid the use of RawExtension and unnecessary conversions of objects, other than for templates

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>