### PR TITLE
2.6 stable updateapicast template26

### DIFF
--- a/pkg/3scale/amp/manual-templates/amp/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/amp/apicast.yml
@@ -32,8 +32,6 @@ objects:
           prometheus.io/scrape: 'true'
           prometheus.io/port: '9421'
       spec:
-        imagePullSecrets: # PRD: remove
-          - name: quay-auth
         containers:
         - env:
           - name: THREESCALE_PORTAL_ENDPOINT

--- a/pkg/3scale/amp/manual-templates/amp/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/amp/apicast.yml
@@ -123,7 +123,7 @@ parameters:
   value: "2.6.0"
   required: true
 - name: AMP_APICAST_IMAGE
-  value: "quay.io/3scale/amp:apicast-master"
+  value: "quay.io/3scale/3scale26:apicast-3scale-2.6.0-ER1"
   required: true
 - description: "Name of the secret containing the THREESCALE_PORTAL_ENDPOINT with the access-token or provider key"
   value: apicast-configuration-url-secret


### PR DESCRIPTION
This PR:
 * Updates apicast template image to use the existing quay community image
 * Removes unused quay-auth imagepullsecret(now it gathers the image from a public quay registry)