### PR TITLE
Remove operator-specific productVersion configurability

### DIFF
--- a/deploy/crds/apps_v1alpha1_apimanager_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_apimanager_crd.yaml
@@ -58,8 +58,6 @@ spec:
               type: object
             imageStreamTagImportInsecure:
               type: boolean
-            productVersion:
-              type: string
             resourceRequirementsEnabled:
               type: boolean
             system:
@@ -129,7 +127,6 @@ spec:
                   type: string
               type: object
           required:
-          - productVersion
           - wildcardDomain
           type: object
         status:

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -21,7 +21,6 @@ This resource is the resource used to deploy a 3scale API Management solution.
 
 | **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
 | --- | --- | --- | --- | --- | --- |
-| ProductVersion | `productVersion` | ProductVersion | Yes | N/A | 3Scale API Management solution release version. Currently the values "2.5" and "upstream" are supported. **Warning**, "upstream" uses 3scale unstable nightly images and it is intended only for development purposes and to be used in non-productive environments |
 | WildcardDomain | `wildcardDomain` | string | Yes | N/A | Root domain for the wildcard routes. Eg. example.com will generate 3scale-admin.example.com. |
 | AppLabel | `appLabel` | string | No | `3scale-api-management` | The value of the `app` label that will be applied to the API management solution
 | TenantName | `tenantName` | string | No | `3scale` | Tenant name under the root that Admin UI will be available with -admin suffix.

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -150,7 +150,6 @@ kind: APIManager
 metadata:
   name: example-apimanager
 spec:
-  productVersion: <productVersion>
   wildcardDomain: <wildcardDomain>
   wildcardPolicy: <None|Subdomain>
   resourceRequirementsEnabled: true

--- a/pkg/3scale/amp/component/productized.go
+++ b/pkg/3scale/amp/component/productized.go
@@ -3,9 +3,7 @@ package component
 import (
 	"fmt"
 
-	imagev1 "github.com/openshift/api/image/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Productized struct {
@@ -71,13 +69,6 @@ func (productized *Productized) PostProcess(template *templatev1.Template, other
 	template.Objects = res
 }
 
-func (productized *Productized) PostProcessObjects(objects []runtime.RawExtension) []runtime.RawExtension {
-	res := objects
-	res = productized.updateAmpImagesURIs(res)
-
-	return res
-}
-
 func (productized *Productized) updateAmpImagesParameters(template *templatev1.Template) {
 	for paramIdx := range template.Parameters {
 		param := &template.Parameters[paramIdx]
@@ -94,35 +85,4 @@ func (productized *Productized) updateAmpImagesParameters(template *templatev1.T
 			param.Value = "registry.access.redhat.com/3scale-amp25/zync"
 		}
 	}
-}
-
-func (productized *Productized) updateAmpImagesURIs(objects []runtime.RawExtension) []runtime.RawExtension {
-	res := objects
-
-	for _, rawExtension := range res {
-		obj := rawExtension.Object
-		is, ok := obj.(*imagev1.ImageStream)
-		if ok {
-			for tagIdx := range is.Spec.Tags {
-				// Only change the ImageStream tag name that has the ampRelease
-				// value. We do not modify the latest tag
-				if is.Spec.Tags[tagIdx].Name == productized.Options.ampRelease {
-					switch is.Name {
-					case "amp-apicast":
-						is.Spec.Tags[tagIdx].From.Name = productized.Options.apicastImage
-					case "amp-system":
-						is.Spec.Tags[tagIdx].From.Name = productized.Options.systemImage
-					case "amp-backend":
-						is.Spec.Tags[tagIdx].From.Name = productized.Options.backendImage
-					case "amp-wildcard-router":
-						is.Spec.Tags[tagIdx].From.Name = productized.Options.routerImage
-					case "amp-zync":
-						is.Spec.Tags[tagIdx].From.Name = productized.Options.zyncImage
-					}
-				}
-			}
-		}
-	}
-
-	return res
 }

--- a/pkg/3scale/amp/operator/ampimages.go
+++ b/pkg/3scale/amp/operator/ampimages.go
@@ -10,7 +10,7 @@ import (
 func (o *OperatorAmpImagesOptionsProvider) GetAmpImagesOptions() (*component.AmpImagesOptions, error) {
 	optProv := component.AmpImagesOptionsBuilder{}
 
-	productVersion := o.APIManagerSpec.ProductVersion
+	productVersion := product.CurrentProductVersion()
 	imageProvider, err := product.NewImageProvider(productVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/3scale/amp/operator/productized.go
+++ b/pkg/3scale/amp/operator/productized.go
@@ -10,7 +10,7 @@ import (
 func (o *OperatorProductizedOptionsProvider) GetProductizedOptions() (*component.ProductizedOptions, error) {
 	pob := component.ProductizedOptionsBuilder{}
 
-	productVersion := o.APIManagerSpec.ProductVersion
+	productVersion := product.CurrentProductVersion()
 	imageProvider, err := product.NewImageProvider(productVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -11,7 +12,7 @@ import (
 func (o *OperatorSystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, error) {
 	optProv := component.SystemOptionsBuilder{}
 
-	productVersion := o.APIManagerSpec.ProductVersion
+	productVersion := product.CurrentProductVersion()
 
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 	optProv.AmpRelease(string(productVersion))

--- a/pkg/3scale/amp/operator/system_mysql_image.go
+++ b/pkg/3scale/amp/operator/system_mysql_image.go
@@ -9,7 +9,7 @@ import (
 
 func (o *OperatorSystemMySQLImageOptionsProvider) GetSystemMySQLImageOptions() (*component.SystemMySQLImageOptions, error) {
 	optProv := component.SystemMySQLImageOptionsBuilder{}
-	productVersion := o.APIManagerSpec.ProductVersion
+	productVersion := product.CurrentProductVersion()
 	imageProvider, err := product.NewImageProvider(productVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/3scale/amp/operator/system_postgresql_image.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image.go
@@ -9,7 +9,7 @@ import (
 
 func (o *OperatorSystemPostgreSQLImageOptionsProvider) GetSystemPostgreSQLImageOptions() (*component.SystemPostgreSQLImageOptions, error) {
 	optProv := component.SystemPostgreSQLImageOptionsBuilder{}
-	productVersion := o.APIManagerSpec.ProductVersion
+	productVersion := product.CurrentProductVersion()
 	imageProvider, err := product.NewImageProvider(productVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/3scale/amp/product/images.go
+++ b/pkg/3scale/amp/product/images.go
@@ -37,3 +37,7 @@ type ImageProvider interface {
 func IsProductizedVersion(productVersion Version) bool {
 	return productVersion != ProductUpstream
 }
+
+func CurrentProductVersion() Version {
+	return ProductRelease_2_5
+}

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -5,8 +5,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -90,8 +88,7 @@ type APIManagerList struct {
 }
 
 type APIManagerCommonSpec struct {
-	ProductVersion product.Version `json:"productVersion"`
-	WildcardDomain string          `json:"wildcardDomain"`
+	WildcardDomain string `json:"wildcardDomain"`
 	// +optional
 	AppLabel *string `json:"appLabel,omitempty"`
 	// +optional

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -68,12 +68,6 @@ func schema_pkg_apis_apps_v1alpha1_APIManagerSpec(ref common.ReferenceCallback) 
 			SchemaProps: spec.SchemaProps{
 				Description: "APIManagerSpec defines the desired state of APIManager",
 				Properties: map[string]spec.Schema{
-					"productVersion": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"wildcardDomain": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -141,7 +135,7 @@ func schema_pkg_apis_apps_v1alpha1_APIManagerSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"productVersion", "wildcardDomain"},
+				Required: []string{"wildcardDomain"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/apimanager/apimanager_controller.go
+++ b/pkg/controller/apimanager/apimanager_controller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -318,16 +317,6 @@ func (r *ReconcileAPIManager) postProcessAPIManagerObjectsGroup(cr *appsv1alpha1
 	if !*cr.Spec.ResourceRequirementsEnabled {
 		e := component.Evaluation{}
 		e.PostProcessObjects(objects)
-	}
-
-	if product.IsProductizedVersion(cr.Spec.ProductVersion) {
-		optsProvider := operator.OperatorProductizedOptionsProvider{APIManagerSpec: &cr.Spec}
-		opts, err := optsProvider.GetProductizedOptions()
-		if err != nil {
-			return nil, err
-		}
-		p := component.Productized{Options: opts}
-		objects = p.PostProcessObjects(objects)
 	}
 
 	if cr.Spec.System.FileStorageSpec.S3 != nil {

--- a/test/e2e/apimanager_controller_test.go
+++ b/test/e2e/apimanager_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/apis"
 	appsgroup "github.com/3scale/3scale-operator/pkg/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
@@ -89,12 +88,31 @@ func productizedUnconstrainedDeploymentSubtest(t *testing.T) {
 	t.Log("operator Deployment is ready")
 
 	enableResourceRequirements := false
+	apicastNightlyImage := "quay.io/3scale/apicast:nightly"
+	backendNightlyImage := "quay.io/3scale/apisonator:nightly"
+	systemNightlyImage := "quay.io/3scale/porta:nightly"
+	wildcardRouterNightlyImage := "quay.io/3scale/wildcard-router:nightly"
+	zyncNightlyImage := "quay.io/3scale/zync:nightly"
 	apimanager := &appsv1alpha1.APIManager{
 		Spec: appsv1alpha1.APIManagerSpec{
 			APIManagerCommonSpec: appsv1alpha1.APIManagerCommonSpec{
-				ProductVersion:              product.ProductUpstream,
 				WildcardDomain:              "test1.127.0.0.1.nip.io",
 				ResourceRequirementsEnabled: &enableResourceRequirements,
+			},
+			Apicast: &appsv1alpha1.ApicastSpec{
+				Image: &apicastNightlyImage,
+			},
+			Backend: &appsv1alpha1.BackendSpec{
+				Image: &backendNightlyImage,
+			},
+			System: &appsv1alpha1.SystemSpec{
+				Image: &systemNightlyImage,
+			},
+			WildcardRouter: &appsv1alpha1.WildcardRouterSpec{
+				Image: &wildcardRouterNightlyImage,
+			},
+			Zync: &appsv1alpha1.ZyncSpec{
+				Image: &zyncNightlyImage,
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/full_test.go
+++ b/test/e2e/full_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
-
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -82,13 +80,32 @@ func TestFullHappyPath(t *testing.T) {
 	enableResourceRequirements := false
 	wildcardPolicy := string(routev1.WildcardPolicySubdomain)
 	apiManagerWildcardDomain := fmt.Sprintf("test1.%s.nip.io", clusterHost)
+	apicastNightlyImage := "quay.io/3scale/apicast:nightly"
+	backendNightlyImage := "quay.io/3scale/apisonator:nightly"
+	systemNightlyImage := "quay.io/3scale/porta:nightly"
+	wildcardRouterNightlyImage := "quay.io/3scale/wildcard-router:nightly"
+	zyncNightlyImage := "quay.io/3scale/zync:nightly"
 	apimanager := &appsv1alpha1.APIManager{
 		Spec: appsv1alpha1.APIManagerSpec{
 			APIManagerCommonSpec: appsv1alpha1.APIManagerCommonSpec{
-				ProductVersion:              product.ProductUpstream,
 				WildcardDomain:              apiManagerWildcardDomain,
 				WildcardPolicy:              &wildcardPolicy,
 				ResourceRequirementsEnabled: &enableResourceRequirements,
+			},
+			Apicast: &appsv1alpha1.ApicastSpec{
+				Image: &apicastNightlyImage,
+			},
+			Backend: &appsv1alpha1.BackendSpec{
+				Image: &backendNightlyImage,
+			},
+			System: &appsv1alpha1.SystemSpec{
+				Image: &systemNightlyImage,
+			},
+			WildcardRouter: &appsv1alpha1.WildcardRouterSpec{
+				Image: &wildcardRouterNightlyImage,
+			},
+			Zync: &appsv1alpha1.ZyncSpec{
+				Image: &zyncNightlyImage,
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This commit removes the ability to configure the productVersion
through the APIManager CR field.
The idea is that every new release of 3scale (excluding bugfix ones)
we'll provide a new operator version. In that regard this is the same
behaviour than before. When we were to release a new 3scale version
new code was needed to be added for the new URLs so this does not change
previous behaviour in that sense.
We'll stop providing upstream nightly configurability. Instead, we'll
provide an example CR deployment with the set of nightly images(by overriding
the image fields) in case someone needs it and we won't commit to support
that at all because of the inherently unstability of those images
and the purpose of them.
We'll probably also have an upstream version of the operator but in another
branch and with stable tags and not nightly ones.
Removing this configurability that for the moment does not provide any value
allows us to not commit to maintain it. If in the future we deem necessary to
provide configurable ProductVersion through the CR we can readd it.
The upgrades of operator versions will be limited between the new version
and the older one which is the same as we have now with templates.