### PR TITLE
Operator version bump 0.4.0

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -4264,7 +4264,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: "2.6"
+  value: "2.7"
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -4161,7 +4161,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: "2.6"
+  value: "2.7"
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -3661,7 +3661,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: "2.6"
+  value: "2.7"
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -4213,7 +4213,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: "2.6"
+  value: "2.7"
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -4365,7 +4365,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: "2.6"
+  value: "2.7"
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -4262,7 +4262,7 @@ parameters:
 - description: AMP release tag.
   name: AMP_RELEASE
   required: true
-  value: "2.6"
+  value: "2.7"
 - description: Used for object app labels
   name: APP_LABEL
   required: true

--- a/pkg/3scale/amp/manual-templates/amp/apicast.yml
+++ b/pkg/3scale/amp/manual-templates/amp/apicast.yml
@@ -118,7 +118,7 @@ objects:
 parameters:
 - name: AMP_RELEASE
   description: "AMP release tag."
-  value: "2.6.0"
+  value: "2.7.0"
   required: true
 - name: AMP_APICAST_IMAGE
   value: "quay.io/3scale/apicast:nightly"

--- a/pkg/3scale/amp/product/3scale_release.go
+++ b/pkg/3scale/amp/product/3scale_release.go
@@ -1,5 +1,5 @@
 package product
 
 var (
-	ThreescaleRelease = "2.6"
+	ThreescaleRelease = "2.7"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.3.0"
+	Version = "0.4.0"
 )


### PR DESCRIPTION
This PR should be merged just before `2.7-stable` and `2.7-stable-prod` branches are created. Stable branches should start off from the merge commit of this PR.