### PR TITLE
[system] rolling_updates.yml inherits from defaults

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1518,28 +1518,7 @@ objects:
 - apiVersion: v1
   data:
     rolling_updates.yml: |
-      production:
-        old_charts: false
-        new_provider_documentation: false
-        proxy_pro: false
-        instant_bill_plan_change: false
-        service_permissions: true
-        async_apicast_deploy: false
-        duplicate_application_id: true
-        duplicate_user_key: true
-        plan_changes_wizard: false
-        require_cc_on_signup: false
-        apicast_per_service: true
-        new_notification_system: true
-        cms_api: false
-        apicast_v2: true
-        forum: false
-        published_service_plan_signup: true
-        apicast_oidc: true
-        policies: true
-        policy_registry: true
-        proxy_private_base_path: true
-        service_mesh_integration: true
+      production: {}
     service_discovery.yml: |
       production:
         enabled: <%= cluster_token_file_exists = File.exists?(cluster_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token') %>

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1535,28 +1535,7 @@ objects:
 - apiVersion: v1
   data:
     rolling_updates.yml: |
-      production:
-        old_charts: false
-        new_provider_documentation: false
-        proxy_pro: false
-        instant_bill_plan_change: false
-        service_permissions: true
-        async_apicast_deploy: false
-        duplicate_application_id: true
-        duplicate_user_key: true
-        plan_changes_wizard: false
-        require_cc_on_signup: false
-        apicast_per_service: true
-        new_notification_system: true
-        cms_api: false
-        apicast_v2: true
-        forum: false
-        published_service_plan_signup: true
-        apicast_oidc: true
-        policies: true
-        policy_registry: true
-        proxy_private_base_path: true
-        service_mesh_integration: true
+      production: {}
     service_discovery.yml: |
       production:
         enabled: <%= cluster_token_file_exists = File.exists?(cluster_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token') %>

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -964,28 +964,7 @@ objects:
 - apiVersion: v1
   data:
     rolling_updates.yml: |
-      production:
-        old_charts: false
-        new_provider_documentation: false
-        proxy_pro: false
-        instant_bill_plan_change: false
-        service_permissions: true
-        async_apicast_deploy: false
-        duplicate_application_id: true
-        duplicate_user_key: true
-        plan_changes_wizard: false
-        require_cc_on_signup: false
-        apicast_per_service: true
-        new_notification_system: true
-        cms_api: false
-        apicast_v2: true
-        forum: false
-        published_service_plan_signup: true
-        apicast_oidc: true
-        policies: true
-        policy_registry: true
-        proxy_private_base_path: true
-        service_mesh_integration: true
+      production: {}
     service_discovery.yml: |
       production:
         enabled: <%= cluster_token_file_exists = File.exists?(cluster_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token') %>

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1527,28 +1527,7 @@ objects:
 - apiVersion: v1
   data:
     rolling_updates.yml: |
-      production:
-        old_charts: false
-        new_provider_documentation: false
-        proxy_pro: false
-        instant_bill_plan_change: false
-        service_permissions: true
-        async_apicast_deploy: false
-        duplicate_application_id: true
-        duplicate_user_key: true
-        plan_changes_wizard: false
-        require_cc_on_signup: false
-        apicast_per_service: true
-        new_notification_system: true
-        cms_api: false
-        apicast_v2: true
-        forum: false
-        published_service_plan_signup: true
-        apicast_oidc: true
-        policies: true
-        policy_registry: true
-        proxy_private_base_path: true
-        service_mesh_integration: true
+      production: {}
     service_discovery.yml: |
       production:
         enabled: <%= cluster_token_file_exists = File.exists?(cluster_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token') %>

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1559,28 +1559,7 @@ objects:
 - apiVersion: v1
   data:
     rolling_updates.yml: |
-      production:
-        old_charts: false
-        new_provider_documentation: false
-        proxy_pro: false
-        instant_bill_plan_change: false
-        service_permissions: true
-        async_apicast_deploy: false
-        duplicate_application_id: true
-        duplicate_user_key: true
-        plan_changes_wizard: false
-        require_cc_on_signup: false
-        apicast_per_service: true
-        new_notification_system: true
-        cms_api: false
-        apicast_v2: true
-        forum: false
-        published_service_plan_signup: true
-        apicast_oidc: true
-        policies: true
-        policy_registry: true
-        proxy_private_base_path: true
-        service_mesh_integration: true
+      production: {}
     service_discovery.yml: |
       production:
         enabled: <%= cluster_token_file_exists = File.exists?(cluster_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token') %>

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1576,28 +1576,7 @@ objects:
 - apiVersion: v1
   data:
     rolling_updates.yml: |
-      production:
-        old_charts: false
-        new_provider_documentation: false
-        proxy_pro: false
-        instant_bill_plan_change: false
-        service_permissions: true
-        async_apicast_deploy: false
-        duplicate_application_id: true
-        duplicate_user_key: true
-        plan_changes_wizard: false
-        require_cc_on_signup: false
-        apicast_per_service: true
-        new_notification_system: true
-        cms_api: false
-        apicast_v2: true
-        forum: false
-        published_service_plan_signup: true
-        apicast_oidc: true
-        policies: true
-        policy_registry: true
-        proxy_private_base_path: true
-        service_mesh_integration: true
+      production: {}
     service_discovery.yml: |
       production:
         enabled: <%= cluster_token_file_exists = File.exists?(cluster_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token') %>

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -1152,28 +1152,7 @@ func (system *System) getSystemZyncConfData() string {
 }
 
 func (system *System) getSystemRollingUpdatesConfData() string {
-	return `production:
-  old_charts: false
-  new_provider_documentation: false
-  proxy_pro: false
-  instant_bill_plan_change: false
-  service_permissions: true
-  async_apicast_deploy: false
-  duplicate_application_id: true
-  duplicate_user_key: true
-  plan_changes_wizard: false
-  require_cc_on_signup: false
-  apicast_per_service: true
-  new_notification_system: true
-  cms_api: false
-  apicast_v2: true
-  forum: false
-  published_service_plan_signup: true
-  apicast_oidc: true
-  policies: true
-  policy_registry: true
-  proxy_private_base_path: true
-  service_mesh_integration: true
+	return `production: {}
 `
 }
 


### PR DESCRIPTION
Porta should have the defaults rolling updates

See https://github.com/3scale/porta/pull/1234 and https://github.com/3scale/porta/pull/744

This config allows to override those defaults

### Note:

This does not affect previous behaviour on 2.7 release

Closes https://issues.jboss.org/browse/THREESCALE-2604