### PR TITLE
Add route customhost update

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -66,6 +66,7 @@ rules:
   - routes/custom-host
   verbs:
   - create
+  - update
 - apiGroups:
   - route.openshift.io
   resources:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3599,6 +3599,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3505,6 +3505,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2964,6 +2964,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3527,6 +3527,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3670,6 +3670,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3576,6 +3576,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -180,6 +180,7 @@ func (zync *Zync) buildZyncQueRole() *rbacv1.Role {
 				},
 				Verbs: []string{
 					"create",
+					"update",
 				},
 			},
 		},


### PR DESCRIPTION
This commits adds the route/custom-host update verb into the zync-que-role that is needed by the Zync component that has been requested by Zync team.

This change has a big impact where you need a privileged user to deploy 3scale from this point on.
This change should be temporary until we find a different way in Zync to do the desired tasks, but we add it so we can proceed with our internal testings for the moment.