### PR TITLE
Add basic unit test for APIManager types package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,6 +319,18 @@ jobs:
       - oc-status
       - push-3scale-images-to-quay
 
+  run-unit-tests:
+    docker:
+      - image: circleci/golang:1.12.5
+    working_directory: /go/src/github.com/3scale/3scale-operator
+    steps:
+      - checkout
+      - run: make vendor
+      - run:
+          name: Run unit tests in pkg folder
+          command: |
+            make unit
+
   run-operator-e2e-test:
     machine:
       image: circleci/classic:latest
@@ -392,6 +404,7 @@ workflows:
     jobs:
       - license-check
       - test-crds
+      - run-unit-tests
       - verify-manifest
       - install-operator
       - run-operator-e2e-test:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 .DEFAULT_GOAL := help
-.PHONY: build e2e test-crds verify-manifest licenses-check push-manifest
+.PHONY: build unit e2e test-crds verify-manifest licenses-check push-manifest
 UNAME := $(shell uname)
 
 ifeq (${UNAME}, Linux)
@@ -66,6 +66,10 @@ e2e-clean:
 
 ## e2e: e2e-clean e2e-setup e2e-run
 e2e: e2e-clean e2e-setup e2e-run
+
+## unit: run all available unit tests in pkg directory of the repository
+unit:
+	go test -v ./pkg/...
 
 ## test-crds: Run CRD unittests
 test-crds:

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -20,6 +20,20 @@ const (
 	OperatorVersionAnnotation   = "apps.3scale.net/threescale-operator-version"
 )
 
+const (
+	defaultAppLabel                    = "3scale-api-management"
+	defaultTenantName                  = "3scale"
+	defaultImageStreamImportInsecure   = false
+	defaultResourceRequirementsEnabled = true
+)
+
+const (
+	defaultApicastManagementAPI = "status"
+	defaultApicastOpenSSLVerify = false
+	defaultApicastResponseCodes = true
+	defaultApicastRegistryURL   = "http://apicast-staging:8090/policies"
+)
+
 // APIManagerSpec defines the desired state of APIManager
 // +k8s:openapi-gen=true
 type APIManagerSpec struct {
@@ -323,29 +337,29 @@ func (apimanager *APIManager) setApicastSpecDefaults() bool {
 	changed := false
 	spec := &apimanager.Spec
 
-	defaultApicastManagementAPI := "status"
-	defaultApicastOpenSSLVerify := false
-	defaultApicastResponseCodes := true
-	defaultApicastRegistryURL := "http://apicast-staging:8090/policies"
+	tmpDefaultApicastManagementAPI := defaultApicastManagementAPI
+	tmpDefaultApicastOpenSSLVerify := defaultApicastOpenSSLVerify
+	tmpDefaultApicastResponseCodes := defaultApicastResponseCodes
+	tmpDefaultApicastRegistryURL := defaultApicastRegistryURL
 	if spec.Apicast == nil {
 		spec.Apicast = &ApicastSpec{}
 		changed = true
 	}
 
 	if spec.Apicast.ApicastManagementAPI == nil {
-		spec.Apicast.ApicastManagementAPI = &defaultApicastManagementAPI
+		spec.Apicast.ApicastManagementAPI = &tmpDefaultApicastManagementAPI
 		changed = true
 	}
 	if spec.Apicast.OpenSSLVerify == nil {
-		spec.Apicast.OpenSSLVerify = &defaultApicastOpenSSLVerify
+		spec.Apicast.OpenSSLVerify = &tmpDefaultApicastOpenSSLVerify
 		changed = true
 	}
 	if spec.Apicast.IncludeResponseCodes == nil {
-		spec.Apicast.IncludeResponseCodes = &defaultApicastResponseCodes
+		spec.Apicast.IncludeResponseCodes = &tmpDefaultApicastResponseCodes
 		changed = true
 	}
 	if spec.Apicast.RegistryURL == nil {
-		spec.Apicast.RegistryURL = &defaultApicastRegistryURL
+		spec.Apicast.RegistryURL = &tmpDefaultApicastRegistryURL
 		changed = true
 	}
 
@@ -423,28 +437,28 @@ func (apimanager *APIManager) setAPIManagerCommonSpecDefaults() bool {
 	changed := false
 	spec := &apimanager.Spec
 
-	defaultAppLabel := "3scale-api-management"
-	defaultTenantName := "3scale"
-	defaultImageStreamTagImportInsecure := false
-	defaultResourceRequirementsEnabled := true
+	tmpDefaultAppLabel := defaultAppLabel
+	tmpDefaultTenantName := defaultTenantName
+	tmpDefaultImageStreamTagImportInsecure := defaultImageStreamImportInsecure
+	tmpDefaultResourceRequirementsEnabled := defaultResourceRequirementsEnabled
 
 	if spec.AppLabel == nil {
-		spec.AppLabel = &defaultAppLabel
+		spec.AppLabel = &tmpDefaultAppLabel
 		changed = true
 	}
 
 	if spec.TenantName == nil {
-		spec.TenantName = &defaultTenantName
+		spec.TenantName = &tmpDefaultTenantName
 		changed = true
 	}
 
 	if spec.ImageStreamTagImportInsecure == nil {
-		spec.ImageStreamTagImportInsecure = &defaultImageStreamTagImportInsecure
+		spec.ImageStreamTagImportInsecure = &tmpDefaultImageStreamTagImportInsecure
 		changed = true
 	}
 
 	if spec.ResourceRequirementsEnabled == nil {
-		spec.ResourceRequirementsEnabled = &defaultResourceRequirementsEnabled
+		spec.ResourceRequirementsEnabled = &tmpDefaultResourceRequirementsEnabled
 		changed = true
 	}
 

--- a/pkg/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types_test.go
@@ -1,0 +1,113 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetDefaults(t *testing.T) {
+	tmpDefaultAppLabel := defaultAppLabel
+	tmpDefaultTenantName := defaultTenantName
+	tmpDefaultImageStreamTagImportInsecure := defaultImageStreamImportInsecure
+	tmpDefaultResourceRequirementsEnabled := defaultResourceRequirementsEnabled
+	tmpDefaultApicastManagementAPI := defaultApicastManagementAPI
+	tmpDefaultApicastOpenSSLVerify := defaultApicastOpenSSLVerify
+	tmpDefaultApicastResponseCodes := defaultApicastResponseCodes
+	tmpDefaultApicastRegistryURL := defaultApicastRegistryURL
+
+	var tmpDefaultReplicas int64 = 1
+
+	inputAPIManager := APIManager{
+		Spec: APIManagerSpec{
+			APIManagerCommonSpec: APIManagerCommonSpec{
+				WildcardDomain: "test.3scale.com",
+			},
+		},
+	}
+	expectedAPIManager := APIManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				OperatorVersionAnnotation:   version.Version,
+				ThreescaleVersionAnnotation: product.ThreescaleRelease,
+			},
+		},
+		Spec: APIManagerSpec{
+			APIManagerCommonSpec: APIManagerCommonSpec{
+				WildcardDomain:               "test.3scale.com",
+				AppLabel:                     &tmpDefaultAppLabel,
+				TenantName:                   &tmpDefaultTenantName,
+				ImageStreamTagImportInsecure: &tmpDefaultImageStreamTagImportInsecure,
+				ResourceRequirementsEnabled:  &tmpDefaultResourceRequirementsEnabled,
+			},
+			Apicast: &ApicastSpec{
+				IncludeResponseCodes: &tmpDefaultApicastResponseCodes,
+				ApicastManagementAPI: &tmpDefaultApicastManagementAPI,
+				OpenSSLVerify:        &tmpDefaultApicastOpenSSLVerify,
+				RegistryURL:          &tmpDefaultApicastRegistryURL,
+				ProductionSpec: &ApicastProductionSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+				StagingSpec: &ApicastStagingSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+			},
+			Backend: &BackendSpec{
+				ListenerSpec: &BackendListenerSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+				WorkerSpec: &BackendWorkerSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+				CronSpec: &BackendCronSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+			},
+			System: &SystemSpec{
+				AppSpec: &SystemAppSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+				DatabaseSpec: &SystemDatabaseSpec{
+					MySQL: &SystemMySQLSpec{},
+				},
+				FileStorageSpec: &SystemFileStorageSpec{
+					PVC: &SystemPVCSpec{},
+				},
+				SidekiqSpec: &SystemSidekiqSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+			},
+			Zync: &ZyncSpec{
+				AppSpec: &ZyncAppSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+				QueSpec: &ZyncQueSpec{
+					Replicas: &tmpDefaultReplicas,
+				},
+			},
+		},
+	}
+
+	tmpInput := inputAPIManager.DeepCopy()
+	t.Run("BasicDefaults", testBasicAPIManagerDefaults(tmpInput, &expectedAPIManager))
+}
+
+func testBasicAPIManagerDefaults(input, expected *APIManager) func(t *testing.T) {
+	return func(t *testing.T) {
+		changed, err := input.SetDefaults()
+		if !changed {
+			t.Errorf("Expected introduced APIManager defaults changed")
+		}
+		if err != nil {
+			t.Errorf("Expected not an error being returned")
+		}
+		if !reflect.DeepEqual(input, expected) {
+			t.Errorf("Resulting APIManager differs from the expected one. Differences are: (%s)", cmp.Diff(input, expected))
+		}
+	}
+}


### PR DESCRIPTION
This PR prepares project to execute unit tests via Makefile and integrated into CircleCI and adds basic unit tests for APIManager types