### PR TITLE
storage and database defaults refactor

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -932,7 +932,7 @@ func (system *System) sidekiqContainerVolumeMounts() []v1.VolumeMount {
 }
 
 func (system *System) SharedStorage() *v1.PersistentVolumeClaim {
-	res := &v1.PersistentVolumeClaim{
+	return &v1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
@@ -946,7 +946,7 @@ func (system *System) SharedStorage() *v1.PersistentVolumeClaim {
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			StorageClassName: system.Options.storageClassName,
+			StorageClassName: system.Options.pvcFileStorageOptions.StorageClass,
 			AccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteMany,
 			},
@@ -957,12 +957,6 @@ func (system *System) SharedStorage() *v1.PersistentVolumeClaim {
 			},
 		},
 	}
-
-	if system.Options.pvcFileStorageOptions != nil {
-		res.Spec.StorageClassName = system.Options.storageClassName
-	}
-
-	return res
 }
 
 func (system *System) ProviderService() *v1.Service {

--- a/pkg/3scale/amp/component/system_options_builder.go
+++ b/pkg/3scale/amp/component/system_options_builder.go
@@ -65,7 +65,6 @@ type SystemOptions struct {
 	backendSharedSecret string
 	tenantName          string
 	wildcardDomain      string
-	storageClassName    *string // should this be a string or *string? check what would be the difference between passing a "" and a nil pointer in the PersistentVolumeClaim corresponding field
 }
 
 type SystemOptionsBuilder struct {
@@ -142,10 +141,6 @@ func (s *SystemOptionsBuilder) TenantName(tenantName string) {
 
 func (s *SystemOptionsBuilder) WildcardDomain(wildcardDomain string) {
 	s.options.wildcardDomain = wildcardDomain
-}
-
-func (s *SystemOptionsBuilder) StorageClassName(storageClassName *string) {
-	s.options.storageClassName = storageClassName
 }
 
 func (s *SystemOptionsBuilder) MemcachedServers(servers *string) {
@@ -288,10 +283,6 @@ func (s *SystemOptionsBuilder) setRequiredOptions() error {
 	}
 	if s.options.wildcardDomain == "" {
 		return fmt.Errorf("no wildcard domain has been provided")
-	}
-
-	if s.options.s3FileStorageOptions == nil && s.options.pvcFileStorageOptions == nil {
-		s.options.pvcFileStorageOptions = &PVCFileStorageOptions{}
 	}
 
 	return nil

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -59,10 +59,6 @@ func NewRedisReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicReconci
 }
 
 func (r *RedisReconciler) Reconcile() (reconcile.Result, error) {
-	if r.apiManager.Spec.HighAvailability != nil && r.apiManager.Spec.HighAvailability.Enabled {
-		return reconcile.Result{}, nil
-	}
-
 	redis, err := Redis(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -19,12 +19,6 @@ func (o *OperatorSystemOptionsProvider) GetSystemOptions() (*component.SystemOpt
 	optProv.TenantName(*o.APIManagerSpec.TenantName)
 	optProv.WildcardDomain(o.APIManagerSpec.WildcardDomain)
 
-	if o.APIManagerSpec.System.FileStorageSpec.PVC == nil {
-		optProv.StorageClassName(nil)
-	} else {
-		optProv.StorageClassName(o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName)
-	}
-
 	err := o.setSecretBasedOptions(&optProv)
 	if err != nil {
 		return nil, err
@@ -222,18 +216,20 @@ func (o *OperatorSystemOptionsProvider) setResourceRequirementsOptions(b *compon
 }
 
 func (o *OperatorSystemOptionsProvider) setFileStorageOptions(b *component.SystemOptionsBuilder) {
-	s3FileStorageSpec := o.APIManagerSpec.System.FileStorageSpec.S3
-	if s3FileStorageSpec != nil {
+	if o.APIManagerSpec.System.FileStorageSpec.PVC != nil {
+		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
+			StorageClass: o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName,
+		})
+	}
+
+	if o.APIManagerSpec.System.FileStorageSpec.S3 != nil {
+		s3FileStorageSpec := o.APIManagerSpec.System.FileStorageSpec.S3
 		b.S3FileStorageOptions(component.S3FileStorageOptions{
 			AWSAccessKeyId:       "",
 			AWSSecretAccessKey:   "",
 			AWSRegion:            s3FileStorageSpec.AWSRegion,
 			AWSBucket:            s3FileStorageSpec.AWSBucket,
 			AWSCredentialsSecret: s3FileStorageSpec.AWSCredentials.Name,
-		})
-	} else { // PVC by default
-		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
-			StorageClass: o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName,
 		})
 	}
 }

--- a/pkg/3scale/amp/operator/system_mysql_image.go
+++ b/pkg/3scale/amp/operator/system_mysql_image.go
@@ -12,11 +12,7 @@ func (o *OperatorSystemMySQLImageOptionsProvider) GetSystemMySQLImageOptions() (
 
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 	optProv.AmpRelease(product.ThreescaleRelease)
-	if o.APIManagerSpec.System.DatabaseSpec.MySQL.Image != nil {
-		optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.MySQL.Image)
-	} else {
-		optProv.Image(component.SystemMySQLImageURL())
-	}
+	optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.MySQL.Image)
 	optProv.InsecureImportPolicy(*o.APIManagerSpec.ImageStreamTagImportInsecure)
 
 	res, err := optProv.Build()

--- a/pkg/3scale/amp/operator/system_mysql_image_reconciler.go
+++ b/pkg/3scale/amp/operator/system_mysql_image_reconciler.go
@@ -20,10 +20,6 @@ func NewSystemMySQLImageReconciler(baseAPIManagerLogicReconciler BaseAPIManagerL
 }
 
 func (r *SystemMySQLImageReconciler) Reconcile() (reconcile.Result, error) {
-	if r.apiManager.Spec.HighAvailability != nil && r.apiManager.Spec.HighAvailability.Enabled {
-		return reconcile.Result{}, nil
-	}
-
 	systemMySQLImage, err := r.systemMySQLImage()
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/3scale/amp/operator/system_mysql_reconciler.go
+++ b/pkg/3scale/amp/operator/system_mysql_reconciler.go
@@ -21,10 +21,6 @@ func NewSystemMySQLReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicR
 }
 
 func (r *SystemMySQLReconciler) Reconcile() (reconcile.Result, error) {
-	if r.apiManager.Spec.HighAvailability != nil && r.apiManager.Spec.HighAvailability.Enabled {
-		return reconcile.Result{}, nil
-	}
-
 	systemMySQL, err := r.systemMySQL()
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/3scale/amp/operator/system_postgresql_image.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image.go
@@ -11,11 +11,7 @@ func (o *OperatorSystemPostgreSQLImageOptionsProvider) GetSystemPostgreSQLImageO
 	optProv := component.SystemPostgreSQLImageOptionsBuilder{}
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 	optProv.AmpRelease(product.ThreescaleRelease)
-	if o.APIManagerSpec.System.DatabaseSpec.PostgreSQL.Image != nil {
-		optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.PostgreSQL.Image)
-	} else {
-		optProv.Image(component.SystemPostgreSQLImageURL())
-	}
+	optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.PostgreSQL.Image)
 	optProv.InsecureImportPolicy(*o.APIManagerSpec.ImageStreamTagImportInsecure)
 
 	res, err := optProv.Build()

--- a/pkg/3scale/amp/operator/system_postgresql_image_reconciler.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image_reconciler.go
@@ -20,10 +20,6 @@ func NewSystemPostgreSQLImageReconciler(baseAPIManagerLogicReconciler BaseAPIMan
 }
 
 func (r *SystemPostgreSQLImageReconciler) Reconcile() (reconcile.Result, error) {
-	if r.apiManager.Spec.HighAvailability != nil && r.apiManager.Spec.HighAvailability.Enabled {
-		return reconcile.Result{}, nil
-	}
-
 	systemPostgreSQLImage, err := r.systemPostgreSQLImage()
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -114,16 +114,19 @@ func NewSystemReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicReconc
 }
 
 func (r *SystemReconciler) reconcileFileStorage(system *component.System) error {
-	if r.apiManager.Spec.System != nil && r.apiManager.Spec.System.FileStorageSpec != nil {
-		if r.apiManager.Spec.System.FileStorageSpec.PVC != nil {
-			return r.reconcileSharedStorage(system.SharedStorage())
-		} else if r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
-			return r.reconcileS3AWSSecret(system.S3AWSSecret())
-		} else {
-			return fmt.Errorf("No FileStorage spec specified. FileStorage is mandatory")
-		}
+	if r.apiManager.Spec.System.FileStorageSpec.PVC != nil && r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
+		r.Logger().Info("[WARNING] Only one System FileStorage can be chosen at the same time. Using PVC as storage.")
 	}
-	return nil
+
+	var err error
+	if r.apiManager.Spec.System.FileStorageSpec.PVC != nil {
+		err = r.reconcileSharedStorage(system.SharedStorage())
+	} else if r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
+		err = r.reconcileS3AWSSecret(system.S3AWSSecret())
+	} else {
+		err = fmt.Errorf("No FileStorage spec specified. FileStorage is mandatory")
+	}
+	return err
 }
 
 func (r *SystemReconciler) reconcileS3AWSSecret(desiredSecret *v1.Secret) error {

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -161,6 +161,6 @@ func (s *System) options() (*component.SystemOptions, error) {
 	sob.BackendSharedSecret("${SYSTEM_BACKEND_SHARED_SECRET}")
 	sob.TenantName("${TENANT_NAME}")
 	sob.WildcardDomain("${WILDCARD_DOMAIN}")
-	sob.StorageClassName(nil)
+	sob.PVCFileStorageOptions(component.PVCFileStorageOptions{StorageClass: nil})
 	return sob.Build()
 }

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -1,8 +1,7 @@
 package v1alpha1
 
 import (
-	"fmt"
-
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/version"
 	"github.com/RHsyseng/operator-utils/pkg/olm"
@@ -455,7 +454,6 @@ func (apimanager *APIManager) setAPIManagerCommonSpecDefaults() bool {
 }
 
 func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
-	// TODO fix how should be shown
 	changed := false
 	spec := &apimanager.Spec
 
@@ -464,17 +462,11 @@ func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
 		changed = true
 	}
 
-	tmpChanged, err := apimanager.setSystemFileStorageSpecDefaults()
+	tmpChanged := apimanager.setSystemFileStorageSpecDefaults()
 	changed = changed || tmpChanged
-	if err != nil {
-		return changed, err
-	}
 
-	tmpChanged, err = apimanager.setSystemDatabaseSpecDefaults()
+	tmpChanged = apimanager.setSystemDatabaseSpecDefaults()
 	changed = changed || tmpChanged
-	if err != nil {
-		return changed, err
-	}
 
 	if spec.System.AppSpec == nil {
 		spec.System.AppSpec = &SystemAppSpec{}
@@ -499,59 +491,59 @@ func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
 	return changed, nil
 }
 
-func (apimanager *APIManager) setSystemFileStorageSpecDefaults() (bool, error) {
+func (apimanager *APIManager) setSystemFileStorageSpecDefaults() bool {
 	changed := false
 	systemSpec := apimanager.Spec.System
-
-	defaultFileStorageSpec := &SystemFileStorageSpec{
-		PVC: &SystemPVCSpec{
-			StorageClassName: nil,
-		},
-	}
 
 	if systemSpec.FileStorageSpec == nil {
-		systemSpec.FileStorageSpec = defaultFileStorageSpec
-		changed = true
-		return changed, nil
-	}
-
-	if systemSpec.FileStorageSpec.PVC != nil && systemSpec.FileStorageSpec.S3 != nil {
-		return changed, fmt.Errorf("Only one FileStorage can be chosen at the same time")
-	}
-
-	if systemSpec.FileStorageSpec.PVC == nil && systemSpec.FileStorageSpec.S3 == nil {
-		systemSpec.FileStorageSpec.PVC = defaultFileStorageSpec.PVC
+		systemSpec.FileStorageSpec = &SystemFileStorageSpec{}
 		changed = true
 	}
 
-	return changed, nil
+	if systemSpec.FileStorageSpec.PVC == nil && systemSpec.FileStorageSpec.S3 != nil {
+		//  No default values for S3
+	} else {
+		// PVC
+		if systemSpec.FileStorageSpec.PVC == nil {
+			systemSpec.FileStorageSpec.PVC = &SystemPVCSpec{}
+			changed = true
+		}
+		// StorageClassName default value is nil
+	}
+
+	return changed
 }
 
-func (apimanager *APIManager) setSystemDatabaseSpecDefaults() (bool, error) {
+func (apimanager *APIManager) setSystemDatabaseSpecDefaults() bool {
 	changed := false
 	systemSpec := apimanager.Spec.System
 
-	defaultDatabaseSpec := &SystemDatabaseSpec{
-		MySQL: &SystemMySQLSpec{
-			Image: nil,
-		},
-	}
-
 	if systemSpec.DatabaseSpec == nil {
-		systemSpec.DatabaseSpec = defaultDatabaseSpec
+		systemSpec.DatabaseSpec = &SystemDatabaseSpec{}
 		changed = true
-		return changed, nil
 	}
 
-	if systemSpec.DatabaseSpec.MySQL != nil && systemSpec.DatabaseSpec.PostgreSQL != nil {
-		return changed, fmt.Errorf("Only one System Database can be chosen at the same time")
+	// PostgreSQL
+	if systemSpec.DatabaseSpec.MySQL == nil && systemSpec.DatabaseSpec.PostgreSQL != nil {
+		if systemSpec.DatabaseSpec.PostgreSQL.Image == nil {
+			defaultPostgreSQLImage := component.SystemPostgreSQLImageURL()
+			systemSpec.DatabaseSpec.PostgreSQL.Image = &defaultPostgreSQLImage
+			changed = true
+		}
+	} else {
+		// MySQL
+		if systemSpec.DatabaseSpec.MySQL == nil {
+			systemSpec.DatabaseSpec.MySQL = &SystemMySQLSpec{}
+		}
+
+		if systemSpec.DatabaseSpec.MySQL.Image == nil {
+			defaultMysqlImage := component.SystemMySQLImageURL()
+			systemSpec.DatabaseSpec.MySQL.Image = &defaultMysqlImage
+			changed = true
+		}
 	}
 
-	if systemSpec.DatabaseSpec.MySQL == nil && systemSpec.DatabaseSpec.PostgreSQL == nil {
-		systemSpec.DatabaseSpec.MySQL = defaultDatabaseSpec.MySQL
-	}
-
-	return changed, nil
+	return changed
 }
 
 func (apimanager *APIManager) setZyncDefaults() bool {


### PR DESCRIPTION
Refactor system storage and database defaults and reconciliation.

CR will be updated with defaults accordingly

```
system:
    appSpec:
      replicas: 1
    database:
      mysql:
        image: centos/mysql-57-centos7
    fileStorage:
      persistentVolumeClaim: {}
    sidekiqSpec:
      replicas: 1

``` 