### PR TITLE
2.6 stable prod add update routecustomhost [THREESCALE-2939]

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -66,6 +66,7 @@ rules:
   - routes/custom-host
   verbs:
   - create
+  - update
 - apiGroups:
   - route.openshift.io
   resources:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3602,6 +3602,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3508,6 +3508,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2967,6 +2967,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3530,6 +3530,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3673,6 +3673,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3579,6 +3579,7 @@ objects:
     - routes/custom-host
     verbs:
     - create
+    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -180,6 +180,7 @@ func (zync *Zync) buildZyncQueRole() *rbacv1.Role {
 				},
 				Verbs: []string{
 					"create",
+					"update",
 				},
 			},
 		},


### PR DESCRIPTION
This commits adds the route/custom-host update verb into the zync-que-role that is needed by the Zync component that has been requested by Zync team.

This change has a big impact where you need a privileged user to deploy 3scale from this point on.

This change should be temporary until we find a different way in Zync to do the desired tasks for CR1, but we add it so we can proceed with our internal testings for the moment.

https://issues.jboss.org/browse/THREESCALE-2939