### PR TITLE
storage and database defaults refactor

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -935,7 +935,7 @@ func (system *System) sidekiqContainerVolumeMounts() []v1.VolumeMount {
 }
 
 func (system *System) SharedStorage() *v1.PersistentVolumeClaim {
-	res := &v1.PersistentVolumeClaim{
+	return &v1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
@@ -949,7 +949,7 @@ func (system *System) SharedStorage() *v1.PersistentVolumeClaim {
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			StorageClassName: system.Options.storageClassName,
+			StorageClassName: system.Options.pvcFileStorageOptions.StorageClass,
 			AccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteMany,
 			},
@@ -960,12 +960,6 @@ func (system *System) SharedStorage() *v1.PersistentVolumeClaim {
 			},
 		},
 	}
-
-	if system.Options.pvcFileStorageOptions != nil {
-		res.Spec.StorageClassName = system.Options.storageClassName
-	}
-
-	return res
 }
 
 func (system *System) ProviderService() *v1.Service {

--- a/pkg/3scale/amp/component/system_options_builder.go
+++ b/pkg/3scale/amp/component/system_options_builder.go
@@ -75,8 +75,6 @@ type SystemOptions struct {
 	backendSharedSecret string
 	tenantName          string
 	wildcardDomain      string
-	storageClassName    *string // should this be a string or *string? check what would be the difference between passing a "" and a nil pointer in the PersistentVolumeClaim corresponding field
-
 	smtpSecretOptions SystemSMTPSecretOptions
 }
 
@@ -154,10 +152,6 @@ func (s *SystemOptionsBuilder) TenantName(tenantName string) {
 
 func (s *SystemOptionsBuilder) WildcardDomain(wildcardDomain string) {
 	s.options.wildcardDomain = wildcardDomain
-}
-
-func (s *SystemOptionsBuilder) StorageClassName(storageClassName *string) {
-	s.options.storageClassName = storageClassName
 }
 
 func (s *SystemOptionsBuilder) MemcachedServers(servers *string) {
@@ -304,10 +298,6 @@ func (s *SystemOptionsBuilder) setRequiredOptions() error {
 	}
 	if s.options.wildcardDomain == "" {
 		return fmt.Errorf("no wildcard domain has been provided")
-	}
-
-	if s.options.s3FileStorageOptions == nil && s.options.pvcFileStorageOptions == nil {
-		s.options.pvcFileStorageOptions = &PVCFileStorageOptions{}
 	}
 
 	return nil

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -249,14 +249,6 @@ func (o *OperatorSystemOptionsProvider) setResourceRequirementsOptions(b *compon
 func (o *OperatorSystemOptionsProvider) setFileStorageOptions(b *component.SystemOptionsBuilder) {
 	if o.APIManagerSpec.System != nil &&
 		o.APIManagerSpec.System.FileStorageSpec != nil &&
-		o.APIManagerSpec.System.FileStorageSpec.PVC != nil {
-		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
-			StorageClass: o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName,
-		})
-	}
-
-	if o.APIManagerSpec.System != nil &&
-		o.APIManagerSpec.System.FileStorageSpec != nil &&
 		o.APIManagerSpec.System.FileStorageSpec.S3 != nil {
 		s3FileStorageSpec := o.APIManagerSpec.System.FileStorageSpec.S3
 		b.S3FileStorageOptions(component.S3FileStorageOptions{
@@ -265,6 +257,18 @@ func (o *OperatorSystemOptionsProvider) setFileStorageOptions(b *component.Syste
 			AWSRegion:            s3FileStorageSpec.AWSRegion,
 			AWSBucket:            s3FileStorageSpec.AWSBucket,
 			AWSCredentialsSecret: s3FileStorageSpec.AWSCredentials.Name,
+		})
+	} else {
+		// default to PVC
+		var storageClass *string
+		if o.APIManagerSpec.System != nil &&
+			o.APIManagerSpec.System.FileStorageSpec != nil &&
+			o.APIManagerSpec.System.FileStorageSpec.PVC != nil {
+			storageClass = o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName
+		}
+
+		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
+			StorageClass: storageClass,
 		})
 	}
 }

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -247,13 +247,17 @@ func (o *OperatorSystemOptionsProvider) setResourceRequirementsOptions(b *compon
 }
 
 func (o *OperatorSystemOptionsProvider) setFileStorageOptions(b *component.SystemOptionsBuilder) {
-	if o.APIManagerSpec.System.FileStorageSpec.PVC != nil {
+	if o.APIManagerSpec.System != nil &&
+		o.APIManagerSpec.System.FileStorageSpec != nil &&
+		o.APIManagerSpec.System.FileStorageSpec.PVC != nil {
 		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
 			StorageClass: o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName,
 		})
 	}
 
-	if o.APIManagerSpec.System.FileStorageSpec.S3 != nil {
+	if o.APIManagerSpec.System != nil &&
+		o.APIManagerSpec.System.FileStorageSpec != nil &&
+		o.APIManagerSpec.System.FileStorageSpec.S3 != nil {
 		s3FileStorageSpec := o.APIManagerSpec.System.FileStorageSpec.S3
 		b.S3FileStorageOptions(component.S3FileStorageOptions{
 			AWSAccessKeyId:       "",

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -22,12 +22,6 @@ func (o *OperatorSystemOptionsProvider) GetSystemOptions() (*component.SystemOpt
 	optProv.TenantName(*o.APIManagerSpec.TenantName)
 	optProv.WildcardDomain(o.APIManagerSpec.WildcardDomain)
 
-	if o.APIManagerSpec.System.FileStorageSpec.PVC == nil {
-		optProv.StorageClassName(nil)
-	} else {
-		optProv.StorageClassName(o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName)
-	}
-
 	err := o.setSecretBasedOptions(&optProv)
 	if err != nil {
 		return nil, err
@@ -253,18 +247,20 @@ func (o *OperatorSystemOptionsProvider) setResourceRequirementsOptions(b *compon
 }
 
 func (o *OperatorSystemOptionsProvider) setFileStorageOptions(b *component.SystemOptionsBuilder) {
-	s3FileStorageSpec := o.APIManagerSpec.System.FileStorageSpec.S3
-	if s3FileStorageSpec != nil {
+	if o.APIManagerSpec.System.FileStorageSpec.PVC != nil {
+		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
+			StorageClass: o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName,
+		})
+	}
+
+	if o.APIManagerSpec.System.FileStorageSpec.S3 != nil {
+		s3FileStorageSpec := o.APIManagerSpec.System.FileStorageSpec.S3
 		b.S3FileStorageOptions(component.S3FileStorageOptions{
 			AWSAccessKeyId:       "",
 			AWSSecretAccessKey:   "",
 			AWSRegion:            s3FileStorageSpec.AWSRegion,
 			AWSBucket:            s3FileStorageSpec.AWSBucket,
 			AWSCredentialsSecret: s3FileStorageSpec.AWSCredentials.Name,
-		})
-	} else { // PVC by default
-		b.PVCFileStorageOptions(component.PVCFileStorageOptions{
-			StorageClass: o.APIManagerSpec.System.FileStorageSpec.PVC.StorageClassName,
 		})
 	}
 }

--- a/pkg/3scale/amp/operator/system_mysql_image.go
+++ b/pkg/3scale/amp/operator/system_mysql_image.go
@@ -12,7 +12,9 @@ func (o *OperatorSystemMySQLImageOptionsProvider) GetSystemMySQLImageOptions() (
 
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 	optProv.AmpRelease(product.ThreescaleRelease)
-	if o.APIManagerSpec.System.DatabaseSpec.MySQL != nil && o.APIManagerSpec.System.DatabaseSpec.MySQL.Image != nil {
+	if o.APIManagerSpec.System.DatabaseSpec != nil &&
+		o.APIManagerSpec.System.DatabaseSpec.MySQL != nil &&
+		o.APIManagerSpec.System.DatabaseSpec.MySQL.Image != nil {
 		optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.MySQL.Image)
 	} else {
 		optProv.Image(component.SystemMySQLImageURL())

--- a/pkg/3scale/amp/operator/system_mysql_image.go
+++ b/pkg/3scale/amp/operator/system_mysql_image.go
@@ -12,7 +12,7 @@ func (o *OperatorSystemMySQLImageOptionsProvider) GetSystemMySQLImageOptions() (
 
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 	optProv.AmpRelease(product.ThreescaleRelease)
-	if o.APIManagerSpec.System.DatabaseSpec.MySQL.Image != nil {
+	if o.APIManagerSpec.System.DatabaseSpec.MySQL != nil && o.APIManagerSpec.System.DatabaseSpec.MySQL.Image != nil {
 		optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.MySQL.Image)
 	} else {
 		optProv.Image(component.SystemMySQLImageURL())

--- a/pkg/3scale/amp/operator/system_postgresql_image.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image.go
@@ -11,7 +11,9 @@ func (o *OperatorSystemPostgreSQLImageOptionsProvider) GetSystemPostgreSQLImageO
 	optProv := component.SystemPostgreSQLImageOptionsBuilder{}
 	optProv.AppLabel(*o.APIManagerSpec.AppLabel)
 	optProv.AmpRelease(product.ThreescaleRelease)
-	if o.APIManagerSpec.System.DatabaseSpec.PostgreSQL.Image != nil {
+	if o.APIManagerSpec.System.DatabaseSpec != nil &&
+		o.APIManagerSpec.System.DatabaseSpec.PostgreSQL != nil &&
+		o.APIManagerSpec.System.DatabaseSpec.PostgreSQL.Image != nil {
 		optProv.Image(*o.APIManagerSpec.System.DatabaseSpec.PostgreSQL.Image)
 	} else {
 		optProv.Image(component.SystemPostgreSQLImageURL())

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -114,19 +114,13 @@ func NewSystemReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicReconc
 }
 
 func (r *SystemReconciler) reconcileFileStorage(system *component.System) error {
-	if r.apiManager.Spec.System.FileStorageSpec.PVC != nil && r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
-		return fmt.Errorf("Only one system FileStorage can be chosen at the same time")
+	if r.apiManager.Spec.System != nil &&
+		r.apiManager.Spec.System.FileStorageSpec != nil &&
+		r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
+		return r.reconcileS3AWSSecret(system.S3AWSSecret())
 	}
 
-	var err error
-	if r.apiManager.Spec.System.FileStorageSpec.PVC != nil {
-		err = r.reconcileSharedStorage(system.SharedStorage())
-	} else if r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
-		err = r.reconcileS3AWSSecret(system.S3AWSSecret())
-	} else {
-		err = fmt.Errorf("No FileStorage spec specified. FileStorage is mandatory")
-	}
-	return err
+	return r.reconcileSharedStorage(system.SharedStorage())
 }
 
 func (r *SystemReconciler) reconcileS3AWSSecret(desiredSecret *v1.Secret) error {

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -114,8 +114,7 @@ func NewSystemReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicReconc
 }
 
 func (r *SystemReconciler) reconcileFileStorage(system *component.System) error {
-	if r.apiManager.Spec.System != nil &&
-		r.apiManager.Spec.System.FileStorageSpec != nil &&
+	if r.apiManager.Spec.System.FileStorageSpec != nil &&
 		r.apiManager.Spec.System.FileStorageSpec.S3 != nil {
 		return r.reconcileS3AWSSecret(system.S3AWSSecret())
 	}

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -281,15 +281,12 @@ func (u *UpgradeApiManager) upgradeSystemRedisImageStream() (reconcile.Result, e
 }
 
 func (u *UpgradeApiManager) upgradeSystemDatabaseImageStream() (reconcile.Result, error) {
-	if u.Cr.Spec.System.DatabaseSpec.MySQL != nil {
-		return u.upgradeSystemMySQLImageStream()
-	}
-
 	if u.Cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
 		return u.upgradeSystemPostgreSQLImageStream()
+	} else {
+		// default is MySQL
+		return u.upgradeSystemMySQLImageStream()
 	}
-
-	return reconcile.Result{}, fmt.Errorf("System database is not set")
 }
 
 func (u *UpgradeApiManager) upgradeSystemMySQLImageStream() (reconcile.Result, error) {

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -281,12 +281,12 @@ func (u *UpgradeApiManager) upgradeSystemRedisImageStream() (reconcile.Result, e
 }
 
 func (u *UpgradeApiManager) upgradeSystemDatabaseImageStream() (reconcile.Result, error) {
-	if u.Cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
+	if u.Cr.Spec.System.DatabaseSpec != nil && u.Cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
 		return u.upgradeSystemPostgreSQLImageStream()
-	} else {
-		// default is MySQL
-		return u.upgradeSystemMySQLImageStream()
 	}
+
+	// default is MySQL
+	return u.upgradeSystemMySQLImageStream()
 }
 
 func (u *UpgradeApiManager) upgradeSystemMySQLImageStream() (reconcile.Result, error) {

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -53,7 +53,7 @@ func (u *UpgradeApiManager) upgradeImages() (reconcile.Result, error) {
 		return res, err
 	}
 
-	if !u.highAvailabilityModeEnabled() {
+	if !u.IsExternalDatabaseEnabled() {
 		res, err = u.upgradeBackendRedisImageStream()
 		if res.Requeue || err != nil {
 			return res, err
@@ -254,10 +254,6 @@ func (u *UpgradeApiManager) ensureDeploymentConfigPodTemplateEnvVars(desired, ex
 	}
 
 	return changed, nil
-}
-
-func (u *UpgradeApiManager) highAvailabilityModeEnabled() bool {
-	return u.Cr.Spec.HighAvailability != nil && u.Cr.Spec.HighAvailability.Enabled
 }
 
 func (u *UpgradeApiManager) upgradeBackendRedisImageStream() (reconcile.Result, error) {

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -53,7 +53,7 @@ func (u *UpgradeApiManager) upgradeImages() (reconcile.Result, error) {
 		return res, err
 	}
 
-	if !u.IsExternalDatabaseEnabled() {
+	if !u.Cr.IsExternalDatabaseEnabled() {
 		res, err = u.upgradeBackendRedisImageStream()
 		if res.Requeue || err != nil {
 			return res, err

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -161,6 +161,6 @@ func (s *System) options() (*component.SystemOptions, error) {
 	sob.BackendSharedSecret("${SYSTEM_BACKEND_SHARED_SECRET}")
 	sob.TenantName("${TENANT_NAME}")
 	sob.WildcardDomain("${WILDCARD_DOMAIN}")
-	sob.StorageClassName(nil)
+	sob.PVCFileStorageOptions(component.PVCFileStorageOptions{StorageClass: nil})
 	return sob.Build()
 }

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/version"
 	"github.com/RHsyseng/operator-utils/pkg/olm"
@@ -469,7 +467,6 @@ func (apimanager *APIManager) setAPIManagerCommonSpecDefaults() bool {
 }
 
 func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
-	// TODO fix how should be shown
 	changed := false
 	spec := &apimanager.Spec
 
@@ -478,17 +475,11 @@ func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
 		changed = true
 	}
 
-	tmpChanged, err := apimanager.setSystemFileStorageSpecDefaults()
+	tmpChanged := apimanager.setSystemFileStorageSpecDefaults()
 	changed = changed || tmpChanged
-	if err != nil {
-		return changed, err
-	}
 
-	tmpChanged, err = apimanager.setSystemDatabaseSpecDefaults()
+	tmpChanged = apimanager.setSystemDatabaseSpecDefaults()
 	changed = changed || tmpChanged
-	if err != nil {
-		return changed, err
-	}
 
 	if spec.System.AppSpec == nil {
 		spec.System.AppSpec = &SystemAppSpec{}
@@ -513,59 +504,36 @@ func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
 	return changed, nil
 }
 
-func (apimanager *APIManager) setSystemFileStorageSpecDefaults() (bool, error) {
+func (apimanager *APIManager) setSystemFileStorageSpecDefaults() bool {
 	changed := false
 	systemSpec := apimanager.Spec.System
-
-	defaultFileStorageSpec := &SystemFileStorageSpec{
-		PVC: &SystemPVCSpec{
-			StorageClassName: nil,
-		},
-	}
 
 	if systemSpec.FileStorageSpec == nil {
-		systemSpec.FileStorageSpec = defaultFileStorageSpec
-		changed = true
-		return changed, nil
-	}
-
-	if systemSpec.FileStorageSpec.PVC != nil && systemSpec.FileStorageSpec.S3 != nil {
-		return changed, fmt.Errorf("Only one FileStorage can be chosen at the same time")
-	}
-
-	if systemSpec.FileStorageSpec.PVC == nil && systemSpec.FileStorageSpec.S3 == nil {
-		systemSpec.FileStorageSpec.PVC = defaultFileStorageSpec.PVC
+		systemSpec.FileStorageSpec = &SystemFileStorageSpec{}
 		changed = true
 	}
 
-	return changed, nil
+	// No default values for S3
+	// PVC
+	if systemSpec.FileStorageSpec.PVC == nil {
+		systemSpec.FileStorageSpec.PVC = &SystemPVCSpec{}
+		changed = true
+		// StorageClassName default value is nil
+	}
+
+	return changed
 }
 
-func (apimanager *APIManager) setSystemDatabaseSpecDefaults() (bool, error) {
+func (apimanager *APIManager) setSystemDatabaseSpecDefaults() bool {
 	changed := false
 	systemSpec := apimanager.Spec.System
 
-	defaultDatabaseSpec := &SystemDatabaseSpec{
-		MySQL: &SystemMySQLSpec{
-			Image: nil,
-		},
-	}
-
 	if systemSpec.DatabaseSpec == nil {
-		systemSpec.DatabaseSpec = defaultDatabaseSpec
+		systemSpec.DatabaseSpec = &SystemDatabaseSpec{}
 		changed = true
-		return changed, nil
 	}
 
-	if systemSpec.DatabaseSpec.MySQL != nil && systemSpec.DatabaseSpec.PostgreSQL != nil {
-		return changed, fmt.Errorf("Only one System Database can be chosen at the same time")
-	}
-
-	if systemSpec.DatabaseSpec.MySQL == nil && systemSpec.DatabaseSpec.PostgreSQL == nil {
-		systemSpec.DatabaseSpec.MySQL = defaultDatabaseSpec.MySQL
-	}
-
-	return changed, nil
+	return changed
 }
 
 func (apimanager *APIManager) setZyncDefaults() bool {
@@ -597,4 +565,8 @@ func (apimanager *APIManager) setZyncDefaults() bool {
 	}
 
 	return changed
+}
+
+func (apimanager *APIManager) IsExternalDatabaseEnabled() bool {
+	return apimanager.Spec.HighAvailability != nil && apimanager.Spec.HighAvailability.Enabled
 }

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -515,7 +515,7 @@ func (apimanager *APIManager) setSystemFileStorageSpecDefaults() bool {
 
 	// No default values for S3
 	// PVC
-	if systemSpec.FileStorageSpec.PVC == nil {
+	if systemSpec.FileStorageSpec.S3 == nil && systemSpec.FileStorageSpec.PVC == nil {
 		systemSpec.FileStorageSpec.PVC = &SystemPVCSpec{}
 		changed = true
 		// StorageClassName default value is nil

--- a/pkg/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types_test.go
@@ -72,10 +72,6 @@ func TestSetDefaults(t *testing.T) {
 				AppSpec: &SystemAppSpec{
 					Replicas: &tmpDefaultReplicas,
 				},
-				DatabaseSpec: &SystemDatabaseSpec{},
-				FileStorageSpec: &SystemFileStorageSpec{
-					PVC: &SystemPVCSpec{},
-				},
 				SidekiqSpec: &SystemSidekiqSpec{
 					Replicas: &tmpDefaultReplicas,
 				},

--- a/pkg/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types_test.go
@@ -72,9 +72,7 @@ func TestSetDefaults(t *testing.T) {
 				AppSpec: &SystemAppSpec{
 					Replicas: &tmpDefaultReplicas,
 				},
-				DatabaseSpec: &SystemDatabaseSpec{
-					MySQL: &SystemMySQLSpec{},
-				},
+				DatabaseSpec: &SystemDatabaseSpec{},
 				FileStorageSpec: &SystemFileStorageSpec{
 					PVC: &SystemPVCSpec{},
 				},

--- a/pkg/controller/apimanager/apimanager_controller.go
+++ b/pkg/controller/apimanager/apimanager_controller.go
@@ -296,22 +296,12 @@ func (r *ReconcileAPIManager) reconcileBackendLogic(cr *appsv1alpha1.APIManager)
 }
 
 func (r *ReconcileAPIManager) reconcileSystemDatabaseLogic(cr *appsv1alpha1.APIManager) (reconcile.Result, error) {
-	if cr.Spec.System.DatabaseSpec.PostgreSQL != nil && cr.Spec.System.DatabaseSpec.MySQL != nil {
-		return reconcile.Result{}, fmt.Errorf("Only one System Database can be chosen at the same time")
+	if cr.Spec.System.DatabaseSpec != nil && cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
+		return r.reconcileSystemPostgreSQLLogic(cr)
 	}
 
-	var res reconcile.Result
-	var err error
-
-	if cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
-		res, err = r.reconcileSystemPostgreSQLLogic(cr)
-	} else {
-		// By default, Mysql
-		// cr.Spec.System.DatabaseSpec.MySQL can be nil Mysql
-		res, err = r.reconcileSystemMySQLLogic(cr)
-	}
-
-	return res, err
+	// Defaults to MySQL
+	return r.reconcileSystemMySQLLogic(cr)
 }
 
 func (r *ReconcileAPIManager) reconcileSystemPostgreSQLLogic(cr *appsv1alpha1.APIManager) (reconcile.Result, error) {


### PR DESCRIPTION
* Fix storageClassName property location
* CR databases defaults cannot be `mysql`. When external databases are configured, this leads to inconsistent information. Changed defaults set for the CR. Mysql is still the *default* database if none configured
* CR storage defaults removed. PVC is still the *default* storage if none configured
* Upgrade procedure to remove databases and storage defaults 