### PR TITLE
Minor APIManager fixes

### DIFF
--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -200,9 +200,13 @@ func init() {
 func (apimanager *APIManager) SetDefaults() (bool, error) {
 	var err error
 	changed := false
-	changed = apimanager.setAPIManagerCommonSpecDefaults()
-	changed = apimanager.setApicastSpecDefaults()
-	changed, err = apimanager.setSystemSpecDefaults()
+	commonChanged := apimanager.setAPIManagerCommonSpecDefaults()
+	apicastChanged := apimanager.setApicastSpecDefaults()
+	systemChanged, err := apimanager.setSystemSpecDefaults()
+
+	if commonChanged || apicastChanged || systemChanged {
+		changed = true
+	}
 
 	return changed, err
 }

--- a/pkg/controller/apimanager/apimanager_controller.go
+++ b/pkg/controller/apimanager/apimanager_controller.go
@@ -123,7 +123,8 @@ func (r *ReconcileAPIManager) Reconcile(request reconcile.Request) (reconcile.Re
 	changed, err := instance.SetDefaults() // TODO check where to put this
 	if err != nil {
 		// Error setting defaults - Stop reconciliation
-		return reconcile.Result{}, nil
+		r.reqLogger.Error(err, "Error setting defaults. Requeuing request...")
+		return reconcile.Result{}, err
 	}
 	if changed {
 		r.reqLogger.Info("Updating defaults for APIManager resource")

--- a/pkg/controller/apimanager/apimanager_controller.go
+++ b/pkg/controller/apimanager/apimanager_controller.go
@@ -3,8 +3,9 @@ package apimanager
 import (
 	"context"
 	"fmt"
-	"github.com/3scale/3scale-operator/pkg/common"
 	"reflect"
+
+	"github.com/3scale/3scale-operator/pkg/common"
 
 	"github.com/go-logr/logr"
 
@@ -113,7 +114,7 @@ func (r *ReconcileAPIManager) Reconcile(request reconcile.Request) (reconcile.Re
 			r.reqLogger.Info("APIManager Resource not found. Ignoring since object must have been deleted")
 			return reconcile.Result{}, nil
 		}
-		r.reqLogger.Error(err, "APIManager Resource cannot be created. Requeuing request...")
+		r.reqLogger.Error(err, "APIManager Resource cannot be retrieved. Requeuing request...")
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
This PR applies some fixes and improvements derivated from the review that @bmozaffa performed on the APIManager reconciliation code. Those fixes are:

* Fixing SetDefaults APIManage method to correctly keep track of the changes detection
* Retrying reconciliation when Defaults initialization fails for some reason
* Updating some logs to better describe the actions happening

Thank you @bmozaffa 