### PR TITLE
Fix operator not being able to create service for Prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ IMAGE ?= quay.io/3scale/3scale-operator
 SOURCE_VERSION ?= master
 VERSION ?= v0.0.1
 NAMESPACE ?= operator-test
+OPERATOR_NAME ?= threescale-operator
 
 ## build: Build operator
 build:
@@ -37,7 +38,7 @@ tag:
 
 ## local: push operator docker image to remote repo
 local:
-	operator-sdk up local --namespace $(NAMESPACE)
+	OPERATOR_NAME=$(OPERATOR_NAME) operator-sdk up local --namespace $(NAMESPACE)
 
 ## e2e-setup: create OCP project for the operator
 e2e-setup:
@@ -45,7 +46,7 @@ e2e-setup:
 
 ## e2e-local-run: running operator locally with go run instead of as an image in the cluster
 e2e-local-run:
-	operator-sdk test local ./test/e2e --up-local --namespace $(NAMESPACE) --go-test-flags '-v -timeout 0'
+	OPERATOR_NAME=$(OPERATOR_NAME) operator-sdk test local ./test/e2e --up-local --namespace $(NAMESPACE) --go-test-flags '-v -timeout 0'
 
 ## e2e-run: operator local test
 e2e-run:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: 3scale-operator
+      name: threescale-operator
   template:
     metadata:
       labels:
-        name: 3scale-operator
+        name: threescale-operator
     spec:
       serviceAccountName: 3scale-operator
       containers:
@@ -29,4 +29,4 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "3scale-operator"
+              value: "threescale-operator"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -32,6 +32,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - 3scale-operator
+  verbs:
+  - "update"
+- apiGroups:
   - image.openshift.io
   resources:
   - imagestreams


### PR DESCRIPTION
Operators created through operator-sdk by default expose Prometheus metrics through a Service that is created when deploying it (not 3scale but the operator itself).

The operator wasn't able to create the Service that is created for exposing the operator Prometheus metrics. That was because you cannot have a Service starting with a number (an error was shown). In the logs it could be seen:

```
{"level":"info","ts":1559141154.4200816,"logger":"cmd","msg":"failed to create or get service for metrics: Service \"3scale-operator\" is invalid: metadata.name: Invalid value: \"3scale-operator\": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"}
```

The OPERATOR_NAME environment variable of the operator's Deployment
element seems to at least control the Service name (although I'm not 100% sure it won't be used for another things, the exact purpose of that envvar is not thoroughly documented, it simply says 'the name of the current operator').

The "3scale-operator" OPERATOR_NAME value has been changed to
"threescale-operator" to make it compatible.

The Pod 'name' label (not confuse with the pod name which is different) it seems also used by the Service to select the pods of the Deployment. We have also changed the pod label "name" to
"threescale-operator" because otherwise the Service did not select
any Pod because the selector did not match.

Also an additional permission was missing to perform garbage collection
of the operator.

I think having some elements as threescale-operator (the Service, the "name" label values for the Pod of the Deployment and Service selectors) and others as 3scale-operator (the Deployment name, Pod names...) is kind of confusing. Also having the Pod name with the name 3scale-operator and the label as threescale-operator is also kind of confusing.

An alternative would be to rename everything to "threescale-operator". But this would mean we would also have some things named 3scale-operator like this github repository URL, references to this URL in our code and the container registry URLs so I'm not totally convinced on doing the opposite way either.
This would also imply changing the official name of the operator that the clients would read and see when deploying to "threescale-operator"

Also I guess this will have implications on what the clients see and use in the OLM panel/configuration (changing or not changing everything)

What do you think? cc @eguzki @mikz 