### PR TITLE
Remove configurable fileuploadstorage in operator and templates

### DIFF
--- a/deploy/crds/apps_v1alpha1_apimanager_cr_s3.yaml
+++ b/deploy/crds/apps_v1alpha1_apimanager_cr_s3.yaml
@@ -12,4 +12,3 @@ spec:
         awsBucket: <bucket-name>
         awsCredentialsSecret:
           name: <credentials-secret-name>
-        fileUploadStorage: <file-upload-storage-name>

--- a/deploy/crds/apps_v1alpha1_apimanager_crd.yaml
+++ b/deploy/crds/apps_v1alpha1_apimanager_crd.yaml
@@ -86,13 +86,10 @@ spec:
                           type: object
                         awsRegion:
                           type: string
-                        fileUploadStorage:
-                          type: string
                       required:
                       - awsBucket
                       - awsRegion
                       - awsCredentialsSecret
-                      - fileUploadStorage
                       type: object
                     persistentVolumeClaim:
                       description: Union type. Only one of the fields can be set.

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -81,7 +81,6 @@ Only one of the fields can be chosen. If no field is specified then PVC is used.
 | AWSBucket | `awsBucket` | string | Yes | N/A | AWS Bucket name of the S3 bucket to be used as System's FileStorage for assets |
 | AWSRegion | `awsRegion` | string | Yes | N/A | AWS Region of the S3 bucket to be used as Sytem's FileStorage for assets |
 | AWSCredentials | `awsCredentialsSecret` | [corev1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core) | Yes | N/A | Local object reference to the secret to be used where the AWS credentials are stored. See [LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core) on how to specify the local object reference to the secret |
-| FileUploadStorage | `fileUploadStorage` | string | Yes | N/A | Define Assets Storage name |
 
 The secret name specified in the `awsCredentialsSecret` field must be
 pre-created by the user before creating the APIManager custom resource.

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1663,7 +1663,7 @@ objects:
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     AWS_BUCKET: ${AWS_BUCKET}
     AWS_REGION: ${AWS_REGION}
-    FILE_UPLOAD_STORAGE: ${FILE_UPLOAD_STORAGE}
+    FILE_UPLOAD_STORAGE: s3
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
     RAILS_ENV: production
@@ -4191,8 +4191,6 @@ parameters:
   name: APICAST_REGISTRY_URL
   required: true
   value: http://apicast-staging:8090/policies
-- description: Define Assets Storage
-  name: FILE_UPLOAD_STORAGE
 - description: AWS Access Key ID to use in S3 Storage for assets.
   name: AWS_ACCESS_KEY_ID
 - description: AWS Access Key Secret to use in S3 Storage for assets.

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1704,7 +1704,7 @@ objects:
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     AWS_BUCKET: ${AWS_BUCKET}
     AWS_REGION: ${AWS_REGION}
-    FILE_UPLOAD_STORAGE: ${FILE_UPLOAD_STORAGE}
+    FILE_UPLOAD_STORAGE: s3
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
     RAILS_ENV: production
@@ -4286,8 +4286,6 @@ parameters:
   name: APICAST_REGISTRY_URL
   required: true
   value: http://apicast-staging:8090/policies
-- description: Define Assets Storage
-  name: FILE_UPLOAD_STORAGE
 - description: AWS Access Key ID to use in S3 Storage for assets.
   name: AWS_ACCESS_KEY_ID
 - description: AWS Access Key Secret to use in S3 Storage for assets.

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -1663,7 +1663,7 @@ objects:
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     AWS_BUCKET: ${AWS_BUCKET}
     AWS_REGION: ${AWS_REGION}
-    FILE_UPLOAD_STORAGE: ${FILE_UPLOAD_STORAGE}
+    FILE_UPLOAD_STORAGE: s3
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
     RAILS_ENV: production
@@ -4191,8 +4191,6 @@ parameters:
   name: APICAST_REGISTRY_URL
   required: true
   value: http://apicast-staging:8090/policies
-- description: Define Assets Storage
-  name: FILE_UPLOAD_STORAGE
 - description: AWS Access Key ID to use in S3 Storage for assets.
   name: AWS_ACCESS_KEY_ID
 - description: AWS Access Key Secret to use in S3 Storage for assets.

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -1704,7 +1704,7 @@ objects:
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     AWS_BUCKET: ${AWS_BUCKET}
     AWS_REGION: ${AWS_REGION}
-    FILE_UPLOAD_STORAGE: ${FILE_UPLOAD_STORAGE}
+    FILE_UPLOAD_STORAGE: s3
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
     RAILS_ENV: production
@@ -4286,8 +4286,6 @@ parameters:
   name: APICAST_REGISTRY_URL
   required: true
   value: http://apicast-staging:8090/policies
-- description: Define Assets Storage
-  name: FILE_UPLOAD_STORAGE
 - description: AWS Access Key ID to use in S3 Storage for assets.
   name: AWS_ACCESS_KEY_ID
 - description: AWS Access Key Secret to use in S3 Storage for assets.

--- a/pkg/3scale/amp/component/s3.go
+++ b/pkg/3scale/amp/component/s3.go
@@ -242,11 +242,6 @@ func (s3 *S3) PostProcessObjects(objects []runtime.RawExtension) []runtime.RawEx
 func (s3 *S3) buildParameters(template *templatev1.Template) {
 	parameters := []templatev1.Parameter{
 		templatev1.Parameter{
-			Name:        "FILE_UPLOAD_STORAGE",
-			Description: "Define Assets Storage",
-			Required:    false,
-		},
-		templatev1.Parameter{
 			Name:        "AWS_ACCESS_KEY_ID",
 			Description: "AWS Access Key ID to use in S3 Storage for assets.",
 			Required:    false,

--- a/pkg/3scale/amp/component/s3.go
+++ b/pkg/3scale/amp/component/s3.go
@@ -30,7 +30,6 @@ type s3RequiredOptions struct {
 	awsSecretAccessKey   string
 	awsRegion            string
 	awsBucket            string
-	fileUploadStorage    string
 	awsCredentialsSecret string
 }
 
@@ -56,7 +55,6 @@ func (o *CLIS3OptionsProvider) GetS3Options() (*S3Options, error) {
 	sob.AwsSecretAccessKey("${AWS_SECRET_ACCESS_KEY}")
 	sob.AwsRegion("${AWS_REGION}")
 	sob.AwsBucket("${AWS_BUCKET}")
-	sob.FileUploadStorage("${FILE_UPLOAD_STORAGE}")
 	sob.AWSCredentialsSecret("aws-auth")
 	res, err := sob.Build()
 	if err != nil {
@@ -197,7 +195,7 @@ func (s3 *S3) addS3PostprocessOptionsToSystemEnvironmentCfgMap(objects []runtime
 		}
 	}
 
-	systemEnvCfgMap.Data["FILE_UPLOAD_STORAGE"] = s3.Options.fileUploadStorage
+	systemEnvCfgMap.Data["FILE_UPLOAD_STORAGE"] = "s3"
 	systemEnvCfgMap.Data["AWS_BUCKET"] = s3.Options.awsBucket
 	systemEnvCfgMap.Data["AWS_REGION"] = s3.Options.awsRegion
 }

--- a/pkg/3scale/amp/component/s3_options_builder.go
+++ b/pkg/3scale/amp/component/s3_options_builder.go
@@ -22,10 +22,6 @@ func (s3 *S3OptionsBuilder) AwsBucket(awsBucket string) {
 	s3.options.awsBucket = awsBucket
 }
 
-func (s3 *S3OptionsBuilder) FileUploadStorage(fileUploadStorage string) {
-	s3.options.fileUploadStorage = fileUploadStorage
-}
-
 func (s3 *S3OptionsBuilder) AWSCredentialsSecret(awsCredentials string) {
 	s3.options.awsCredentialsSecret = awsCredentials
 }
@@ -54,9 +50,6 @@ func (s3 *S3OptionsBuilder) setRequiredOptions() error {
 	}
 	if s3.options.awsBucket == "" {
 		return fmt.Errorf("no AWS bucket has been provided")
-	}
-	if s3.options.fileUploadStorage == "" {
-		return fmt.Errorf("no file upload storage has been provided")
 	}
 	if s3.options.awsCredentialsSecret == "" {
 		return fmt.Errorf("no AWS credentials secret has been provided")

--- a/pkg/3scale/amp/operator/s3.go
+++ b/pkg/3scale/amp/operator/s3.go
@@ -11,7 +11,6 @@ func (o *OperatorS3OptionsProvider) GetS3Options() (*component.S3Options, error)
 	SystemS3Spec := *o.APIManagerSpec.System.FileStorageSpec.S3
 	sob.AwsRegion(SystemS3Spec.AWSRegion)
 	sob.AwsBucket(SystemS3Spec.AWSBucket)
-	sob.FileUploadStorage(SystemS3Spec.FileUploadStorage)
 
 	err := o.setSecretBasedOptions(&sob)
 	if err != nil {

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -158,10 +158,9 @@ type SystemPVCSpec struct {
 }
 
 type SystemS3Spec struct {
-	AWSBucket         string                  `json:"awsBucket"`
-	AWSRegion         string                  `json:"awsRegion"`
-	AWSCredentials    v1.LocalObjectReference `json:"awsCredentialsSecret"`
-	FileUploadStorage string                  `json:"fileUploadStorage"`
+	AWSBucket      string                  `json:"awsBucket"`
+	AWSRegion      string                  `json:"awsRegion"`
+	AWSCredentials v1.LocalObjectReference `json:"awsCredentialsSecret"`
 }
 
 type SystemDatabaseSpec struct {


### PR DESCRIPTION
When in the S3 context (both in templates and operator), the only value that makes sense to have is "s3" as the FILE_UPLOAD_STORAGE environment variable needed by system so we remove the configurability of it.

Part of the PR was already implemented by @matskiv in the https://github.com/3scale/3scale-operator/pull/147 but when a forked branch is created and then a PR submitted CircleCI tests are not currently working due to some credentials permissions/data. We will fix this as soon as we can and apply this solution now.

I merged the commit submitted by @matskiv in the other PR maintaining the original commit and author and I've submitted new commits that contain the parts that were still pending to be implemented.