### PR TITLE
Rename postgresql imagestream

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -164,12 +164,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3914,7 +3914,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3820,7 +3820,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3297,7 +3297,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3860,7 +3860,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -164,12 +164,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -4003,7 +4003,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3909,7 +3909,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -164,12 +164,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3914,7 +3914,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3820,7 +3820,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3297,7 +3297,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3860,7 +3860,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -164,12 +164,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -4003,7 +4003,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -163,12 +163,12 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
-      openshift.io/display-name: Zync database
+      openshift.io/display-name: Zync database PostgreSQL
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
       threescale_component: system
-    name: postgresql
+    name: zync-database-postgresql
   spec:
     lookupPolicy:
       local: false
@@ -3909,7 +3909,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:latest
+          name: zync-database-postgresql:latest
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -22,17 +22,17 @@ type AmpImages struct {
 }
 
 type AmpImagesOptions struct {
-	appLabel             string
-	ampRelease           string
-	apicastImage         string
-	backendImage         string
-	systemImage          string
-	zyncImage            string
-	postgreSQLImage      string
-	backendRedisImage    string
-	systemRedisImage     string
-	systemMemcachedImage string
-	insecureImportPolicy bool
+	appLabel                    string
+	ampRelease                  string
+	apicastImage                string
+	backendImage                string
+	systemImage                 string
+	zyncImage                   string
+	ZyncDatabasePostgreSQLImage string
+	backendRedisImage           string
+	systemRedisImage            string
+	systemMemcachedImage        string
+	insecureImportPolicy        bool
 }
 
 func NewAmpImages(options []string) *AmpImages {
@@ -56,7 +56,7 @@ func (o *CLIAmpImagesOptionsProvider) GetAmpImagesOptions() (*AmpImagesOptions, 
 	aob.BackendImage("${AMP_BACKEND_IMAGE}")
 	aob.SystemImage("${AMP_SYSTEM_IMAGE}")
 	aob.ZyncImage("${AMP_ZYNC_IMAGE}")
-	aob.PostgreSQLImage("${ZYNC_DATABASE_IMAGE}")
+	aob.ZyncDatabasePostgreSQLImage("${ZYNC_DATABASE_IMAGE}")
 	aob.BackendRedisImage("${REDIS_IMAGE}")
 	aob.SystemRedisImage("${REDIS_IMAGE}")
 	aob.SystemMemcachedImage("${MEMCACHED_IMAGE}")
@@ -99,7 +99,7 @@ func (ampImages *AmpImages) buildObjects() []common.KubernetesObject {
 	zyncImageStream := ampImages.buildAmpZyncImageStream()
 	apicastImageStream := ampImages.buildApicastImageStream()
 	systemImageStream := ampImages.buildAmpSystemImageStream()
-	postgreSQLImageStream := ampImages.buildPostgreSQLImageStream()
+	zyncDatabasePostgreSQL := ampImages.buildZyncDatabasePostgreSQLImageStream()
 	backendRedisImageStream := ampImages.buildBackendRedisImageStream()
 	systemRedisImageStream := ampImages.buildSystemRedisImageStream()
 	systemMemcachedImageStream := ampImages.buildSystemMemcachedImageStream()
@@ -111,7 +111,7 @@ func (ampImages *AmpImages) buildObjects() []common.KubernetesObject {
 		zyncImageStream,
 		apicastImageStream,
 		systemImageStream,
-		postgreSQLImageStream,
+		zyncDatabasePostgreSQL,
 		backendRedisImageStream,
 		systemRedisImageStream,
 		systemMemcachedImageStream,
@@ -298,16 +298,16 @@ func (ampImages *AmpImages) buildAmpSystemImageStream() *imagev1.ImageStream {
 	}
 }
 
-func (ampImages *AmpImages) buildPostgreSQLImageStream() *imagev1.ImageStream {
+func (ampImages *AmpImages) buildZyncDatabasePostgreSQLImageStream() *imagev1.ImageStream {
 	return &imagev1.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "postgresql",
+			Name: "zync-database-postgresql",
 			Labels: map[string]string{
 				"app":                  ampImages.Options.appLabel,
 				"threescale_component": "system",
 			},
 			Annotations: map[string]string{
-				"openshift.io/display-name": "Zync database",
+				"openshift.io/display-name": "Zync database PostgreSQL",
 			},
 		},
 		TypeMeta: metav1.TypeMeta{APIVersion: "image.openshift.io/v1", Kind: "ImageStream"},
@@ -330,7 +330,7 @@ func (ampImages *AmpImages) buildPostgreSQLImageStream() *imagev1.ImageStream {
 					},
 					From: &v1.ObjectReference{
 						Kind: "DockerImage",
-						Name: ampImages.Options.postgreSQLImage,
+						Name: ampImages.Options.ZyncDatabasePostgreSQLImage,
 					},
 					ImportPolicy: imagev1.TagImportPolicy{
 						Insecure: insecureImportPolicy,

--- a/pkg/3scale/amp/component/ampimages_options_builder.go
+++ b/pkg/3scale/amp/component/ampimages_options_builder.go
@@ -30,8 +30,8 @@ func (ampImages *AmpImagesOptionsBuilder) ZyncImage(zyncImage string) {
 	ampImages.options.zyncImage = zyncImage
 }
 
-func (ampImages *AmpImagesOptionsBuilder) PostgreSQLImage(postgreSQLImage string) {
-	ampImages.options.postgreSQLImage = postgreSQLImage
+func (ampImages *AmpImagesOptionsBuilder) ZyncDatabasePostgreSQLImage(zyncDatabaseImage string) {
+	ampImages.options.ZyncDatabasePostgreSQLImage = zyncDatabaseImage
 }
 
 func (ampImages *AmpImagesOptionsBuilder) BackendRedisImage(image string) {
@@ -69,8 +69,8 @@ func (ampImages *AmpImagesOptionsBuilder) Build() (*AmpImagesOptions, error) {
 	if ampImages.options.zyncImage == "" {
 		return nil, fmt.Errorf("no Zync image has been provided")
 	}
-	if ampImages.options.postgreSQLImage == "" {
-		return nil, fmt.Errorf("no PostgreSQL image has been provided")
+	if ampImages.options.ZyncDatabasePostgreSQLImage == "" {
+		return nil, fmt.Errorf("no Zync database PostgreSQL image has been provided")
 	}
 	if ampImages.options.backendRedisImage == "" {
 		return nil, fmt.Errorf("no Backend Redis image has been provided")

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -566,7 +566,7 @@ func (zync *Zync) buildZyncDatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "postgresql:latest",
+							Name: "zync-database-postgresql:latest",
 						},
 					},
 				},

--- a/pkg/3scale/amp/operator/ampimages.go
+++ b/pkg/3scale/amp/operator/ampimages.go
@@ -43,9 +43,9 @@ func (o *OperatorAmpImagesOptionsProvider) GetAmpImagesOptions() (*component.Amp
 	}
 
 	if o.APIManagerSpec.Zync != nil && o.APIManagerSpec.Zync.PostgreSQLImage != nil {
-		optProv.PostgreSQLImage(*o.APIManagerSpec.Zync.PostgreSQLImage)
+		optProv.ZyncDatabasePostgreSQLImage(*o.APIManagerSpec.Zync.PostgreSQLImage)
 	} else {
-		optProv.PostgreSQLImage(imageProvider.GetZyncPostgreSQLImage())
+		optProv.ZyncDatabasePostgreSQLImage(imageProvider.GetZyncPostgreSQLImage())
 	}
 
 	if o.APIManagerSpec.Backend != nil && o.APIManagerSpec.Backend.RedisImage != nil {


### PR DESCRIPTION
With the introduction of the PostgreSQL database to be used by System, we created a new ImageStream named system-postgresql. We did not reuse the 'postgresql' ImageStream because we want to manage triggered updates on the ImageStream independently.
Now the situation when deploying 3scale with system using postgresql would leave us with two imagestreams:
"postgresql"
"system-postgresql"

This PR changes that and renames the "postgresql" ImageStream to "zync-database-postgresql"

So we'll have two imagestreams:
"zync-database-postgresql"
"system-postgresql"

That will be able to be managed independently