### PR TITLE
Revert pull request #187

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -66,7 +66,6 @@ rules:
   - routes/custom-host
   verbs:
   - create
-  - update
 - apiGroups:
   - route.openshift.io
   resources:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3602,7 +3602,6 @@ objects:
     - routes/custom-host
     verbs:
     - create
-    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3508,7 +3508,6 @@ objects:
     - routes/custom-host
     verbs:
     - create
-    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2967,7 +2967,6 @@ objects:
     - routes/custom-host
     verbs:
     - create
-    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3530,7 +3530,6 @@ objects:
     - routes/custom-host
     verbs:
     - create
-    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3673,7 +3673,6 @@ objects:
     - routes/custom-host
     verbs:
     - create
-    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3579,7 +3579,6 @@ objects:
     - routes/custom-host
     verbs:
     - create
-    - update
 - apiVersion: v1
   imagePullSecrets:
   - name: threescale-registry-auth

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -180,7 +180,6 @@ func (zync *Zync) buildZyncQueRole() *rbacv1.Role {
 				},
 				Verbs: []string{
 					"create",
-					"update",
 				},
 			},
 		},


### PR DESCRIPTION
This PR reverts the addition of role permissions temporarily needed that were requiring admin privileges to be able to deploy the role that used them.

cc @mikz please approve this when the changes related to not needing this additional permission are in zync's master

Thank you.