### PR TITLE
[3] 2.6 stable backport template factory refactor

### DIFF
--- a/pkg/3scale/amp/cmd/template.go
+++ b/pkg/3scale/amp/cmd/template.go
@@ -58,9 +58,8 @@ to quickly create a Cobra application.`
 // is the one needed by the Cobra library
 func runCommand(cmd *cobra.Command, args []string) {
 	templateName := args[0]
-	componentOptions := []string{}
 
-	template := amptemplate.NewTemplate(templateName, componentOptions)
+	template := amptemplate.NewTemplate(templateName)
 
 	serializedResult, err := runtime.DefaultUnstructuredConverter.ToUnstructured(template)
 	if err != nil {

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -9,7 +9,7 @@ import (
 type Apicast struct {
 }
 
-func NewApicastAdapter(options []string) Adapter {
+func NewApicastAdapter() Adapter {
 	return NewAppenderAdapter(&Apicast{})
 }
 

--- a/pkg/3scale/amp/template/adapters/backend.go
+++ b/pkg/3scale/amp/template/adapters/backend.go
@@ -9,7 +9,7 @@ import (
 type Backend struct {
 }
 
-func NewBackendAdapter(options []string) Adapter {
+func NewBackendAdapter() Adapter {
 	return NewAppenderAdapter(&Backend{})
 }
 

--- a/pkg/3scale/amp/template/adapters/eval.go
+++ b/pkg/3scale/amp/template/adapters/eval.go
@@ -9,7 +9,7 @@ import (
 type EvalAdapter struct {
 }
 
-func NewEvalAdapter(options []string) Adapter {
+func NewEvalAdapter() Adapter {
 	return &EvalAdapter{}
 }
 

--- a/pkg/3scale/amp/template/adapters/ha.go
+++ b/pkg/3scale/amp/template/adapters/ha.go
@@ -9,7 +9,7 @@ import (
 type HAAdapter struct {
 }
 
-func NewHAAdapter(options []string) Adapter {
+func NewHAAdapter() Adapter {
 	return &HAAdapter{}
 }
 

--- a/pkg/3scale/amp/template/adapters/images.go
+++ b/pkg/3scale/amp/template/adapters/images.go
@@ -10,7 +10,7 @@ import (
 type ImagesAdapter struct {
 }
 
-func NewImagesAdapter(options []string) Adapter {
+func NewImagesAdapter() Adapter {
 	return NewAppenderAdapter(&ImagesAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/memcached.go
+++ b/pkg/3scale/amp/template/adapters/memcached.go
@@ -9,7 +9,7 @@ import (
 type MemcachedAdapter struct {
 }
 
-func NewMemcachedAdapter(options []string) Adapter {
+func NewMemcachedAdapter() Adapter {
 	return NewAppenderAdapter(&MemcachedAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -10,7 +10,7 @@ import (
 type RedisAdapter struct {
 }
 
-func NewRedisAdapter(options []string) Adapter {
+func NewRedisAdapter() Adapter {
 	return NewAppenderAdapter(&RedisAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/s3.go
+++ b/pkg/3scale/amp/template/adapters/s3.go
@@ -9,7 +9,7 @@ import (
 type S3 struct {
 }
 
-func NewS3Adapter(options []string) Adapter {
+func NewS3Adapter() Adapter {
 	return &S3{}
 }
 

--- a/pkg/3scale/amp/template/adapters/system-mysql-image.go
+++ b/pkg/3scale/amp/template/adapters/system-mysql-image.go
@@ -10,7 +10,7 @@ import (
 type SystemMysqlImageAdapter struct {
 }
 
-func NewSystemMysqlImageAdapter(options []string) Adapter {
+func NewSystemMysqlImageAdapter() Adapter {
 	return NewAppenderAdapter(&SystemMysqlImageAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/system-mysql.go
+++ b/pkg/3scale/amp/template/adapters/system-mysql.go
@@ -9,7 +9,7 @@ import (
 type SystemMysqlAdapter struct {
 }
 
-func NewMysqlAdapter(options []string) Adapter {
+func NewMysqlAdapter() Adapter {
 	return NewAppenderAdapter(&SystemMysqlAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/system-postgresql-image.go
+++ b/pkg/3scale/amp/template/adapters/system-postgresql-image.go
@@ -10,7 +10,7 @@ import (
 type SystemPostgreSQLImageAdapter struct {
 }
 
-func NewSystemPostgreSQLImageAdapter(options []string) Adapter {
+func NewSystemPostgreSQLImageAdapter() Adapter {
 	return NewAppenderAdapter(&SystemPostgreSQLImageAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/system-postgresql.go
+++ b/pkg/3scale/amp/template/adapters/system-postgresql.go
@@ -9,7 +9,7 @@ import (
 type SystemPostgreSQLAdapter struct {
 }
 
-func NewSystemPostgreSQLAdapter(options []string) Adapter {
+func NewSystemPostgreSQLAdapter() Adapter {
 	return NewAppenderAdapter(&SystemPostgreSQLAdapter{})
 }
 

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -9,7 +9,7 @@ import (
 type System struct {
 }
 
-func NewSystemAdapter(options []string) Adapter {
+func NewSystemAdapter() Adapter {
 	return NewAppenderAdapter(&System{})
 }
 

--- a/pkg/3scale/amp/template/adapters/zync.go
+++ b/pkg/3scale/amp/template/adapters/zync.go
@@ -9,7 +9,7 @@ import (
 type Zync struct {
 }
 
-func NewZyncAdapter(options []string) Adapter {
+func NewZyncAdapter() Adapter {
 	return NewAppenderAdapter(&Zync{})
 }
 

--- a/pkg/3scale/amp/template/amp.go
+++ b/pkg/3scale/amp/template/amp.go
@@ -5,6 +5,11 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 )
 
+func init() {
+	// TemplateFactories is a list of template factories
+	TemplateFactories = append(TemplateFactories, NewAmpTemplateFactory)
+}
+
 type AmpTemplateAdapter struct {
 }
 
@@ -13,18 +18,28 @@ func (a *AmpTemplateAdapter) Adapt(template *templatev1.Template) {
 	template.Message = "Login on https://${TENANT_NAME}-admin.${WILDCARD_DOMAIN} as ${ADMIN_USERNAME}/${ADMIN_PASSWORD}"
 }
 
-// AmpTemplateAdapters defines the list of adapters to build the template
-func AmpTemplateAdapters(options []string) []adapters.Adapter {
+type AmpTemplateFactory struct {
+}
+
+func (f *AmpTemplateFactory) Adapters() []adapters.Adapter {
 	return []adapters.Adapter{
-		adapters.NewImagesAdapter(options),
-		adapters.NewSystemMysqlImageAdapter(options),
-		adapters.NewRedisAdapter(options),
-		adapters.NewBackendAdapter(options),
-		adapters.NewMysqlAdapter(options),
-		adapters.NewMemcachedAdapter(options),
-		adapters.NewSystemAdapter(options),
-		adapters.NewZyncAdapter(options),
-		adapters.NewApicastAdapter(options),
+		adapters.NewImagesAdapter(),
+		adapters.NewSystemMysqlImageAdapter(),
+		adapters.NewRedisAdapter(),
+		adapters.NewBackendAdapter(),
+		adapters.NewMysqlAdapter(),
+		adapters.NewMemcachedAdapter(),
+		adapters.NewSystemAdapter(),
+		adapters.NewZyncAdapter(),
+		adapters.NewApicastAdapter(),
 		&AmpTemplateAdapter{},
 	}
+}
+
+func (f *AmpTemplateFactory) Type() TemplateType {
+	return "amp-template"
+}
+
+func NewAmpTemplateFactory() TemplateFactory {
+	return &AmpTemplateFactory{}
 }

--- a/pkg/3scale/amp/template/ampeval.go
+++ b/pkg/3scale/amp/template/ampeval.go
@@ -2,9 +2,23 @@ package template
 
 import "github.com/3scale/3scale-operator/pkg/3scale/amp/template/adapters"
 
-// AmpEvalTemplateAdapters defines the list of adapters to build the template
-func AmpEvalTemplateAdapters(options []string) []adapters.Adapter {
-	adapterList := AmpTemplateAdapters(options)
+func init() {
+	// TemplateFactories is a list of template factories
+	TemplateFactories = append(TemplateFactories, NewAmpEvalTemplateFactory)
+}
 
-	return append(adapterList, adapters.NewEvalAdapter(options))
+type AmpEvalTemplateFactory struct {
+}
+
+func (f *AmpEvalTemplateFactory) Adapters() []adapters.Adapter {
+	ampFactory := NewAmpTemplateFactory()
+	return append(ampFactory.Adapters(), adapters.NewEvalAdapter())
+}
+
+func (f *AmpEvalTemplateFactory) Type() TemplateType {
+	return "amp-eval-template"
+}
+
+func NewAmpEvalTemplateFactory() TemplateFactory {
+	return &AmpEvalTemplateFactory{}
 }

--- a/pkg/3scale/amp/template/ampevals3.go
+++ b/pkg/3scale/amp/template/ampevals3.go
@@ -5,6 +5,11 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 )
 
+func init() {
+	// TemplateFactories is a list of template factories
+	TemplateFactories = append(TemplateFactories, NewAmpEvalS3TemplateFactory)
+}
+
 type EvalS3Adapter struct {
 }
 
@@ -13,11 +18,21 @@ func (e *EvalS3Adapter) Adapt(template *templatev1.Template) {
 	template.ObjectMeta.Annotations["description"] = "3scale API Management main system (Evaluation) with shared file storage in AWS S3."
 }
 
-// AmpEvalS3TemplateAdapters defines the list of adapters to build the template
-func AmpEvalS3TemplateAdapters(options []string) []adapters.Adapter {
-	adapterList := AmpTemplateAdapters(options)
-	evalAdapter := adapters.NewEvalAdapter(options)
-	s3Adapter := adapters.NewS3Adapter(options)
+type AmpEvalS3TemplateFactory struct {
+}
 
-	return append(adapterList, evalAdapter, s3Adapter, &EvalS3Adapter{})
+func (f *AmpEvalS3TemplateFactory) Adapters() []adapters.Adapter {
+	ampFactory := NewAmpTemplateFactory()
+	evalAdapter := adapters.NewEvalAdapter()
+	s3Adapter := adapters.NewS3Adapter()
+
+	return append(ampFactory.Adapters(), evalAdapter, s3Adapter, &EvalS3Adapter{})
+}
+
+func (f *AmpEvalS3TemplateFactory) Type() TemplateType {
+	return "amp-eval-s3-template"
+}
+
+func NewAmpEvalS3TemplateFactory() TemplateFactory {
+	return &AmpEvalS3TemplateFactory{}
 }

--- a/pkg/3scale/amp/template/ampha.go
+++ b/pkg/3scale/amp/template/ampha.go
@@ -2,16 +2,31 @@ package template
 
 import "github.com/3scale/3scale-operator/pkg/3scale/amp/template/adapters"
 
-// AmpHATemplateAdapters defines the list of adapters to build the template
-func AmpHATemplateAdapters(options []string) []adapters.Adapter {
+func init() {
+	// TemplateFactories is a list of template factories
+	TemplateFactories = append(TemplateFactories, NewAmpHATemplateFactory)
+}
+
+type AmpHATemplateFactory struct {
+}
+
+func (f *AmpHATemplateFactory) Adapters() []adapters.Adapter {
 	return []adapters.Adapter{
-		adapters.NewImagesAdapter(options),
-		adapters.NewRedisAdapter(options),
-		adapters.NewBackendAdapter(options),
-		adapters.NewMemcachedAdapter(options),
-		adapters.NewSystemAdapter(options),
-		adapters.NewZyncAdapter(options),
-		adapters.NewApicastAdapter(options),
-		adapters.NewHAAdapter(options),
+		adapters.NewImagesAdapter(),
+		adapters.NewRedisAdapter(),
+		adapters.NewBackendAdapter(),
+		adapters.NewMemcachedAdapter(),
+		adapters.NewSystemAdapter(),
+		adapters.NewZyncAdapter(),
+		adapters.NewApicastAdapter(),
+		adapters.NewHAAdapter(),
 	}
+}
+
+func (f *AmpHATemplateFactory) Type() TemplateType {
+	return "amp-ha-template"
+}
+
+func NewAmpHATemplateFactory() TemplateFactory {
+	return &AmpHATemplateFactory{}
 }

--- a/pkg/3scale/amp/template/amppostgresql.go
+++ b/pkg/3scale/amp/template/amppostgresql.go
@@ -5,6 +5,11 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 )
 
+func init() {
+	// TemplateFactories is a list of template factories
+	TemplateFactories = append(TemplateFactories, NewAmpPostgresqlTemplateFactory)
+}
+
 type AmpPostgresqlTemplateAdapter struct {
 }
 
@@ -26,18 +31,28 @@ func (a *AmpPostgresqlTemplateAdapter) buildAmpTemplateMetaAnnotations() map[str
 	return annotations
 }
 
-// AmpPostgresqlTemplateAdapters defines the list of adapters to build the template
-func AmpPostgresqlTemplateAdapters(options []string) []adapters.Adapter {
+type AmpPostgresqlTemplateFactory struct {
+}
+
+func (f *AmpPostgresqlTemplateFactory) Adapters() []adapters.Adapter {
 	return []adapters.Adapter{
-		adapters.NewImagesAdapter(options),
-		adapters.NewSystemPostgreSQLImageAdapter(options),
-		adapters.NewRedisAdapter(options),
-		adapters.NewBackendAdapter(options),
-		adapters.NewSystemPostgreSQLAdapter(options),
-		adapters.NewMemcachedAdapter(options),
-		adapters.NewSystemAdapter(options),
-		adapters.NewZyncAdapter(options),
-		adapters.NewApicastAdapter(options),
+		adapters.NewImagesAdapter(),
+		adapters.NewSystemPostgreSQLImageAdapter(),
+		adapters.NewRedisAdapter(),
+		adapters.NewBackendAdapter(),
+		adapters.NewSystemPostgreSQLAdapter(),
+		adapters.NewMemcachedAdapter(),
+		adapters.NewSystemAdapter(),
+		adapters.NewZyncAdapter(),
+		adapters.NewApicastAdapter(),
 		&AmpPostgresqlTemplateAdapter{},
 	}
+}
+
+func (f *AmpPostgresqlTemplateFactory) Type() TemplateType {
+	return "amp-postgresql-template"
+}
+
+func NewAmpPostgresqlTemplateFactory() TemplateFactory {
+	return &AmpPostgresqlTemplateFactory{}
 }

--- a/pkg/3scale/amp/template/amps3.go
+++ b/pkg/3scale/amp/template/amps3.go
@@ -2,9 +2,23 @@ package template
 
 import "github.com/3scale/3scale-operator/pkg/3scale/amp/template/adapters"
 
-// AmpS3TemplateAdapters defines the list of adapters to build the template
-func AmpS3TemplateAdapters(options []string) []adapters.Adapter {
-	adapterList := AmpTemplateAdapters(options)
+func init() {
+	// TemplateFactories is a list of template factories
+	TemplateFactories = append(TemplateFactories, NewAmpS3TemplateFactory)
+}
 
-	return append(adapterList, adapters.NewS3Adapter(options))
+type AmpS3TemplateFactory struct {
+}
+
+func (f *AmpS3TemplateFactory) Adapters() []adapters.Adapter {
+	ampFactory := NewAmpTemplateFactory()
+	return append(ampFactory.Adapters(), adapters.NewS3Adapter())
+}
+
+func (f *AmpS3TemplateFactory) Type() TemplateType {
+	return "amp-s3-template"
+}
+
+func NewAmpS3TemplateFactory() TemplateFactory {
+	return &AmpS3TemplateFactory{}
 }


### PR DESCRIPTION
This PR backports the https://github.com/3scale/3scale-operator/pull/173 PR that refactors template generation factories that we want to include for 2.6 CR1