### PR TITLE
Support for float32 / Plan crd unit testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/3scale/3scale-porta-go-client v0.0.3
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect
-	github.com/RHsyseng/operator-utils v0.0.0-20190511234839-4edf3fc41521
+	github.com/RHsyseng/operator-utils v0.0.0-20190616014937-557e58cee892
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
 	github.com/coreos/prometheus-operator v0.26.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVk
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RHsyseng/operator-utils v0.0.0-20190511234839-4edf3fc41521 h1:93rF6AnS2yY87WNRjhmjqZ53GOgozZFXJTnUKEpYc24=
-github.com/RHsyseng/operator-utils v0.0.0-20190511234839-4edf3fc41521/go.mod h1:E+hCtYz+9UsXfAGnRjX2LGuaa5gSGNKHCVTmGZR79vY=
+github.com/RHsyseng/operator-utils v0.0.0-20190616014937-557e58cee892 h1:lMsgHbR2Ro4EGH0G0g/dvaehCSZgNoYGSlYbRx0ocCc=
+github.com/RHsyseng/operator-utils v0.0.0-20190616014937-557e58cee892/go.mod h1:E+hCtYz+9UsXfAGnRjX2LGuaa5gSGNKHCVTmGZR79vY=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/test/crds/crd_validation_test.go
+++ b/test/crds/crd_validation_test.go
@@ -62,8 +62,7 @@ func TestCompleteCRD(t *testing.T) {
 		"capabilities_v1alpha1_limit_crd.yaml":       &capabilities.Limit{},
 		"capabilities_v1alpha1_mappingrule_crd.yaml": &capabilities.MappingRule{},
 		"capabilities_v1alpha1_metric_crd.yaml":      &capabilities.Metric{},
-		// double types not supported by validator. plan crd test disabled.
-		//"capabilities_v1alpha1_plan_crd.yaml":   &capabilities.Plan{},
+		"capabilities_v1alpha1_plan_crd.yaml":   &capabilities.Plan{},
 		"capabilities_v1alpha1_tenant_crd.yaml": &capabilities.Tenant{},
 	}
 	for crd, obj := range crdStructMap {


### PR DESCRIPTION
Updated to newer version of operator-utils with float32 type support
Plan CRD test uncommented / added back

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>