### PR TITLE
Move system smtp to secret

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -326,3 +326,15 @@ existing secret names.
 | --- | --- | --- |
 | AWS_ACCESS_KEY_ID | AWS Access Key ID to use in S3 Storage for System's file storage | N/A |
 | AWS_SECRET_ACCESS_KEY | AWS Access Key Secret to use in S3 Storage for System's file storage | N/A |
+
+#### system-smtp
+
+| **Field** | **Description** | **Default value** |
+| --- | --- | --- |
+| address | Address (hostname or IP) of the remote mail server to use. If set to a value different than `""` System will use the mail server to send mails related to events that happen in the API management solution |  `""` |
+| port | Port of the remote mail server to use | `""` |
+| domain | In case the mail server requires a HELO domain | `""` |
+| authentication | In case the mail server requires authentication, set this setting to the authentication type here. `plain` to send the password in the clear, `login` to send password Base64 encoded, or `cram_md5` to combine a Challenge/Response mechanism based on the HMAC-MD5 algorithm | `""` |
+| username | In case the mail server requires authentication and the authentication type requires it | `""` |
+| password | In case the mail server requires authentication and the authentication type requires it | `""` |
+| openssl.verify.mode | When using TLS, you can set how OpenSSL checks the certificate. This is really useful if you need to validate a self-signed and/or a wildcard certificate. You can use the name of an OpenSSL verify constant: `none` or `peer` | `""` |

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1551,7 +1551,15 @@ objects:
       threescale_component: system
     name: system
 - apiVersion: v1
-  data:
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
+    name: system-smtp
+  stringData:
     address: ""
     authentication: ""
     domain: ""
@@ -1559,14 +1567,6 @@ objects:
     password: ""
     port: ""
     username: ""
-  kind: ConfigMap
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-      threescale_component_element: smtp
-    name: smtp
 - apiVersion: v1
   data:
     AMP_RELEASE: ${AMP_RELEASE}
@@ -1822,39 +1822,39 @@ objects:
                   name: backend-listener
             - name: SMTP_ADDRESS
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: address
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_USER_NAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_DOMAIN
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: domain
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PORT
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: port
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_AUTHENTICATION
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: authentication
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_OPENSSL_VERIFY_MODE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: openssl.verify.mode
-                  name: smtp
+                  name: system-smtp
             - name: APICAST_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -2126,39 +2126,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2441,39 +2441,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2755,39 +2755,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -3128,39 +3128,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1568,7 +1568,15 @@ objects:
       threescale_component: system
     name: system
 - apiVersion: v1
-  data:
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
+    name: system-smtp
+  stringData:
     address: ""
     authentication: ""
     domain: ""
@@ -1576,14 +1584,6 @@ objects:
     password: ""
     port: ""
     username: ""
-  kind: ConfigMap
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-      threescale_component_element: smtp
-    name: smtp
 - apiVersion: v1
   data:
     AMP_RELEASE: ${AMP_RELEASE}
@@ -1836,39 +1836,39 @@ objects:
                   name: backend-listener
             - name: SMTP_ADDRESS
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: address
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_USER_NAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_DOMAIN
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: domain
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PORT
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: port
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_AUTHENTICATION
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: authentication
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_OPENSSL_VERIFY_MODE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: openssl.verify.mode
-                  name: smtp
+                  name: system-smtp
             - name: APICAST_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -2117,39 +2117,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2409,39 +2409,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2700,39 +2700,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -3054,39 +3054,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -997,7 +997,15 @@ objects:
       threescale_component: system
     name: system
 - apiVersion: v1
-  data:
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
+    name: system-smtp
+  stringData:
     address: ""
     authentication: ""
     domain: ""
@@ -1005,14 +1013,6 @@ objects:
     password: ""
     port: ""
     username: ""
-  kind: ConfigMap
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-      threescale_component_element: smtp
-    name: smtp
 - apiVersion: v1
   data:
     AMP_RELEASE: ${AMP_RELEASE}
@@ -1265,39 +1265,39 @@ objects:
                   name: backend-listener
             - name: SMTP_ADDRESS
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: address
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_USER_NAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_DOMAIN
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: domain
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PORT
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: port
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_AUTHENTICATION
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: authentication
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_OPENSSL_VERIFY_MODE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: openssl.verify.mode
-                  name: smtp
+                  name: system-smtp
             - name: APICAST_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -1546,39 +1546,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -1844,39 +1844,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2141,39 +2141,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2501,39 +2501,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1560,7 +1560,15 @@ objects:
       threescale_component: system
     name: system
 - apiVersion: v1
-  data:
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
+    name: system-smtp
+  stringData:
     address: ""
     authentication: ""
     domain: ""
@@ -1568,14 +1576,6 @@ objects:
     password: ""
     port: ""
     username: ""
-  kind: ConfigMap
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-      threescale_component_element: smtp
-    name: smtp
 - apiVersion: v1
   data:
     AMP_RELEASE: ${AMP_RELEASE}
@@ -1828,39 +1828,39 @@ objects:
                   name: backend-listener
             - name: SMTP_ADDRESS
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: address
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_USER_NAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_DOMAIN
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: domain
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PORT
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: port
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_AUTHENTICATION
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: authentication
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_OPENSSL_VERIFY_MODE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: openssl.verify.mode
-                  name: smtp
+                  name: system-smtp
             - name: APICAST_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -2109,39 +2109,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2407,39 +2407,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2704,39 +2704,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -3064,39 +3064,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1592,7 +1592,15 @@ objects:
       threescale_component: system
     name: system
 - apiVersion: v1
-  data:
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
+    name: system-smtp
+  stringData:
     address: ""
     authentication: ""
     domain: ""
@@ -1600,14 +1608,6 @@ objects:
     password: ""
     port: ""
     username: ""
-  kind: ConfigMap
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-      threescale_component_element: smtp
-    name: smtp
 - apiVersion: v1
   data:
     AMP_RELEASE: ${AMP_RELEASE}
@@ -1863,39 +1863,39 @@ objects:
                   name: backend-listener
             - name: SMTP_ADDRESS
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: address
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_USER_NAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_DOMAIN
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: domain
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PORT
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: port
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_AUTHENTICATION
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: authentication
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_OPENSSL_VERIFY_MODE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: openssl.verify.mode
-                  name: smtp
+                  name: system-smtp
             - name: APICAST_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -2167,39 +2167,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2488,39 +2488,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2808,39 +2808,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -3187,39 +3187,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1609,7 +1609,15 @@ objects:
       threescale_component: system
     name: system
 - apiVersion: v1
-  data:
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+      threescale_component_element: smtp
+    name: system-smtp
+  stringData:
     address: ""
     authentication: ""
     domain: ""
@@ -1617,14 +1625,6 @@ objects:
     password: ""
     port: ""
     username: ""
-  kind: ConfigMap
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-      threescale_component_element: smtp
-    name: smtp
 - apiVersion: v1
   data:
     AMP_RELEASE: ${AMP_RELEASE}
@@ -1877,39 +1877,39 @@ objects:
                   name: backend-listener
             - name: SMTP_ADDRESS
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: address
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_USER_NAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_DOMAIN
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: domain
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_PORT
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: port
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_AUTHENTICATION
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: authentication
-                  name: smtp
+                  name: system-smtp
             - name: SMTP_OPENSSL_VERIFY_MODE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: openssl.verify.mode
-                  name: smtp
+                  name: system-smtp
             - name: APICAST_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -2158,39 +2158,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2456,39 +2456,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -2753,39 +2753,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -3113,39 +3113,39 @@ objects:
                 name: backend-listener
           - name: SMTP_ADDRESS
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: address
-                name: smtp
+                name: system-smtp
           - name: SMTP_USER_NAME
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: username
-                name: smtp
+                name: system-smtp
           - name: SMTP_PASSWORD
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: password
-                name: smtp
+                name: system-smtp
           - name: SMTP_DOMAIN
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: domain
-                name: smtp
+                name: system-smtp
           - name: SMTP_PORT
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: port
-                name: smtp
+                name: system-smtp
           - name: SMTP_AUTHENTICATION
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: authentication
-                name: smtp
+                name: system-smtp
           - name: SMTP_OPENSSL_VERIFY_MODE
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 key: openssl.verify.mode
-                name: smtp
+                name: system-smtp
           - name: APICAST_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/component/system_options_builder.go
+++ b/pkg/3scale/amp/component/system_options_builder.go
@@ -15,6 +15,16 @@ type S3FileStorageOptions struct {
 	AWSCredentialsSecret string
 }
 
+type SystemSMTPSecretOptions struct {
+	Address           string
+	Authentication    string
+	Domain            string
+	OpenSSLVerifyMode string
+	Password          string
+	Port              string
+	Username          string
+}
+
 type PVCFileStorageOptions struct {
 	StorageClass *string
 }
@@ -66,6 +76,8 @@ type SystemOptions struct {
 	tenantName          string
 	wildcardDomain      string
 	storageClassName    *string // should this be a string or *string? check what would be the difference between passing a "" and a nil pointer in the PersistentVolumeClaim corresponding field
+
+	smtpSecretOptions SystemSMTPSecretOptions
 }
 
 type SystemOptionsBuilder struct {
@@ -230,6 +242,10 @@ func (s *SystemOptionsBuilder) AppReplicas(replicas int32) {
 
 func (s *SystemOptionsBuilder) SidekiqReplicas(replicas int32) {
 	s.options.sidekiqReplicas = &replicas
+}
+
+func (s *SystemOptionsBuilder) SystemSMTPSecretOptions(options SystemSMTPSecretOptions) {
+	s.options.smtpSecretOptions = options
 }
 
 func (s *SystemOptionsBuilder) Build() (*SystemOptions, error) {

--- a/pkg/3scale/amp/operator/backend.go
+++ b/pkg/3scale/amp/operator/backend.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8s.io/api/core/v1"
@@ -60,45 +61,45 @@ func (o *OperatorBackendOptionsProvider) setBackendInternalApiOptions(b *compone
 	defaultSystemBackendUsername := "3scale_api_user"
 	defaultSystemBackendPassword := oprand.String(8)
 
-	currSecret, err := getSecret(component.BackendSecretInternalApiSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.BackendSecretInternalApiSecretName, o.Namespace, o.Client)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
 	// when secret is not found, it behaves like an empty secret
 	secretData := currSecret.Data
-	b.SystemBackendUsername(getSecretDataValueOrDefault(secretData, component.BackendSecretInternalApiUsernameFieldName, defaultSystemBackendUsername))
-	b.SystemBackendPassword(getSecretDataValueOrDefault(secretData, component.BackendSecretInternalApiPasswordFieldName, defaultSystemBackendPassword))
+	b.SystemBackendUsername(helper.GetSecretDataValueOrDefault(secretData, component.BackendSecretInternalApiUsernameFieldName, defaultSystemBackendUsername))
+	b.SystemBackendPassword(helper.GetSecretDataValueOrDefault(secretData, component.BackendSecretInternalApiPasswordFieldName, defaultSystemBackendPassword))
 
 	return nil
 }
 
 func (o *OperatorBackendOptionsProvider) setBackendListenerOptions(b *component.BackendOptionsBuilder) error {
-	currSecret, err := getSecret(component.BackendSecretBackendListenerSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.BackendSecretBackendListenerSecretName, o.Namespace, o.Client)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
 	secretData := currSecret.Data
-	b.ListenerServiceEndpoint(getSecretDataValue(secretData, component.BackendSecretBackendListenerServiceEndpointFieldName))
-	b.ListenerRouteEndpoint(getSecretDataValue(secretData, component.BackendSecretBackendListenerRouteEndpointFieldName))
+	b.ListenerServiceEndpoint(helper.GetSecretDataValue(secretData, component.BackendSecretBackendListenerServiceEndpointFieldName))
+	b.ListenerRouteEndpoint(helper.GetSecretDataValue(secretData, component.BackendSecretBackendListenerRouteEndpointFieldName))
 
 	return nil
 }
 
 func (o *OperatorBackendOptionsProvider) setBackendRedisOptions(b *component.BackendOptionsBuilder) error {
-	currSecret, err := getSecret(component.BackendSecretBackendRedisSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.BackendSecretBackendRedisSecretName, o.Namespace, o.Client)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
 	secretData := currSecret.Data
-	b.RedisStorageURL(getSecretDataValue(secretData, component.BackendSecretBackendRedisStorageURLFieldName))
-	b.RedisQueuesURL(getSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesURLFieldName))
-	b.RedisStorageSentinelHosts(getSecretDataValue(secretData, component.BackendSecretBackendRedisStorageSentinelHostsFieldName))
-	b.RedisStorageSentinelRole(getSecretDataValue(secretData, component.BackendSecretBackendRedisStorageSentinelRoleFieldName))
-	b.RedisQueuesSentinelHosts(getSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesSentinelHostsFieldName))
-	b.RedisQueuesSentinelRole(getSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesSentinelRoleFieldName))
+	b.RedisStorageURL(helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisStorageURLFieldName))
+	b.RedisQueuesURL(helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesURLFieldName))
+	b.RedisStorageSentinelHosts(helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisStorageSentinelHostsFieldName))
+	b.RedisStorageSentinelRole(helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisStorageSentinelRoleFieldName))
+	b.RedisQueuesSentinelHosts(helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesSentinelHostsFieldName))
+	b.RedisQueuesSentinelRole(helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesSentinelRoleFieldName))
 
 	return nil
 }

--- a/pkg/3scale/amp/operator/highavailability.go
+++ b/pkg/3scale/amp/operator/highavailability.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/helper"
 )
 
 func (o *OperatorHighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (*component.HighAvailabilityOptions, error) {
@@ -30,20 +31,20 @@ func (o *OperatorHighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (
 }
 
 func (o *OperatorHighAvailabilityOptionsProvider) setBackendRedisOptions(builder *component.HighAvailabilityOptionsBuilder) error {
-	currSecret, err := getSecret(component.BackendSecretBackendRedisSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.BackendSecretBackendRedisSecretName, o.Namespace, o.Client)
 	if err != nil {
 		return err
 	}
 
 	secretData := currSecret.Data
 	var result *string
-	result = getSecretDataValue(secretData, component.BackendSecretBackendRedisStorageURLFieldName)
+	result = helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisStorageURLFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.BackendSecretBackendRedisStorageURLFieldName, component.BackendSecretBackendRedisSecretName)
 	}
 	builder.BackendRedisStorageEndpoint(*result)
 
-	result = getSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesURLFieldName)
+	result = helper.GetSecretDataValue(secretData, component.BackendSecretBackendRedisQueuesURLFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.BackendSecretBackendRedisQueuesURLFieldName, component.BackendSecretBackendRedisSecretName)
 	}
@@ -53,20 +54,20 @@ func (o *OperatorHighAvailabilityOptionsProvider) setBackendRedisOptions(builder
 }
 
 func (o *OperatorHighAvailabilityOptionsProvider) setSystemRedisOptions(builder *component.HighAvailabilityOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemRedisSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemRedisSecretName, o.Namespace, o.Client)
 	if err != nil {
 		return err
 	}
 
 	secretData := currSecret.Data
 	var result *string
-	result = getSecretDataValue(secretData, component.SystemSecretSystemRedisURLFieldName)
+	result = helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisURLFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.SystemSecretSystemRedisURLFieldName, component.SystemSecretSystemRedisSecretName)
 	}
 	builder.SystemRedisURL(*result)
 
-	result = getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisURLFieldName)
+	result = helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisURLFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.SystemSecretSystemRedisMessageBusRedisURLFieldName, component.SystemSecretSystemRedisSecretName)
 	}
@@ -76,14 +77,14 @@ func (o *OperatorHighAvailabilityOptionsProvider) setSystemRedisOptions(builder 
 }
 
 func (o *OperatorHighAvailabilityOptionsProvider) setSystemDatabaseOptions(builder *component.HighAvailabilityOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemDatabaseSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemDatabaseSecretName, o.Namespace, o.Client)
 	if err != nil {
 		return err
 	}
 
 	secretData := currSecret.Data
 	var result *string
-	result = getSecretDataValue(secretData, component.SystemSecretSystemDatabaseURLFieldName)
+	result = helper.GetSecretDataValue(secretData, component.SystemSecretSystemDatabaseURLFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.SystemSecretSystemDatabaseURLFieldName, component.SystemSecretSystemDatabaseSecretName)
 	}

--- a/pkg/3scale/amp/operator/mysql.go
+++ b/pkg/3scale/amp/operator/mysql.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -39,7 +40,7 @@ func (o *OperatorMysqlOptionsProvider) setSecretBasedOptions(builder *component.
 }
 
 func (o *OperatorMysqlOptionsProvider) setSystemDatabaseOptions(builder *component.SystemMysqlOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemDatabaseSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemDatabaseSecretName, o.Namespace, o.Client)
 	defaultDatabaseName := "system"
 	defaultDatabaseRootPassword := oprand.String(8)
 	defaultDatabaseUsername := "mysql"
@@ -55,8 +56,8 @@ func (o *OperatorMysqlOptionsProvider) setSystemDatabaseOptions(builder *compone
 	// If a field of a secret already exists in the deployed secret then
 	// We do not modify it. Otherwise we set a default value
 	secretData := currSecret.Data
-	builder.User(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseUserFieldName, defaultDatabaseUsername))
-	builder.Password(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabasePasswordFieldName, defaultDatabasePassword))
+	builder.User(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseUserFieldName, defaultDatabaseUsername))
+	builder.Password(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabasePasswordFieldName, defaultDatabasePassword))
 	err = o.parseAndSetDatabaseURLAndParts(builder, secretData, defaultDatabaseURL)
 	if err != nil {
 		return err
@@ -65,7 +66,7 @@ func (o *OperatorMysqlOptionsProvider) setSystemDatabaseOptions(builder *compone
 }
 
 func (o *OperatorMysqlOptionsProvider) parseAndSetDatabaseURLAndParts(builder *component.SystemMysqlOptionsBuilder, secretData map[string][]byte, defaultDatabaseURL string) error {
-	resultURLStr := getSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseURLFieldName, defaultDatabaseURL)
+	resultURLStr := helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseURLFieldName, defaultDatabaseURL)
 	resultURL, err := o.systemDatabaseURLIsValid(resultURLStr)
 	if err != nil {
 		return err

--- a/pkg/3scale/amp/operator/mysql_test.go
+++ b/pkg/3scale/amp/operator/mysql_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,7 +27,7 @@ func getSystemDBSecret(namespace, databaseURL string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 

--- a/pkg/3scale/amp/operator/s3.go
+++ b/pkg/3scale/amp/operator/s3.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/helper"
 )
 
 func (o *OperatorS3OptionsProvider) GetS3Options() (*component.S3Options, error) {
@@ -35,7 +36,7 @@ func (o *OperatorS3OptionsProvider) setSecretBasedOptions(sob *component.S3Optio
 
 func (o *OperatorS3OptionsProvider) setAWSSecretOptions(sob *component.S3OptionsBuilder) error {
 	awsCredentialsSecretName := o.APIManagerSpec.System.FileStorageSpec.S3.AWSCredentials.Name
-	currSecret, err := getSecret(awsCredentialsSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(awsCredentialsSecretName, o.Namespace, o.Client)
 	if err != nil {
 		return err
 	}
@@ -44,13 +45,13 @@ func (o *OperatorS3OptionsProvider) setAWSSecretOptions(sob *component.S3Options
 	// We do not modify it. Otherwise we set a default value
 	secretData := currSecret.Data
 	var result *string
-	result = getSecretDataValue(secretData, component.S3SecretAWSAccessKeyIdFieldName)
+	result = helper.GetSecretDataValue(secretData, component.S3SecretAWSAccessKeyIdFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.S3SecretAWSAccessKeyIdFieldName, awsCredentialsSecretName)
 	}
 	sob.AwsAccessKeyId(*result)
 
-	result = getSecretDataValue(secretData, component.S3SecretAWSSecretAccessKeyFieldName)
+	result = helper.GetSecretDataValue(secretData, component.S3SecretAWSSecretAccessKeyFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.S3SecretAWSSecretAccessKeyFieldName, awsCredentialsSecretName)
 	}

--- a/pkg/3scale/amp/operator/s3_test.go
+++ b/pkg/3scale/amp/operator/s3_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/3scale/3scale-operator/pkg/helper"
+
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -22,7 +24,7 @@ func getTestSecret(namespace, secretName string, data map[string]string) *v1.Sec
 		StringData: data,
 		Type:       v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 

--- a/pkg/3scale/amp/operator/secret_reconciler_test.go
+++ b/pkg/3scale/amp/operator/secret_reconciler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/3scale/3scale-operator/pkg/helper"
+
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +41,7 @@ func TestDefaultsOnlySecretReconciler(t *testing.T) {
 			"a3": "a3Value",
 		},
 	}
-	existingSecret.Data = getSecretDataFromStringData(existingSecret.StringData)
+	existingSecret.Data = helper.GetSecretDataFromStringData(existingSecret.StringData)
 	if !defaultsOnlySecretReconciler.IsUpdateNeeded(desiredSecret, existingSecret) {
 		t.Fatal("when defaults can be applied, reconciler reported no update needed")
 	}
@@ -78,7 +80,7 @@ func TestDefaultsOnlySecretReconcilerNoUpdateNeeded(t *testing.T) {
 			"a2": "other_a2_value",
 		},
 	}
-	existingSecret.Data = getSecretDataFromStringData(existingSecret.StringData)
+	existingSecret.Data = helper.GetSecretDataFromStringData(existingSecret.StringData)
 	if defaultsOnlySecretReconciler.IsUpdateNeeded(desiredSecret, existingSecret) {
 		t.Fatal("when defaults cannot be applied, reconciler reported update needed")
 	}

--- a/pkg/3scale/amp/operator/system.go
+++ b/pkg/3scale/amp/operator/system.go
@@ -7,6 +7,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,19 +96,19 @@ func (o *OperatorSystemOptionsProvider) setSecretBasedOptions(builder *component
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemMemcachedOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemMemcachedSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemMemcachedSecretName, o.Namespace, o.Client)
 
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
 	secretData := currSecret.Data
-	builder.MemcachedServers(getSecretDataValue(secretData, component.SystemSecretSystemMemcachedServersFieldName))
+	builder.MemcachedServers(helper.GetSecretDataValue(secretData, component.SystemSecretSystemMemcachedServersFieldName))
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemRecaptchaOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemRecaptchaSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemRecaptchaSecretName, o.Namespace, o.Client)
 	defaultRecaptchaPublicKey := ""
 	defaultRecaptchaPrivateKey := ""
 
@@ -116,14 +117,14 @@ func (o *OperatorSystemOptionsProvider) setSystemRecaptchaOptions(builder *compo
 	}
 
 	secretData := currSecret.Data
-	builder.RecaptchaPublicKey(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemRecaptchaPublicKeyFieldName, defaultRecaptchaPublicKey))
-	builder.RecaptchaPublicKey(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemRecaptchaPrivateKeyFieldName, defaultRecaptchaPrivateKey))
+	builder.RecaptchaPublicKey(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemRecaptchaPublicKeyFieldName, defaultRecaptchaPublicKey))
+	builder.RecaptchaPublicKey(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemRecaptchaPrivateKeyFieldName, defaultRecaptchaPrivateKey))
 
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemEventHookOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemEventsHookSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemEventsHookSecretName, o.Namespace, o.Client)
 	defaultBackendSharedSecret := oprand.String(8)
 
 	if err != nil && !errors.IsNotFound(err) {
@@ -131,33 +132,33 @@ func (o *OperatorSystemOptionsProvider) setSystemEventHookOptions(builder *compo
 	}
 
 	secretData := currSecret.Data
-	builder.BackendSharedSecret(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemEventsHookPasswordFieldName, defaultBackendSharedSecret))
-	builder.EventHooksURL(getSecretDataValue(secretData, component.SystemSecretSystemEventsHookURLFieldName))
+	builder.BackendSharedSecret(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemEventsHookPasswordFieldName, defaultBackendSharedSecret))
+	builder.EventHooksURL(helper.GetSecretDataValue(secretData, component.SystemSecretSystemEventsHookURLFieldName))
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemRedisOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemRedisSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemRedisSecretName, o.Namespace, o.Client)
 
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
 	secretData := currSecret.Data
-	builder.RedisURL(getSecretDataValue(secretData, component.SystemSecretSystemRedisURLFieldName))
-	builder.RedisSentinelHosts(getSecretDataValue(secretData, component.SystemSecretSystemRedisSentinelHosts))
-	builder.RedisSentinelRole(getSecretDataValue(secretData, component.SystemSecretSystemRedisSentinelRole))
-	builder.MessageBusRedisSentinelHosts(getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusSentinelHosts))
-	builder.MessageBusRedisSentinelRole(getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusSentinelRole))
-	builder.MessageBusRedisURL(getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisURLFieldName))
-	builder.RedisNamespace(getSecretDataValue(secretData, component.SystemSecretSystemRedisNamespace))
-	builder.MessageBusRedisNamespace(getSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisNamespace))
+	builder.RedisURL(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisURLFieldName))
+	builder.RedisSentinelHosts(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisSentinelHosts))
+	builder.RedisSentinelRole(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisSentinelRole))
+	builder.MessageBusRedisSentinelHosts(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusSentinelHosts))
+	builder.MessageBusRedisSentinelRole(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusSentinelRole))
+	builder.MessageBusRedisURL(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisURLFieldName))
+	builder.RedisNamespace(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisNamespace))
+	builder.MessageBusRedisNamespace(helper.GetSecretDataValue(secretData, component.SystemSecretSystemRedisMessageBusRedisNamespace))
 
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemAppOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemAppSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemAppSecretName, o.Namespace, o.Client)
 	// TODO is not exactly what we were generating
 	// in OpenShift templates. We were generating
 	// '[a-f0-9]{128}' . Ask system if there's some reason
@@ -171,13 +172,13 @@ func (o *OperatorSystemOptionsProvider) setSystemAppOptions(builder *component.S
 	}
 
 	secretData := currSecret.Data
-	builder.AppSecretKeyBase(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemAppSecretKeyBaseFieldName, defaultSecretKeyBase))
+	builder.AppSecretKeyBase(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemAppSecretKeyBaseFieldName, defaultSecretKeyBase))
 
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemSeedOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemSeedSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemSeedSecretName, o.Namespace, o.Client)
 	defaultMasterDomain := "master"
 	defaultMasterUser := "master"
 	defaultMasterPassword := oprand.String(8)
@@ -191,20 +192,20 @@ func (o *OperatorSystemOptionsProvider) setSystemSeedOptions(builder *component.
 	}
 
 	secretData := currSecret.Data
-	builder.MasterName(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterDomainFieldName, defaultMasterDomain))
-	builder.MasterUsername(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterUserFieldName, defaultMasterUser))
-	builder.MasterPassword(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterPasswordFieldName, defaultMasterPassword))
-	builder.AdminUsername(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminUserFieldName, defaultAdminUser))
-	builder.AdminPassword(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminPasswordFieldName, defaultAdminPassword))
-	builder.AdminAccessToken(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminAccessTokenFieldName, defaultAdminAccessToken))
-	builder.MasterAccessToken(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterAccessTokenFieldName, defaultMasterAccessToken))
-	builder.AdminEmail(getSecretDataValue(secretData, component.SystemSecretSystemSeedAdminEmailFieldName))
+	builder.MasterName(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterDomainFieldName, defaultMasterDomain))
+	builder.MasterUsername(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterUserFieldName, defaultMasterUser))
+	builder.MasterPassword(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterPasswordFieldName, defaultMasterPassword))
+	builder.AdminUsername(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminUserFieldName, defaultAdminUser))
+	builder.AdminPassword(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminPasswordFieldName, defaultAdminPassword))
+	builder.AdminAccessToken(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedAdminAccessTokenFieldName, defaultAdminAccessToken))
+	builder.MasterAccessToken(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSeedMasterAccessTokenFieldName, defaultMasterAccessToken))
+	builder.AdminEmail(helper.GetSecretDataValue(secretData, component.SystemSecretSystemSeedAdminEmailFieldName))
 
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemMasterApicastOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemMasterApicastSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemMasterApicastSecretName, o.Namespace, o.Client)
 	defaultSystemMasterApicastAccessToken := oprand.String(8)
 
 	if err != nil && !errors.IsNotFound(err) {
@@ -213,13 +214,13 @@ func (o *OperatorSystemOptionsProvider) setSystemMasterApicastOptions(builder *c
 
 	secretData := currSecret.Data
 	// TODO we do not reconcile ProxyConfigEndpoint nor BaseURL fields because they are dependant on the TenantName
-	builder.ApicastAccessToken(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemMasterApicastAccessToken, defaultSystemMasterApicastAccessToken))
+	builder.ApicastAccessToken(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemMasterApicastAccessToken, defaultSystemMasterApicastAccessToken))
 
 	return nil
 }
 
 func (o *OperatorSystemOptionsProvider) setSystemSMTPOptions(builder *component.SystemOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemSMTPSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemSMTPSecretName, o.Namespace, o.Client)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -227,13 +228,13 @@ func (o *OperatorSystemOptionsProvider) setSystemSMTPOptions(builder *component.
 	secretData := currSecret.Data
 
 	smtpSecretOptions := component.SystemSMTPSecretOptions{
-		Address:           getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPAddressFieldName, ""),
-		Authentication:    getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPAuthenticationFieldName, ""),
-		Domain:            getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPDomainFieldName, ""),
-		OpenSSLVerifyMode: getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPOpenSSLVerifyModeFieldName, ""),
-		Password:          getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPPasswordFieldName, ""),
-		Port:              getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPPortFieldName, ""),
-		Username:          getSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPUserNameFieldName, ""),
+		Address:           helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPAddressFieldName, ""),
+		Authentication:    helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPAuthenticationFieldName, ""),
+		Domain:            helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPDomainFieldName, ""),
+		OpenSSLVerifyMode: helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPOpenSSLVerifyModeFieldName, ""),
+		Password:          helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPPasswordFieldName, ""),
+		Port:              helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPPortFieldName, ""),
+		Username:          helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemSMTPUserNameFieldName, ""),
 	}
 
 	builder.SystemSMTPSecretOptions(smtpSecretOptions)
@@ -270,7 +271,7 @@ func (o *OperatorSystemOptionsProvider) setFileStorageOptions(b *component.Syste
 
 func (o *OperatorSystemOptionsProvider) setAWSSecretOptions(sob *component.SystemOptionsBuilder) error {
 	awsCredentialsSecretName := o.APIManagerSpec.System.FileStorageSpec.S3.AWSCredentials.Name
-	currSecret, err := getSecret(awsCredentialsSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(awsCredentialsSecretName, o.Namespace, o.Client)
 	if err != nil {
 		return err
 	}
@@ -279,13 +280,13 @@ func (o *OperatorSystemOptionsProvider) setAWSSecretOptions(sob *component.Syste
 	// We do not modify it. Otherwise we set a default value
 	secretData := currSecret.Data
 	var result *string
-	result = getSecretDataValue(secretData, component.S3SecretAWSAccessKeyIdFieldName)
+	result = helper.GetSecretDataValue(secretData, component.S3SecretAWSAccessKeyIdFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.S3SecretAWSAccessKeyIdFieldName, awsCredentialsSecretName)
 	}
 	awsAccessKeyID := *result
 
-	result = getSecretDataValue(secretData, component.S3SecretAWSSecretAccessKeyFieldName)
+	result = helper.GetSecretDataValue(secretData, component.S3SecretAWSSecretAccessKeyFieldName)
 	if result == nil {
 		return fmt.Errorf("Secret field '%s' is required in secret '%s'", component.S3SecretAWSSecretAccessKeyFieldName, awsCredentialsSecretName)
 	}

--- a/pkg/3scale/amp/operator/system_postgresql.go
+++ b/pkg/3scale/amp/operator/system_postgresql.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -39,7 +40,7 @@ func (o *OperatorSystemPostgreSQLOptionsProvider) setSecretBasedOptions(builder 
 }
 
 func (o *OperatorSystemPostgreSQLOptionsProvider) setSystemDatabaseOptions(builder *component.SystemPostgreSQLOptionsBuilder) error {
-	currSecret, err := getSecret(component.SystemSecretSystemDatabaseSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.SystemSecretSystemDatabaseSecretName, o.Namespace, o.Client)
 	defaultDatabaseName := "system"
 	defaultDatabaseUsername := "system"
 	defaultDatabasePassword := oprand.String(8)
@@ -54,8 +55,8 @@ func (o *OperatorSystemPostgreSQLOptionsProvider) setSystemDatabaseOptions(build
 	// If a field of a secret already exists in the deployed secret then
 	// We do not modify it. Otherwise we set a default value
 	secretData := currSecret.Data
-	builder.User(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseUserFieldName, defaultDatabaseUsername))
-	builder.Password(getSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabasePasswordFieldName, defaultDatabasePassword))
+	builder.User(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseUserFieldName, defaultDatabaseUsername))
+	builder.Password(helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabasePasswordFieldName, defaultDatabasePassword))
 	err = o.parseAndSetDatabaseURLAndParts(builder, secretData, defaultDatabaseURL)
 	if err != nil {
 		return err
@@ -65,7 +66,7 @@ func (o *OperatorSystemPostgreSQLOptionsProvider) setSystemDatabaseOptions(build
 }
 
 func (o *OperatorSystemPostgreSQLOptionsProvider) parseAndSetDatabaseURLAndParts(builder *component.SystemPostgreSQLOptionsBuilder, secretData map[string][]byte, defaultDatabaseURL string) error {
-	resultURLStr := getSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseURLFieldName, defaultDatabaseURL)
+	resultURLStr := helper.GetSecretDataValueOrDefault(secretData, component.SystemSecretSystemDatabaseURLFieldName, defaultDatabaseURL)
 	resultURL, err := o.systemDatabaseURLIsValid(resultURLStr)
 	if err != nil {
 		return err

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -192,7 +192,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.reconcileSMTPConfigMap(system.SMTPConfigMap())
+	err = r.reconcileSMTPSecret(system.SMTPSecret())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -290,9 +290,9 @@ func (r *SystemReconciler) reconcileEnvironmentConfigMap(desiredConfigMap *v1.Co
 	return reconciler.Reconcile(desiredConfigMap)
 }
 
-func (r *SystemReconciler) reconcileSMTPConfigMap(desiredConfigMap *v1.ConfigMap) error {
-	reconciler := NewConfigMapBaseReconciler(r.BaseAPIManagerLogicReconciler, NewCreateOnlyConfigMapReconciler())
-	return reconciler.Reconcile(desiredConfigMap)
+func (r *SystemReconciler) reconcileSMTPSecret(desiredSecret *v1.Secret) error {
+	reconciler := NewSecretBaseReconciler(r.BaseAPIManagerLogicReconciler, NewDefaultsOnlySecretReconciler())
+	return reconciler.Reconcile(desiredSecret)
 }
 
 func (r *SystemReconciler) reconcileEventsHookSecret(desiredSecret *v1.Secret) error {

--- a/pkg/3scale/amp/operator/system_reconciler_test.go
+++ b/pkg/3scale/amp/operator/system_reconciler_test.go
@@ -71,7 +71,7 @@ func TestSystemReconcilerCreate(t *testing.T) {
 		{"systemSphinxqDC", "system-sphinx", &appsv1.DeploymentConfig{}},
 		{"systemCM", "system", &v1.ConfigMap{}},
 		{"systemEnvironmentCM", "system-environment", &v1.ConfigMap{}},
-		{"systemSMTPCM", "smtp", &v1.ConfigMap{}},
+		{"systemSMTPSecret", "system-smtp", &v1.Secret{}},
 		{"systemEventsHookSecret", component.SystemSecretSystemEventsHookSecretName, &v1.Secret{}},
 		{"systemRedisSecret", component.SystemSecretSystemRedisSecretName, &v1.Secret{}},
 		{"systemMasterApicastSecret", component.SystemSecretSystemMasterApicastSecretName, &v1.Secret{}},

--- a/pkg/3scale/amp/operator/system_test.go
+++ b/pkg/3scale/amp/operator/system_test.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"testing"
 
+	"github.com/3scale/3scale-operator/pkg/helper"
+
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -63,7 +65,7 @@ func getMemcachedSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -80,7 +82,7 @@ func getRecaptchaSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -97,7 +99,7 @@ func getEventHookSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -120,7 +122,7 @@ func getSystemRedisSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -136,7 +138,7 @@ func getSystemAppSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -159,7 +161,7 @@ func getSystemSeedSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -175,7 +177,7 @@ func getSystemMasterApicastSecret(namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 
@@ -192,7 +194,7 @@ func getAWSCredentialsSecret(name, namespace string) *v1.Secret {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	secret.Data = getSecretDataFromStringData(secret.StringData)
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
 }
 

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -5,9 +5,15 @@ import (
 	"fmt"
 	"reflect"
 
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/go-logr/logr"
 	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,7 +34,21 @@ func (u *UpgradeApiManager) Upgrade() (reconcile.Result, error) {
 		return res, err
 	}
 
-	res, err = u.upgradeAMPImageStreams()
+	res, err = u.upgradeImages()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeSystemSMTP()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeImages() (reconcile.Result, error) {
+	res, err := u.upgradeAMPImageStreams()
 	if res.Requeue || err != nil {
 		return res, err
 	}
@@ -59,6 +79,181 @@ func (u *UpgradeApiManager) upgradeAMPImageStreams() (reconcile.Result, error) {
 	baseLogicReconciler := NewBaseLogicReconciler(baseReconciler)
 	reconciler := NewAMPImagesReconciler(NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.Cr))
 	return reconciler.Reconcile()
+}
+
+func (u *UpgradeApiManager) upgradeSystemSMTP() (reconcile.Result, error) {
+	res, err := u.migrateSystemSMTPData()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeSystemSMTPEnvVars()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeSystemSMTPEnvVars() (reconcile.Result, error) {
+	res, err := u.upgradeSystemSidekiqEnvVars()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeSystemAppEnvVars()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeSystemSidekiqEnvVars() (reconcile.Result, error) {
+	system, err := System(u.Cr, u.Client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	desiredSidekiqDeploymentConfig := system.SidekiqDeploymentConfig()
+	existingSidekiqDeploymentConfig := &appsv1.DeploymentConfig{}
+	err = u.Client.Get(context.TODO(), types.NamespacedName{Name: desiredSidekiqDeploymentConfig.Name, Namespace: u.Cr.Namespace}, existingSidekiqDeploymentConfig)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	changed, err := u.ensureDeploymentConfigPodTemplateEnvVars(desiredSidekiqDeploymentConfig, existingSidekiqDeploymentConfig)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if changed {
+		u.Logger.Info(fmt.Sprintf("Update object %s", ObjectInfo(existingSidekiqDeploymentConfig)))
+		err := u.Client.Update(context.TODO(), existingSidekiqDeploymentConfig)
+		return reconcile.Result{Requeue: true}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeSystemAppEnvVars() (reconcile.Result, error) {
+	system, err := System(u.Cr, u.Client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	desiredSystemAppDeploymentConfig := system.AppDeploymentConfig()
+	existingSystemAppDeploymentConfig := &appsv1.DeploymentConfig{}
+	err = u.Client.Get(context.TODO(), types.NamespacedName{Name: desiredSystemAppDeploymentConfig.Name, Namespace: u.Cr.Namespace}, existingSystemAppDeploymentConfig)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	changed, err := u.ensureDeploymentConfigPodTemplateEnvVars(desiredSystemAppDeploymentConfig, existingSystemAppDeploymentConfig)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	tmpChanged := u.ensureDeploymentConfigPreHookPodEnvVars(desiredSystemAppDeploymentConfig, existingSystemAppDeploymentConfig)
+	changed = changed || tmpChanged
+
+	if changed {
+		u.Logger.Info(fmt.Sprintf("Update object %s", ObjectInfo(existingSystemAppDeploymentConfig)))
+		err := u.Client.Update(context.TODO(), existingSystemAppDeploymentConfig)
+		return reconcile.Result{Requeue: true}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) migrateSystemSMTPData() (reconcile.Result, error) {
+	existingConfigMap := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{
+		Name:      "smtp",
+		Namespace: u.Cr.Namespace,
+	}
+	err := u.Client.Get(context.TODO(), configMapNamespacedName, existingConfigMap)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	existingSecret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{
+		Name:      component.SystemSecretSystemSMTPSecretName,
+		Namespace: u.Cr.Namespace,
+	}
+	err = u.Client.Get(context.TODO(), secretNamespacedName, existingSecret)
+	if err != nil && !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+
+	if errors.IsNotFound(err) {
+		system, err := System(u.Cr, u.Client)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		// We rely on System options provider not needing the system-smtp secret
+		// existing so we obtain the default one and overwrite the data
+		// with the existing ConfigMap data and we create the secret
+		existingSecret = system.SMTPSecret()
+		existingSecret.SetNamespace(u.Cr.Namespace)
+		err = controllerutil.SetControllerReference(u.Cr, existingSecret, u.Scheme)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		// We make sure StringData is nil so it does not get precedence over Data.
+		// We use Data to set the secret and not StringData due to at the time
+		// of writing this comment when using the Kubernetes FakeClient the
+		// mocked client does not convert from StringData to Data, producing a
+		// different behavior than with the real code execution
+		existingSecret.StringData = nil
+		existingSecret.Data = helper.GetSecretDataFromStringData(existingConfigMap.Data)
+
+		u.Logger.Info(fmt.Sprintf("Create object %s", ObjectInfo(existingSecret)))
+		err = u.Client.Create(context.TODO(), existingSecret)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	changed := false
+	secretStringData := helper.GetSecretStringDataFromData(existingSecret.Data)
+	changed = !reflect.DeepEqual(existingConfigMap.Data, secretStringData)
+	if changed {
+		existingSecret.Data = helper.GetSecretDataFromStringData(existingConfigMap.Data)
+		u.Logger.Info(fmt.Sprintf("Update object %s", ObjectInfo(existingSecret)))
+		err := u.Client.Update(context.TODO(), existingSecret)
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) ensureDeploymentConfigPreHookPodEnvVars(desired, existing *appsv1.DeploymentConfig) bool {
+	changed := false
+	desiredPreHookPod := desired.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	existingPrehookPod := existing.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	if !reflect.DeepEqual(existingPrehookPod.Env, desiredPreHookPod.Env) {
+		existingPrehookPod.Env = desiredPreHookPod.Env
+		changed = true
+	}
+	return changed
+}
+
+func (u *UpgradeApiManager) ensureDeploymentConfigPodTemplateEnvVars(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	if len(existing.Spec.Template.Spec.Containers) != len(desired.Spec.Template.Spec.Containers) {
+		return false, fmt.Errorf("%s desired containers length does not match existing containers length", desired.Name)
+	}
+
+	changed := false
+	for idx := range existing.Spec.Template.Spec.Containers {
+		desiredContainer := &desired.Spec.Template.Spec.Containers[idx]
+		existingContainer := &existing.Spec.Template.Spec.Containers[idx]
+		if !reflect.DeepEqual(existingContainer.Env, desiredContainer.Env) {
+			existingContainer.Env = desiredContainer.Env
+			changed = true
+		}
+	}
+
+	return changed, nil
 }
 
 func (u *UpgradeApiManager) highAvailabilityModeEnabled() bool {
@@ -127,14 +322,8 @@ func (u *UpgradeApiManager) upgradeSystemAppPreHookPodEnv() (reconcile.Result, e
 		return reconcile.Result{}, err
 	}
 
-	desiredEnv := system.AppDeploymentConfig().Spec.Strategy.RollingParams.Pre.ExecNewPod.Env
-
-	changed := false
-	existingPreHookPod := existingDeploymentConfig.Spec.Strategy.RollingParams.Pre.ExecNewPod
-	if !reflect.DeepEqual(existingPreHookPod.Env, desiredEnv) {
-		existingPreHookPod.Env = desiredEnv
-		changed = true
-	}
+	desiredDeploymentConfig := system.AppDeploymentConfig()
+	changed := u.ensureDeploymentConfigPreHookPodEnvVars(desiredDeploymentConfig, existingDeploymentConfig)
 
 	if changed {
 		u.Logger.Info(fmt.Sprintf("Update object %s", ObjectInfo(existingDeploymentConfig)))

--- a/pkg/3scale/amp/operator/zync.go
+++ b/pkg/3scale/amp/operator/zync.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	oprand "github.com/3scale/3scale-operator/pkg/crypto/rand"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -42,7 +43,7 @@ func (o *OperatorZyncOptionsProvider) setZyncSecretOptions(zob *component.ZyncOp
 	defaultZyncDatabasePassword := oprand.String(16)
 	defaultZyncAuthenticationToken := oprand.String(16)
 
-	currSecret, err := getSecret(component.ZyncSecretName, o.Namespace, o.Client)
+	currSecret, err := helper.GetSecret(component.ZyncSecretName, o.Namespace, o.Client)
 
 	if err != nil && !errors.IsNotFound(err) {
 		return err
@@ -51,9 +52,9 @@ func (o *OperatorZyncOptionsProvider) setZyncSecretOptions(zob *component.ZyncOp
 	// If a field of a secret already exists in the deployed secret then
 	// We do not modify it. Otherwise we set a default value
 	secretData := currSecret.Data
-	zob.SecretKeyBase(getSecretDataValueOrDefault(secretData, component.ZyncSecretKeyBaseFieldName, defaultZyncSecretKeyBase))
-	zob.DatabasePassword(getSecretDataValueOrDefault(secretData, component.ZyncSecretDatabasePasswordFieldName, defaultZyncDatabasePassword))
-	zob.AuthenticationToken(getSecretDataValueOrDefault(secretData, component.ZyncSecretAuthenticationTokenFieldName, defaultZyncAuthenticationToken))
+	zob.SecretKeyBase(helper.GetSecretDataValueOrDefault(secretData, component.ZyncSecretKeyBaseFieldName, defaultZyncSecretKeyBase))
+	zob.DatabasePassword(helper.GetSecretDataValueOrDefault(secretData, component.ZyncSecretDatabasePasswordFieldName, defaultZyncDatabasePassword))
+	zob.AuthenticationToken(helper.GetSecretDataValueOrDefault(secretData, component.ZyncSecretAuthenticationTokenFieldName, defaultZyncAuthenticationToken))
 
 	return nil
 }

--- a/pkg/controller/apimanager/apimanager_controller_test.go
+++ b/pkg/controller/apimanager/apimanager_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
@@ -151,11 +153,64 @@ func TestAPIManagerControllerUpgrade(t *testing.T) {
 					},
 				},
 			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "system-master",
+						},
+						corev1.Container{
+							Name: "system-developer",
+						},
+						corev1.Container{
+							Name: "system-provider",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	systemSidekiq := &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system-sidekiq",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentConfigSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "system-sidekiq",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	smtpConfigMapToReplace := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "smtp",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			component.SystemSecretSystemSMTPAddressFieldName:           "myaddress@domain.com",
+			component.SystemSecretSystemSMTPUserNameFieldName:          "myusername",
+			component.SystemSecretSystemSMTPPasswordFieldName:          "mypassword",
+			component.SystemSecretSystemSMTPDomainFieldName:            "mydomain",
+			component.SystemSecretSystemSMTPPortFieldName:              "25",
+			component.SystemSecretSystemSMTPAuthenticationFieldName:    "login",
+			component.SystemSecretSystemSMTPOpenSSLVerifyModeFieldName: "none",
 		},
 	}
 
 	// Objects to track in the fake client.
-	objs := []runtime.Object{apimanager, systemApp}
+	objs := []runtime.Object{apimanager, systemApp, systemSidekiq, &smtpConfigMapToReplace}
 
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
@@ -207,12 +262,43 @@ func TestAPIManagerControllerUpgrade(t *testing.T) {
 	}
 
 	if !res.Requeue {
-		t.Error("upgrade not expected to finish. Should requeue before update annotations")
+		t.Error("upgrade not expected to finish. Should requeue before update system-app pre-hook pod")
 	}
 
 	res, err = r.Reconcile(req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if !res.Requeue {
+		t.Error("upgrade not expected to finish. Should requeue after migrating smtp ConfigMap to system-smtp Secret")
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if !res.Requeue {
+		t.Error("upgrade not expected to finish. Should requeue after updating smtp envvars in system-sidekiq")
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if !res.Requeue {
+		t.Error("upgrade not expected to finish. Should requeue after updating smtp envvars in system-app")
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if !res.Requeue {
+		t.Error("upgrade not expected to finish. Should requeue before update annotations")
 	}
 
 	finalAPIManager := &appsv1alpha1.APIManager{}

--- a/pkg/helper/secretutils.go
+++ b/pkg/helper/secretutils.go
@@ -1,4 +1,4 @@
-package operator
+package helper
 
 import (
 	"context"
@@ -7,14 +7,14 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getSecretDataValueOrDefault(secretData map[string][]byte, fieldName string, defaultValue string) string {
+func GetSecretDataValueOrDefault(secretData map[string][]byte, fieldName string, defaultValue string) string {
 	if value, exists := secretData[fieldName]; exists {
 		return string(value)
 	}
 	return defaultValue
 }
 
-func getSecret(name string, namespace string, client k8sclient.Client) (*v1.Secret, error) {
+func GetSecret(name string, namespace string, client k8sclient.Client) (*v1.Secret, error) {
 	secret := &v1.Secret{}
 
 	objKey := k8sclient.ObjectKey{
@@ -30,7 +30,7 @@ func getSecret(name string, namespace string, client k8sclient.Client) (*v1.Secr
 	return secret, nil
 }
 
-func getSecretDataValue(secretData map[string][]byte, fieldName string) *string {
+func GetSecretDataValue(secretData map[string][]byte, fieldName string) *string {
 	if value, exists := secretData[fieldName]; exists {
 		resultStr := string(value)
 		return &resultStr
@@ -39,7 +39,7 @@ func getSecretDataValue(secretData map[string][]byte, fieldName string) *string 
 	}
 }
 
-func getSecretDataFromStringData(secretStringData map[string]string) map[string][]byte {
+func GetSecretDataFromStringData(secretStringData map[string]string) map[string][]byte {
 	result := map[string][]byte{}
 	for k, v := range secretStringData {
 		result[k] = []byte(v)
@@ -47,7 +47,7 @@ func getSecretDataFromStringData(secretStringData map[string]string) map[string]
 	return result
 }
 
-func getSecretStringDataFromData(secretData map[string][]byte) map[string]string {
+func GetSecretStringDataFromData(secretData map[string][]byte) map[string]string {
 	result := map[string]string{}
 	for k, v := range secretData {
 		result[k] = string(v)
@@ -58,7 +58,7 @@ func getSecretStringDataFromData(secretData map[string][]byte) map[string]string
 // Returns a new map containing the contents of `from` and the
 // contents of `to`. The value for entries with duplicated keys
 // will be that of `from`
-func mergeSecretData(from, to map[string][]byte) map[string][]byte {
+func MergeSecretData(from, to map[string][]byte) map[string][]byte {
 	result := map[string][]byte{}
 	for key := range to {
 		val := make([]byte, len(to[key]))


### PR DESCRIPTION
This PR changes the deployment of the SMTP configuration from a ConfigMap to a Secret.
The reason of this is because some of the configuration contains credentials.