### PR TITLE
upgrade database imagestreams tagged with 3scale release tag names

### DIFF
--- a/pkg/3scale/amp/operator/redis.go
+++ b/pkg/3scale/amp/operator/redis.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -43,4 +44,13 @@ func (o *OperatorRedisOptionsProvider) setResourceRequirementsOptions(b *compone
 		b.SystemRedisContainerResourceRequirements(v1.ResourceRequirements{})
 		b.BackendRedisContainerResourceRequirements(v1.ResourceRequirements{})
 	}
+}
+
+func Redis(cr *appsv1alpha1.APIManager) (*component.Redis, error) {
+	optsProvider := OperatorRedisOptionsProvider{APIManagerSpec: &cr.Spec}
+	opts, err := optsProvider.GetRedisOptions()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewRedis(opts), nil
 }

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	v1 "k8s.io/api/core/v1"
@@ -64,7 +63,7 @@ func (r *RedisReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, nil
 	}
 
-	redis, err := r.redis()
+	redis, err := Redis(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -115,15 +114,6 @@ func (r *RedisReconciler) Reconcile() (reconcile.Result, error) {
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *RedisReconciler) redis() (*component.Redis, error) {
-	optsProvider := OperatorRedisOptionsProvider{APIManagerSpec: &r.apiManager.Spec}
-	opts, err := optsProvider.GetRedisOptions()
-	if err != nil {
-		return nil, err
-	}
-	return component.NewRedis(opts), nil
 }
 
 func (r *RedisReconciler) reconcileBackendDeploymentConfig(desiredDeploymentConfig *appsv1.DeploymentConfig) error {

--- a/pkg/controller/apimanager/upgrade_26_to_27.go
+++ b/pkg/controller/apimanager/upgrade_26_to_27.go
@@ -1,6 +1,8 @@
 package apimanager
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -15,6 +17,23 @@ func (u *Upgrade26_to_27) Upgrade() (reconcile.Result, error) {
 		return res, err
 	}
 
+	if !u.highAvailabilityModeEnabled() {
+		res, err = u.upgradeBackendRedisImageStream()
+		if res.Requeue || err != nil {
+			return res, err
+		}
+
+		res, err = u.upgradeSystemRedisImageStream()
+		if res.Requeue || err != nil {
+			return res, err
+		}
+
+		res, err = u.upgradeSystemDatabaseImageStream()
+		if res.Requeue || err != nil {
+			return res, err
+		}
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -23,5 +42,59 @@ func (u *Upgrade26_to_27) upgradeAMPImageStreams() (reconcile.Result, error) {
 	baseReconciler := operator.NewBaseReconciler(u.client, u.apiClientReader, u.scheme, u.logger)
 	baseLogicReconciler := operator.NewBaseLogicReconciler(baseReconciler)
 	reconciler := operator.NewAMPImagesReconciler(operator.NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.cr))
+	return reconciler.Reconcile()
+}
+
+func (u *Upgrade26_to_27) highAvailabilityModeEnabled() bool {
+	return u.cr.Spec.HighAvailability != nil && u.cr.Spec.HighAvailability.Enabled
+}
+
+func (u *Upgrade26_to_27) upgradeBackendRedisImageStream() (reconcile.Result, error) {
+	redis, err := operator.Redis(u.cr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	baseReconciler := operator.NewBaseReconciler(u.client, u.apiClientReader, u.scheme, u.logger)
+	baseLogicReconciler := operator.NewBaseLogicReconciler(baseReconciler)
+	reconciler := operator.NewImageStreamBaseReconciler(operator.NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.cr), operator.NewImageStreamGenericReconciler())
+	return reconcile.Result{}, reconciler.Reconcile(redis.BackendImageStream())
+}
+
+func (u *Upgrade26_to_27) upgradeSystemRedisImageStream() (reconcile.Result, error) {
+	redis, err := operator.Redis(u.cr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	baseReconciler := operator.NewBaseReconciler(u.client, u.apiClientReader, u.scheme, u.logger)
+	baseLogicReconciler := operator.NewBaseLogicReconciler(baseReconciler)
+	reconciler := operator.NewImageStreamBaseReconciler(operator.NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.cr), operator.NewImageStreamGenericReconciler())
+	return reconcile.Result{}, reconciler.Reconcile(redis.SystemImageStream())
+}
+
+func (u *Upgrade26_to_27) upgradeSystemDatabaseImageStream() (reconcile.Result, error) {
+	if u.cr.Spec.System.DatabaseSpec.MySQL != nil {
+		return u.upgradeSystemMySQLImageStream()
+	}
+
+	if u.cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
+		return u.upgradeSystemPostgreSQLImageStream()
+	}
+
+	return reconcile.Result{}, fmt.Errorf("System database is not set")
+}
+
+func (u *Upgrade26_to_27) upgradeSystemMySQLImageStream() (reconcile.Result, error) {
+	baseReconciler := operator.NewBaseReconciler(u.client, u.apiClientReader, u.scheme, u.logger)
+	baseLogicReconciler := operator.NewBaseLogicReconciler(baseReconciler)
+	reconciler := operator.NewSystemMySQLImageReconciler(operator.NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.cr))
+	return reconciler.Reconcile()
+}
+
+func (u *Upgrade26_to_27) upgradeSystemPostgreSQLImageStream() (reconcile.Result, error) {
+	baseReconciler := operator.NewBaseReconciler(u.client, u.apiClientReader, u.scheme, u.logger)
+	baseLogicReconciler := operator.NewBaseLogicReconciler(baseReconciler)
+	reconciler := operator.NewSystemPostgreSQLImageReconciler(operator.NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.cr))
 	return reconciler.Reconcile()
 }


### PR DESCRIPTION
Database imagestreams are tagged with 3scale release tag names. For instance backend redis imagestream:

```yml
tags:
  - annotations:
      openshift.io/display-name: Backend 2.6 Redis
    from:
      kind: DockerImage
      name: centos/redis-32-centos7
    generation: 2
    importPolicy: {}
    name: "2.6"
    referencePolicy:
      type: Source
  - annotations:
      openshift.io/display-name: Backend Redis (latest)
    from:
      kind: ImageStreamTag
      name: "2.6"
    generation: 1
    importPolicy: {}
    name: latest
    referencePolicy:
      type: Source
```

To be consistent, upgrade should update those tags, even when image does not change.

Tests have shown that even changing latest tag of the imagestream, deploymentconfigs are not redeployed if image sha remains equal.

Upgrading procedure implemented using reconciliation methods.