### PR TITLE
Community images 2.6

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1376,13 +1376,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources: {}
         serviceAccountName: amp
@@ -4282,7 +4279,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4294,24 +4291,24 @@ parameters:
   value: 3scale
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: quay.io/3scale/apisonator:nightly
+  value: quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: quay.io/3scale/zync:nightly
+  value: quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1
 - name: AMP_APICAST_IMAGE
   required: true
-  value: quay.io/3scale/apicast:nightly
+  value: quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: quay.io/3scale/porta:nightly
+  value: quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4320,11 +4317,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1375,13 +1375,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources: {}
         serviceAccountName: amp
@@ -4179,7 +4176,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4194,24 +4191,24 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: quay.io/3scale/apisonator:nightly
+  value: quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: quay.io/3scale/zync:nightly
+  value: quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1
 - name: AMP_APICAST_IMAGE
   required: true
-  value: quay.io/3scale/apicast:nightly
+  value: quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: quay.io/3scale/porta:nightly
+  value: quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4220,11 +4217,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -817,13 +817,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -3679,7 +3676,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3694,24 +3691,24 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: quay.io/3scale/apisonator:nightly
+  value: quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: quay.io/3scale/zync:nightly
+  value: quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1
 - name: AMP_APICAST_IMAGE
   required: true
-  value: quay.io/3scale/apicast:nightly
+  value: quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: quay.io/3scale/porta:nightly
+  value: quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1361,13 +1361,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -4231,7 +4228,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4246,24 +4243,24 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: quay.io/3scale/apisonator:nightly
+  value: quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: quay.io/3scale/zync:nightly
+  value: quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1
 - name: AMP_APICAST_IMAGE
   required: true
-  value: quay.io/3scale/apicast:nightly
+  value: quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: quay.io/3scale/porta:nightly
+  value: quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4272,11 +4269,11 @@ parameters:
 - description: System PostgreSQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for PostgreSQL user that will be used for accessing the database.
   displayName: System PostgreSQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1411,13 +1411,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -4383,7 +4380,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4395,24 +4392,24 @@ parameters:
   value: 3scale
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: quay.io/3scale/apisonator:nightly
+  value: quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: quay.io/3scale/zync:nightly
+  value: quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1
 - name: AMP_APICAST_IMAGE
   required: true
-  value: quay.io/3scale/apicast:nightly
+  value: quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: quay.io/3scale/porta:nightly
+  value: quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4421,11 +4418,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1410,13 +1410,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -4280,7 +4277,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4295,24 +4292,24 @@ parameters:
   value: "null"
 - name: AMP_BACKEND_IMAGE
   required: true
-  value: quay.io/3scale/apisonator:nightly
+  value: quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1
 - name: AMP_ZYNC_IMAGE
   required: true
-  value: quay.io/3scale/zync:nightly
+  value: quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1
 - name: AMP_APICAST_IMAGE
   required: true
-  value: quay.io/3scale/apicast:nightly
+  value: quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1
 - name: AMP_SYSTEM_IMAGE
   required: true
-  value: quay.io/3scale/porta:nightly
+  value: quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4321,11 +4318,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval-s3.yml
@@ -1376,13 +1376,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources: {}
         serviceAccountName: amp
@@ -4282,7 +4279,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4307,11 +4304,11 @@ parameters:
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4320,11 +4317,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-eval.yml
@@ -1375,13 +1375,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources: {}
         serviceAccountName: amp
@@ -4179,7 +4176,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4207,11 +4204,11 @@ parameters:
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4220,11 +4217,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-ha.yml
@@ -817,13 +817,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -3679,7 +3676,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -3707,11 +3704,11 @@ parameters:
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-postgresql.yml
@@ -1361,13 +1361,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -4231,7 +4228,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4259,11 +4256,11 @@ parameters:
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4272,11 +4269,11 @@ parameters:
 - description: System PostgreSQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for PostgreSQL user that will be used for accessing the database.
   displayName: System PostgreSQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp-s3.yml
@@ -1411,13 +1411,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -4383,7 +4380,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4408,11 +4405,11 @@ parameters:
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4421,11 +4418,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml
@@ -1410,13 +1410,10 @@ objects:
           - containerPort: 11211
             protocol: TCP
           readinessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - echo version | nc $HOSTNAME 11211 | grep VERSION
             initialDelaySeconds: 10
             periodSeconds: 30
+            tcpSocket:
+              port: 11211
             timeoutSeconds: 5
           resources:
             limits:
@@ -4280,7 +4277,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: 2.5.0
+  value: 2.6.0
 - description: Used for object app labels
   name: APP_LABEL
   required: true
@@ -4308,11 +4305,11 @@ parameters:
 - description: Zync's PostgreSQL image to use
   name: ZYNC_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+  value: centos/postgresql-10-centos7
 - description: Memcached image to use
   name: MEMCACHED_IMAGE
   required: true
-  value: registry.access.redhat.com/3scale-amp20/memcached
+  value: memcached:1.5
 - description: Set to true if the server may bypass certificate verification or connect
     directly over HTTP during image import.
   name: IMAGESTREAM_TAG_IMPORT_INSECURE
@@ -4321,11 +4318,11 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7
+  value: centos/mysql-57-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: registry.access.redhat.com/rhscl/redis-32-rhel7:3.2
+  value: centos/redis-32-centos7
 - description: Username for System's MySQL user that will be used for accessing the
     database.
   displayName: System MySQL User

--- a/pkg/3scale/amp/cmd/template.go
+++ b/pkg/3scale/amp/cmd/template.go
@@ -258,7 +258,7 @@ func buildTemplateParameters() []templatev1.Parameter {
 			Name:        "AMP_RELEASE",
 			Description: "AMP release tag.",
 			Required:    true,
-			Value:       "2.5.0",
+			Value:       "2.6.0",
 		},
 		templatev1.Parameter{
 			Name:        "APP_LABEL",

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -489,33 +489,33 @@ func (ampImages *AmpImages) buildParameters(template *templatev1.Template) {
 		templatev1.Parameter{
 			Name:     "AMP_BACKEND_IMAGE",
 			Required: true,
-			Value:    "quay.io/3scale/apisonator:nightly",
+			Value:    "quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1",
 		},
 		templatev1.Parameter{
 			Name:     "AMP_ZYNC_IMAGE",
-			Value:    "quay.io/3scale/zync:nightly",
+			Value:    "quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1",
 			Required: true,
 		},
 		templatev1.Parameter{
 			Name:     "AMP_APICAST_IMAGE",
-			Value:    "quay.io/3scale/apicast:nightly",
+			Value:    "quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1",
 			Required: true,
 		},
 		templatev1.Parameter{
 			Name:     "AMP_SYSTEM_IMAGE",
-			Value:    "quay.io/3scale/porta:nightly",
+			Value:    "quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1",
 			Required: true,
 		},
 		templatev1.Parameter{
 			Name:        "ZYNC_DATABASE_IMAGE",
 			Description: "Zync's PostgreSQL image to use",
-			Value:       "registry.access.redhat.com/rhscl/postgresql-10-rhel7",
+			Value:       "centos/postgresql-10-centos7",
 			Required:    true,
 		},
 		templatev1.Parameter{
 			Name:        "MEMCACHED_IMAGE",
 			Description: "Memcached image to use",
-			Value:       "registry.access.redhat.com/3scale-amp20/memcached",
+			Value:       "memcached:1.5",
 			Required:    true,
 		},
 		templatev1.Parameter{

--- a/pkg/3scale/amp/component/memcached.go
+++ b/pkg/3scale/amp/component/memcached.go
@@ -201,9 +201,10 @@ func (m *Memcached) buildSystemMemcachedDeploymentConfig() *appsv1.DeploymentCon
 								FailureThreshold:    0,
 							},
 							ReadinessProbe: &v1.Probe{
-								Handler: v1.Handler{
-									Exec: &v1.ExecAction{
-										Command: []string{"sh", "-c", "echo version | nc $HOSTNAME 11211 | grep VERSION"}},
+								Handler: v1.Handler{TCPSocket: &v1.TCPSocketAction{
+									Port: intstr.IntOrString{
+										Type:   intstr.Type(intstr.Int),
+										IntVal: 11211}},
 								},
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -97,7 +97,7 @@ func (redis *Redis) buildParameters(template *templatev1.Template) {
 			Name:        "REDIS_IMAGE",
 			Description: "Redis image to use",
 			Required:    true,
-			Value:       "registry.access.redhat.com/rhscl/redis-32-rhel7:3.2",
+			Value:       "centos/redis-32-centos7",
 		},
 	}
 	template.Parameters = append(template.Parameters, parameters...)

--- a/pkg/3scale/amp/component/system_mysql_image.go
+++ b/pkg/3scale/amp/component/system_mysql_image.go
@@ -132,7 +132,7 @@ func (s *SystemMySQLImage) buildParameters(template *templatev1.Template) {
 		templatev1.Parameter{
 			Name:        "SYSTEM_DATABASE_IMAGE",
 			Description: "System MySQL image to use",
-			Value:       "registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7",
+			Value:       "centos/mysql-57-centos7",
 			Required:    true,
 		},
 	}

--- a/pkg/3scale/amp/component/system_postgresql_image.go
+++ b/pkg/3scale/amp/component/system_postgresql_image.go
@@ -133,7 +133,7 @@ func (s *SystemPostgreSQLImage) buildParameters(template *templatev1.Template) {
 			Name:        "SYSTEM_DATABASE_IMAGE",
 			Description: "System PostgreSQL image to use",
 			Required:    true,
-			Value:       "registry.access.redhat.com/rhscl/postgresql-10-rhel7",
+			Value:       "centos/postgresql-10-centos7",
 		},
 	}
 	template.Parameters = append(template.Parameters, parameters...)

--- a/pkg/3scale/amp/manual-templates/amp/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/amp/apicast.yml
@@ -120,7 +120,7 @@ objects:
 parameters:
 - name: AMP_RELEASE
   description: "AMP release tag."
-  value: "2.5.0"
+  value: "2.6.0"
   required: true
 - name: AMP_APICAST_IMAGE
   value: "quay.io/3scale/amp:apicast-master"

--- a/pkg/3scale/amp/product/images.go
+++ b/pkg/3scale/amp/product/images.go
@@ -7,10 +7,13 @@ type Version string
 const (
 	ProductUpstream    Version = "upstream"
 	ProductRelease_2_5 Version = "2.5"
+	ProductRelease_2_6 Version = "2.6"
 )
 
 func NewImageProvider(productVersion Version) (ImageProvider, error) {
 	switch productVersion {
+	case ProductRelease_2_6:
+		return &release_2_6{}, nil
 	case ProductRelease_2_5:
 		return &release_2_5{}, nil
 	case ProductUpstream:
@@ -38,5 +41,5 @@ func IsProductizedVersion(productVersion Version) bool {
 }
 
 func CurrentProductVersion() Version {
-	return ProductRelease_2_5
+	return ProductRelease_2_6
 }

--- a/pkg/3scale/amp/product/release_2_6.go
+++ b/pkg/3scale/amp/product/release_2_6.go
@@ -1,0 +1,43 @@
+package product
+
+type release_2_6 struct{}
+
+func (p *release_2_6) GetApicastImage() string {
+	return "quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1"
+}
+
+func (p *release_2_6) GetBackendImage() string {
+	return "quay.io/3scale/3scale26:apisonator-3scale-2.6.0-ER1"
+}
+
+func (p *release_2_6) GetBackendRedisImage() string {
+	return "centos/redis-32-centos7"
+}
+
+func (p *release_2_6) GetSystemImage() string {
+	return "quay.io/3scale/3scale26:porta-3scale-2.6.0-ER1"
+}
+
+func (p *release_2_6) GetSystemRedisImage() string {
+	return "centos/redis-32-centos7"
+}
+
+func (p *release_2_6) GetSystemMySQLImage() string {
+	return "centos/mysql-57-centos7"
+}
+
+func (p *release_2_6) GetSystemPostgreSQLImage() string {
+	return "centos/postgresql-10-centos7"
+}
+
+func (p *release_2_6) GetSystemMemcachedImage() string {
+	return "memcached:1.5"
+}
+
+func (p *release_2_6) GetZyncImage() string {
+	return "quay.io/3scale/3scale26:zync-3scale-2.6.0-ER1"
+}
+
+func (p *release_2_6) GetZyncPostgreSQLImage() string {
+	return "centos/postgresql-10-centos7"
+}


### PR DESCRIPTION
Changes:

* Updated AMP images to community based images with `3scale-2.6.0-ER1` tag
* Bumped AMP Release to 2.6
* Updated Database images to community based `centos` images
* Updated Memcached image to dockerhub image
* Patch memcached `readiness probe` to support replaced image
* Re-generated templates