### PR TITLE
[WIP] Change system services ports

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1452,8 +1452,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1471,8 +1471,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1490,8 +1490,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3191,8 +3191,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3345,7 +3344,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3386,7 +3385,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3412,8 +3411,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3916,7 +3915,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1469,8 +1469,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1488,8 +1488,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1507,8 +1507,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3094,8 +3094,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3251,7 +3250,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3292,7 +3291,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3318,8 +3317,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3822,7 +3821,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -917,8 +917,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -936,8 +936,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -955,8 +955,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -2547,8 +2547,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -2710,7 +2709,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -2751,7 +2750,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -2777,8 +2776,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3305,7 +3304,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1461,8 +1461,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1480,8 +1480,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1499,8 +1499,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3110,8 +3110,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3273,7 +3272,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3314,7 +3313,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3340,8 +3339,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3868,7 +3867,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1493,8 +1493,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1512,8 +1512,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1531,8 +1531,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3256,8 +3256,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3416,7 +3415,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3457,7 +3456,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3483,8 +3482,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4011,7 +4010,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1510,8 +1510,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1529,8 +1529,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1548,8 +1548,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3159,8 +3159,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3322,7 +3321,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3363,7 +3362,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3389,8 +3388,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3917,7 +3916,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -1452,8 +1452,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1471,8 +1471,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1490,8 +1490,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3191,8 +3191,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3345,7 +3344,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3386,7 +3385,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3412,8 +3411,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3916,7 +3915,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -1469,8 +1469,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1488,8 +1488,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1507,8 +1507,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3094,8 +3094,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3251,7 +3250,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3292,7 +3291,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3318,8 +3317,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3822,7 +3821,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -917,8 +917,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -936,8 +936,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -955,8 +955,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -2547,8 +2547,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -2710,7 +2709,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -2751,7 +2750,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -2777,8 +2776,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3305,7 +3304,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
@@ -1461,8 +1461,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1480,8 +1480,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1499,8 +1499,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3110,8 +3110,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3273,7 +3272,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3314,7 +3313,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3340,8 +3339,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3868,7 +3867,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -1493,8 +1493,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1512,8 +1512,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1531,8 +1531,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3256,8 +3256,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3416,7 +3415,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3457,7 +3456,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3483,8 +3482,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -4011,7 +4010,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -1510,8 +1510,8 @@ objects:
     name: system-provider
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: provider
+      port: 80
       protocol: TCP
       targetPort: provider
     selector:
@@ -1529,8 +1529,8 @@ objects:
     name: system-master
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: master
+      port: 80
       protocol: TCP
       targetPort: master
     selector:
@@ -1548,8 +1548,8 @@ objects:
     name: system-developer
   spec:
     ports:
-    - name: http
-      port: 3000
+    - name: developer
+      port: 80
       protocol: TCP
       targetPort: developer
     selector:
@@ -3159,8 +3159,7 @@ objects:
           - bash
           - -c
           - bundle exec sh -c "until rake boot:redis && curl --output /dev/null --silent
-            --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS;
-            done"
+            --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done"
           env:
           - name: SLEEP_SECONDS
             value: "1"
@@ -3322,7 +3321,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS
@@ -3363,7 +3362,7 @@ objects:
     name: system-events-hook
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
-    URL: http://system-master:3000/master/events/import
+    URL: http://system-master/master/events/import
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3389,8 +3388,8 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
-    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
+    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master
+    PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3917,7 +3916,7 @@ objects:
         - command:
           - sh
           - -c
-          - until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status);
+          - until $(curl --output /dev/null --silent --fail --head http://system-master/status);
             do sleep $SLEEP_SECONDS; done
           env:
           - name: SLEEP_SECONDS

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -453,7 +453,7 @@ func (apicast *Apicast) buildApicastProductionDeploymentConfig() *appsv1.Deploym
 						v1.Container{
 							Name:    "system-master-svc",
 							Image:   "amp-apicast:latest",
-							Command: []string{"sh", "-c", "until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status); do sleep $SLEEP_SECONDS; done"},
+							Command: []string{"sh", "-c", "until $(curl --output /dev/null --silent --fail --head http://system-master/status); do sleep $SLEEP_SECONDS; done"},
 							Env: []v1.EnvVar{
 								v1.EnvVar{
 									Name:  "SLEEP_SECONDS",

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -1137,7 +1137,7 @@ func (system *System) buildSystemProviderService() *v1.Service {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
-					Name:       "http",
+					Name:       "provider",
 					Protocol:   v1.ProtocolTCP,
 					Port:       3000,
 					TargetPort: intstr.FromString("provider"),
@@ -1165,7 +1165,7 @@ func (system *System) buildSystemMasterService() *v1.Service {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
-					Name:       "http",
+					Name:       "master",
 					Protocol:   v1.ProtocolTCP,
 					Port:       3000,
 					TargetPort: intstr.FromString("master"),
@@ -1193,7 +1193,7 @@ func (system *System) buildSystemDeveloperService() *v1.Service {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				v1.ServicePort{
-					Name:       "http",
+					Name:       "developer",
 					Protocol:   v1.ProtocolTCP,
 					Port:       3000,
 					TargetPort: intstr.FromString("developer"),

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -1043,7 +1043,7 @@ func (system *System) buildSystemSidekiqDeploymentConfig() *appsv1.DeploymentCon
 							Command: []string{
 								"bash",
 								"-c",
-								"bundle exec sh -c \"until rake boot:redis && curl --output /dev/null --silent --fail --head http://system-master:3000/status; do sleep $SLEEP_SECONDS; done\"",
+								"bundle exec sh -c \"until rake boot:redis && curl --output /dev/null --silent --fail --head http://system-master/status; do sleep $SLEEP_SECONDS; done\"",
 							},
 							Env: []v1.EnvVar{
 								envVarFromValue("SLEEP_SECONDS", "1"),
@@ -1139,7 +1139,7 @@ func (system *System) buildSystemProviderService() *v1.Service {
 				v1.ServicePort{
 					Name:       "provider",
 					Protocol:   v1.ProtocolTCP,
-					Port:       3000,
+					Port:       80,
 					TargetPort: intstr.FromString("provider"),
 				},
 			},
@@ -1167,7 +1167,7 @@ func (system *System) buildSystemMasterService() *v1.Service {
 				v1.ServicePort{
 					Name:       "master",
 					Protocol:   v1.ProtocolTCP,
-					Port:       3000,
+					Port:       80,
 					TargetPort: intstr.FromString("master"),
 				},
 			},
@@ -1195,7 +1195,7 @@ func (system *System) buildSystemDeveloperService() *v1.Service {
 				v1.ServicePort{
 					Name:       "developer",
 					Protocol:   v1.ProtocolTCP,
-					Port:       3000,
+					Port:       80,
 					TargetPort: intstr.FromString("developer"),
 				},
 			},
@@ -1522,7 +1522,7 @@ func (system *System) buildSystemSphinxDeploymentConfig() *appsv1.DeploymentConf
 						v1.Container{
 							Name:    "system-master-svc",
 							Image:   "amp-system:latest",
-							Command: []string{"sh", "-c", "until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status); do sleep $SLEEP_SECONDS; done"},
+							Command: []string{"sh", "-c", "until $(curl --output /dev/null --silent --fail --head http://system-master/status); do sleep $SLEEP_SECONDS; done"},
 							Env: []v1.EnvVar{
 								envVarFromValue("SLEEP_SECONDS", "1"),
 							},

--- a/pkg/3scale/amp/component/system_options_builder.go
+++ b/pkg/3scale/amp/component/system_options_builder.go
@@ -177,14 +177,14 @@ func (s *SystemOptionsBuilder) setRequiredOptions() error {
 
 func (s *SystemOptionsBuilder) setNonRequiredOptions() {
 	defaultMemcachedServers := "system-memcache:11211"
-	defaultEventHooksURL := "http://system-master:3000/master/events/import"
+	defaultEventHooksURL := "http://system-master/master/events/import"
 	defaultRedisURL := "redis://system-redis:6379/1"
 	defaultMessageBusRedisURL := ""
 	defaultRedisNamespace := ""
 	defaultMessageBusRedisNamespace := ""
 
-	defaultApicastSystemMasterProxyConfigEndpoint := "http://" + s.options.apicastAccessToken + "@system-master:3000/master/api/proxy/configs"
-	defaultApicastSystemMasterBaseURL := "http://" + s.options.apicastAccessToken + "@system-master:3000"
+	defaultApicastSystemMasterProxyConfigEndpoint := "http://" + s.options.apicastAccessToken + "@system-master/master/api/proxy/configs"
+	defaultApicastSystemMasterBaseURL := "http://" + s.options.apicastAccessToken + "@system-master"
 	defaultAdminEmail := ""
 
 	if s.options.memcachedServers == nil {


### PR DESCRIPTION
As requested by @mikz, the system-{developer,master,provider} OpenShift Services user-facing port have been changed to port 80 in all of them.
The name of the user-facing port in the service has been replaced from "http" to the same name as the Port name exposed in the corresponding containers.

This change will need to be part of the migration procedure too.