### PR TITLE
Add routes checking in e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,13 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v2-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+            - v3-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
       - run:
           name: Install operator dependencies
           command: |
             make vendor
       - save_cache:
-          key: v2-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+          key: v3-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
           paths:
             - "vendor"
             - "/go/pkg"

--- a/test/e2e/e2eutil/wait.go
+++ b/test/e2e/e2eutil/wait.go
@@ -2,17 +2,21 @@ package e2eutil
 
 import (
 	"context"
+	"fmt"
+	"testing"
+	"time"
+
 	"github.com/3scale/3scale-operator/pkg/apis/capabilities/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
 	appsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	clientappsv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	clientroutev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -93,4 +97,61 @@ func WaitForReconciliationWith3scale(t *testing.T, c test.FrameworkClient, bindi
 	}
 	return nil
 
+}
+
+func WaitForRouteFromHost(t *testing.T, kubeClient kubernetes.Interface, osRouteV1Client clientroutev1.RouteV1Interface, namespace, host string, retryInterval, timeout time.Duration) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		routeInteface := osRouteV1Client.Routes(namespace)
+		routeFieldSelector := "spec.host=" + host
+		routeList, err := routeInteface.List(
+			metav1.ListOptions{
+				IncludeUninitialized: true,
+				FieldSelector:        routeFieldSelector},
+		)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("Waiting for availability of Route with host '%s'\n", host)
+				return false, nil
+			}
+			return false, err
+		}
+
+		routeItems := routeList.Items
+		if len(routeItems) == 0 {
+			t.Logf("Waiting for availability of Route with host '%s'\n", host)
+			return false, nil
+		}
+		if len(routeItems) > 1 {
+			return false, fmt.Errorf("Found unexpected routes with duplicated 'host' fields")
+		}
+
+		route := routeItems[0]
+		routeStatusIngresses := route.Status.Ingress
+		if routeStatusIngresses == nil || len(routeStatusIngresses) == 0 {
+			t.Logf("Waiting for availability of Route with host '%s'\n", host)
+			return false, nil
+		}
+
+		for _, routeStatusIngress := range routeStatusIngresses {
+			routeStatusIngressConditions := routeStatusIngress.Conditions
+			isReady := false
+			for _, routeStatusIngressCondition := range routeStatusIngressConditions {
+				if routeStatusIngressCondition.Type == routev1.RouteAdmitted && routeStatusIngressCondition.Status == corev1.ConditionTrue {
+					isReady = true
+					break
+				}
+			}
+			if !isReady {
+				t.Logf("Waiting for availability of Route with host '%s'\n", host)
+				return false, nil
+			}
+		}
+
+		t.Logf("Route '%s' with host '%s' available\n", route.Name, route.Spec.Host)
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This PR adds code in the e2e test that checks that all routes that should be created by default in an APIManager deployment are indeed created