### PR TITLE
[build] update zync build

### DIFF
--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -37,11 +37,11 @@ objects:
         ref: "${GIT_REF}"
       type: Git
     strategy:
-      sourceStrategy:
+      dockerStrategy:
         from:
           kind: ImageStreamTag
           name: ruby-24-centos7:latest
-      type: Source
+      type: Docker
     triggers:
     - type: ConfigChange
 


### PR DESCRIPTION
zync uses Docker build now (https://github.com/3scale/zync/pull/197)

/cc @3scale/qe 