### PR TITLE
do not cache vendor folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,16 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v3-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+            - v4-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+            # Find the most recently generated cache used from any branch
+            - v4-3scaleoperator-vendor-{{ arch }}
       - run:
           name: Install operator dependencies
           command: |
             make vendor
       - save_cache:
-          key: v3-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+          key: v4-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
           paths:
-            - "vendor"
             - "/go/pkg"
 
   install-openshift:


### PR DESCRIPTION
`vendor` folder should not be cached.

Go modules cache directory should only be cached, i.e. `/go/pkg` folder. 

Same go.sum (same modules and releases) may lead to different `vendor` folder, because vendor only contains used packages, not used modules. `/go/pkg` folder contains used modules and can be identified uniquely by `go.sum`. Does not happen the same with `vendor` folder.