### PR TITLE
Fix zync que role permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -58,10 +58,20 @@ rules:
   - route.openshift.io
   resources:
   - routes
-  - routes/custom-host
-  - routes/status
   verbs:
   - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/status
+  verbs:
+  - get
 - apiGroups:
   - apps.openshift.io
   resources:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3584,13 +3584,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3490,13 +3490,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2949,13 +2949,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3512,13 +3512,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3655,13 +3655,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3561,13 +3561,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -3584,13 +3584,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -3490,13 +3490,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -2949,13 +2949,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
@@ -3512,13 +3512,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -3655,13 +3655,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -3561,13 +3561,23 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    - routes/status
-    - routes/custom-host
     verbs:
     - get
     - list
     - create
     - delete
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/status
+    verbs:
+    - get
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -243,14 +243,30 @@ func (zync *Zync) buildZyncQueRole() *rbacv1.Role {
 				APIGroups: []string{"route.openshift.io"},
 				Resources: []string{
 					"routes",
-					"routes/status",
-					"routes/custom-host",
 				},
 				Verbs: []string{
 					"get",
 					"list",
 					"create",
 					"delete",
+				},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"route.openshift.io"},
+				Resources: []string{
+					"routes/status",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"route.openshift.io"},
+				Resources: []string{
+					"routes/custom-host",
+				},
+				Verbs: []string{
+					"create",
 				},
 			},
 		},


### PR DESCRIPTION
routes/status and routes/custom-host subresource do not have the same verbs than routes.

Applying them caused errors when deploying 3scale with non-privileged users.

This PR modifies the role permissions to specific verbs for routes/status (get verb only)
The same happened with routes/custom-host and has been changed too. routes/custom-host has been left with only the 'create' permission as originally requested.
