### PR TITLE
2.6-stable-prod backport operator storageclassname fix

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -903,6 +903,7 @@ func (system *System) buildSystemSharedPVC() *v1.PersistentVolumeClaim {
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: system.Options.storageClassName,
 			AccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteMany,
 			},


### PR DESCRIPTION
2.6 stable prod backport system's fileStorage StorageClassName attribute not being set on operator