### PR TITLE
[FIX] backend redis secret read THREESCALE-3258

### DIFF
--- a/pkg/3scale/amp/operator/backend.go
+++ b/pkg/3scale/amp/operator/backend.go
@@ -120,7 +120,7 @@ func (o *OperatorBackendOptionsProvider) setBackendRedisOptions(b *component.Bac
 		}
 		result = getSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesSentinelHostsFieldName)
 		if result != nil {
-			b.RedisStorageSentinelHosts(*result)
+			b.RedisQueuesSentinelHosts(*result)
 		}
 		result = getSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesSentinelRoleFieldName)
 		if result != nil {


### PR DESCRIPTION
`REDIS_QUEUES_SENTINEL_HOSTS` was read from `backend-redis` secret, but not set in options object correctly. 

Secret reconciliation made both `REDIS_QUEUES_SENTINEL_HOSTS` and `REDIS_STORAGE_SENTINEL_HOSTS` keys in the secret being updated to empty string. Hence, backend deployment was not correct.