### PR TITLE
Change imagestream tagging structure

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -130,6 +130,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreamtags
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -27,16 +27,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: amp-backend (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -63,16 +53,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP Zync (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
@@ -101,16 +81,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: AMP APIcast (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -137,16 +107,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP System (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
@@ -175,16 +135,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Zync PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
@@ -211,16 +161,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Memcached (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Memcached
       from:
@@ -255,16 +195,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System MySQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} MySQL
       from:
@@ -354,7 +284,7 @@ objects:
         - backend-redis
         from:
           kind: ImageStreamTag
-          name: backend-redis:latest
+          name: backend-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -468,16 +398,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Backend Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Backend ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
@@ -567,7 +487,7 @@ objects:
         - system-redis
         from:
           kind: ImageStreamTag
-          name: system-redis:latest
+          name: system-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -625,16 +545,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
@@ -781,7 +691,7 @@ objects:
         - backend-cron
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -907,7 +817,7 @@ objects:
         - backend-listener
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1100,7 +1010,7 @@ objects:
         - backend-worker
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1254,7 +1164,7 @@ objects:
         - system-mysql
         from:
           kind: ImageStreamTag
-          name: system-mysql:latest
+          name: system-mysql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1408,7 +1318,7 @@ objects:
         - memcache
         from:
           kind: ImageStreamTag
-          name: system-memcached:latest
+          name: system-memcached:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2952,7 +2862,7 @@ objects:
         - system-master
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3377,7 +3287,7 @@ objects:
         - system-sidekiq
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3520,7 +3430,7 @@ objects:
         - system-sphinx
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3797,7 +3707,7 @@ objects:
         - zync
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3903,7 +3813,7 @@ objects:
         - que
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3986,7 +3896,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: zync-database-postgresql:latest
+          name: zync-database-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4149,7 +4059,7 @@ objects:
         - apicast-staging
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4274,7 +4184,7 @@ objects:
         - apicast-production
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -26,16 +26,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: amp-backend (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -62,16 +52,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP Zync (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
@@ -100,16 +80,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: AMP APIcast (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -136,16 +106,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP System (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
@@ -174,16 +134,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Zync PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
@@ -210,16 +160,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Memcached (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Memcached
       from:
@@ -254,16 +194,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System MySQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} MySQL
       from:
@@ -353,7 +283,7 @@ objects:
         - backend-redis
         from:
           kind: ImageStreamTag
-          name: backend-redis:latest
+          name: backend-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -467,16 +397,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Backend Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Backend ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
@@ -566,7 +486,7 @@ objects:
         - system-redis
         from:
           kind: ImageStreamTag
-          name: system-redis:latest
+          name: system-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -624,16 +544,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
@@ -780,7 +690,7 @@ objects:
         - backend-cron
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -906,7 +816,7 @@ objects:
         - backend-listener
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1099,7 +1009,7 @@ objects:
         - backend-worker
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1253,7 +1163,7 @@ objects:
         - system-mysql
         from:
           kind: ImageStreamTag
-          name: system-mysql:latest
+          name: system-mysql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1407,7 +1317,7 @@ objects:
         - memcache
         from:
           kind: ImageStreamTag
-          name: system-memcached:latest
+          name: system-memcached:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2807,7 +2717,7 @@ objects:
         - system-master
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3194,7 +3104,7 @@ objects:
         - system-sidekiq
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3337,7 +3247,7 @@ objects:
         - system-sphinx
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3614,7 +3524,7 @@ objects:
         - zync
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3720,7 +3630,7 @@ objects:
         - que
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3803,7 +3713,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: zync-database-postgresql:latest
+          name: zync-database-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3966,7 +3876,7 @@ objects:
         - apicast-staging
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4091,7 +4001,7 @@ objects:
         - apicast-production
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -26,16 +26,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: amp-backend (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -62,16 +52,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP Zync (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
@@ -100,16 +80,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: AMP APIcast (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -136,16 +106,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP System (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
@@ -174,16 +134,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Zync PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
@@ -210,16 +160,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Memcached (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Memcached
       from:
@@ -379,7 +319,7 @@ objects:
         - backend-cron
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -511,7 +451,7 @@ objects:
         - backend-listener
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -710,7 +650,7 @@ objects:
         - backend-worker
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -896,7 +836,7 @@ objects:
         - memcache
         from:
           kind: ImageStreamTag
-          name: system-memcached:latest
+          name: system-memcached:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2314,7 +2254,7 @@ objects:
         - system-master
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2707,7 +2647,7 @@ objects:
         - system-sidekiq
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2856,7 +2796,7 @@ objects:
         - system-sphinx
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3177,7 +3117,7 @@ objects:
         - zync
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3289,7 +3229,7 @@ objects:
         - que
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3378,7 +3318,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: zync-database-postgresql:latest
+          name: zync-database-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3583,7 +3523,7 @@ objects:
         - apicast-staging
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3714,7 +3654,7 @@ objects:
         - apicast-production
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -26,16 +26,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: amp-backend (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -62,16 +52,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP Zync (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
@@ -100,16 +80,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: AMP APIcast (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -136,16 +106,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP System (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
@@ -174,16 +134,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Zync PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
@@ -210,16 +160,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Memcached (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Memcached
       from:
@@ -254,16 +194,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} PostgreSQL
       from:
@@ -359,7 +289,7 @@ objects:
         - backend-redis
         from:
           kind: ImageStreamTag
-          name: backend-redis:latest
+          name: backend-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -473,16 +403,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Backend Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Backend ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
@@ -578,7 +498,7 @@ objects:
         - system-redis
         from:
           kind: ImageStreamTag
-          name: system-redis:latest
+          name: system-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -636,16 +556,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
@@ -798,7 +708,7 @@ objects:
         - backend-cron
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -930,7 +840,7 @@ objects:
         - backend-listener
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1129,7 +1039,7 @@ objects:
         - backend-worker
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1272,7 +1182,7 @@ objects:
         - system-postgresql
         from:
           kind: ImageStreamTag
-          name: system-postgresql:latest
+          name: system-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1399,7 +1309,7 @@ objects:
         - memcache
         from:
           kind: ImageStreamTag
-          name: system-memcached:latest
+          name: system-memcached:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2817,7 +2727,7 @@ objects:
         - system-master
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3210,7 +3120,7 @@ objects:
         - system-sidekiq
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3359,7 +3269,7 @@ objects:
         - system-sphinx
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3642,7 +3552,7 @@ objects:
         - zync
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3754,7 +3664,7 @@ objects:
         - que
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3843,7 +3753,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: zync-database-postgresql:latest
+          name: zync-database-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4012,7 +3922,7 @@ objects:
         - apicast-staging
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4143,7 +4053,7 @@ objects:
         - apicast-production
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -27,16 +27,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: amp-backend (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -63,16 +53,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP Zync (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
@@ -101,16 +81,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: AMP APIcast (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -137,16 +107,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP System (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
@@ -175,16 +135,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Zync PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
@@ -211,16 +161,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Memcached (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Memcached
       from:
@@ -255,16 +195,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System MySQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} MySQL
       from:
@@ -360,7 +290,7 @@ objects:
         - backend-redis
         from:
           kind: ImageStreamTag
-          name: backend-redis:latest
+          name: backend-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -474,16 +404,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Backend Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Backend ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
@@ -579,7 +499,7 @@ objects:
         - system-redis
         from:
           kind: ImageStreamTag
-          name: system-redis:latest
+          name: system-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -637,16 +557,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
@@ -799,7 +709,7 @@ objects:
         - backend-cron
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -931,7 +841,7 @@ objects:
         - backend-listener
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1130,7 +1040,7 @@ objects:
         - backend-worker
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1289,7 +1199,7 @@ objects:
         - system-mysql
         from:
           kind: ImageStreamTag
-          name: system-mysql:latest
+          name: system-mysql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1449,7 +1359,7 @@ objects:
         - memcache
         from:
           kind: ImageStreamTag
-          name: system-memcached:latest
+          name: system-memcached:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3011,7 +2921,7 @@ objects:
         - system-master
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3442,7 +3352,7 @@ objects:
         - system-sidekiq
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3591,7 +3501,7 @@ objects:
         - system-sphinx
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3874,7 +3784,7 @@ objects:
         - zync
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3986,7 +3896,7 @@ objects:
         - que
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4075,7 +3985,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: zync-database-postgresql:latest
+          name: zync-database-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4244,7 +4154,7 @@ objects:
         - apicast-staging
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4375,7 +4285,7 @@ objects:
         - apicast-production
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -26,16 +26,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: amp-backend (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -62,16 +52,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP Zync (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
@@ -100,16 +80,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: AMP APIcast (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
@@ -136,16 +106,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: AMP System (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
@@ -174,16 +134,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Zync PostgreSQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Zync ${AMP_RELEASE} PostgreSQL
       from:
         kind: DockerImage
@@ -210,16 +160,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Memcached (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Memcached
       from:
@@ -254,16 +194,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System MySQL (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} MySQL
       from:
@@ -359,7 +289,7 @@ objects:
         - backend-redis
         from:
           kind: ImageStreamTag
-          name: backend-redis:latest
+          name: backend-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -473,16 +403,6 @@ objects:
       local: false
     tags:
     - annotations:
-        openshift.io/display-name: Backend Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
-    - annotations:
         openshift.io/display-name: Backend ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
@@ -578,7 +498,7 @@ objects:
         - system-redis
         from:
           kind: ImageStreamTag
-          name: system-redis:latest
+          name: system-redis:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -636,16 +556,6 @@ objects:
     lookupPolicy:
       local: false
     tags:
-    - annotations:
-        openshift.io/display-name: System Redis (latest)
-      from:
-        kind: ImageStreamTag
-        name: ${AMP_RELEASE}
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
     - annotations:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
@@ -798,7 +708,7 @@ objects:
         - backend-cron
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -930,7 +840,7 @@ objects:
         - backend-listener
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1129,7 +1039,7 @@ objects:
         - backend-worker
         from:
           kind: ImageStreamTag
-          name: amp-backend:latest
+          name: amp-backend:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1288,7 +1198,7 @@ objects:
         - system-mysql
         from:
           kind: ImageStreamTag
-          name: system-mysql:latest
+          name: system-mysql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -1448,7 +1358,7 @@ objects:
         - memcache
         from:
           kind: ImageStreamTag
-          name: system-memcached:latest
+          name: system-memcached:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -2866,7 +2776,7 @@ objects:
         - system-master
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3259,7 +3169,7 @@ objects:
         - system-sidekiq
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3408,7 +3318,7 @@ objects:
         - system-sphinx
         from:
           kind: ImageStreamTag
-          name: amp-system:latest
+          name: amp-system:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3691,7 +3601,7 @@ objects:
         - zync
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3803,7 +3713,7 @@ objects:
         - que
         from:
           kind: ImageStreamTag
-          name: amp-zync:latest
+          name: amp-zync:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -3892,7 +3802,7 @@ objects:
         - postgresql
         from:
           kind: ImageStreamTag
-          name: zync-database-postgresql:latest
+          name: zync-database-postgresql:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4061,7 +3971,7 @@ objects:
         - apicast-staging
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0
@@ -4192,7 +4102,7 @@ objects:
         - apicast-production
         from:
           kind: ImageStreamTag
-          name: amp-apicast:latest
+          name: amp-apicast:${AMP_RELEASE}
       type: ImageChange
   status:
     availableReplicas: 0

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -144,16 +144,6 @@ func (ampImages *AmpImages) APICastImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "AMP APIcast (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: ampImages.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: ampImages.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "AMP APIcast " + ampImages.Options.AmpRelease,

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -58,16 +58,6 @@ func (ampImages *AmpImages) BackendImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "amp-backend (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: ampImages.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: ampImages.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "amp-backend " + ampImages.Options.AmpRelease,

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -91,16 +91,6 @@ func (ampImages *AmpImages) ZyncImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "AMP Zync (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: ampImages.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: ampImages.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "AMP Zync " + ampImages.Options.AmpRelease,

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -157,16 +157,6 @@ func (ampImages *AmpImages) SystemImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "AMP System (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: ampImages.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: ampImages.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "AMP system " + ampImages.Options.AmpRelease,

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -223,16 +223,6 @@ func (ampImages *AmpImages) SystemMemcachedImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "System Memcached (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: ampImages.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: ampImages.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "System " + ampImages.Options.AmpRelease + " Memcached",

--- a/pkg/3scale/amp/component/ampimages.go
+++ b/pkg/3scale/amp/component/ampimages.go
@@ -200,16 +200,6 @@ func (ampImages *AmpImages) ZyncDatabasePostgreSQLImageStream() *imagev1.ImageSt
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "Zync PostgreSQL (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: ampImages.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: ampImages.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "Zync " + ampImages.Options.AmpRelease + " PostgreSQL",

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 	"k8s.io/api/policy/v1beta1"
 
@@ -157,7 +159,7 @@ func (apicast *Apicast) StagingDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-apicast:latest",
+							Name: fmt.Sprintf("amp-apicast:%s", apicast.Options.ImageTag),
 						},
 					},
 				},
@@ -271,7 +273,7 @@ func (apicast *Apicast) ProductionDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-apicast:latest",
+							Name: fmt.Sprintf("amp-apicast:%s", apicast.Options.ImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -13,6 +13,7 @@ type ApicastOptions struct {
 	ResponseCodes                  string                  `validate:"required"`
 	TenantName                     string                  `validate:"required"`
 	WildcardDomain                 string                  `validate:"required"`
+	ImageTag                       string                  `validate:"required"`
 	ProductionResourceRequirements v1.ResourceRequirements `validate:"-"`
 	StagingResourceRequirements    v1.ResourceRequirements `validate:"-"`
 	ProductionReplicas             int32

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 	"k8s.io/api/policy/v1beta1"
 
@@ -114,7 +116,7 @@ func (backend *Backend) WorkerDeploymentConfig() *appsv1.DeploymentConfig {
 						ContainerNames: []string{"backend-redis-svc", "backend-worker"},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-backend:latest"}}},
+							Name: fmt.Sprintf("amp-backend:%s", backend.Options.ImageTag)}}},
 			},
 			Replicas: backend.Options.WorkerReplicas,
 			Selector: map[string]string{"deploymentConfig": "backend-worker"},
@@ -186,7 +188,7 @@ func (backend *Backend) CronDeploymentConfig() *appsv1.DeploymentConfig {
 						ContainerNames: []string{"backend-redis-svc", "backend-cron"},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-backend:latest"}}},
+							Name: fmt.Sprintf("amp-backend:%s", backend.Options.ImageTag)}}},
 			},
 			Replicas: backend.Options.CronReplicas,
 			Selector: map[string]string{"deploymentConfig": "backend-cron"},
@@ -259,7 +261,7 @@ func (backend *Backend) ListenerDeploymentConfig() *appsv1.DeploymentConfig {
 						ContainerNames: []string{"backend-listener"},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-backend:latest"}}},
+							Name: fmt.Sprintf("amp-backend:%s", backend.Options.ImageTag)}}},
 			},
 			Replicas: backend.Options.ListenerReplicas,
 			Selector: map[string]string{"deploymentConfig": "backend-listener"},

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -16,6 +16,7 @@ type BackendOptions struct {
 	StorageSentinelRole          string
 	QueuesSentinelHosts          string
 	QueuesSentinelRole           string
+	ImageTag                     string                  `validate:"required"`
 	ListenerResourceRequirements v1.ResourceRequirements `validate:"-"`
 	WorkerResourceRequirements   v1.ResourceRequirements `validate:"-"`
 	CronResourceRequirements     v1.ResourceRequirements `validate:"-"`

--- a/pkg/3scale/amp/component/memcached.go
+++ b/pkg/3scale/amp/component/memcached.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -64,7 +66,7 @@ func (m *Memcached) DeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "system-memcached:latest",
+							Name: fmt.Sprintf("system-memcached:%s", m.Options.ImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/memcached_options.go
+++ b/pkg/3scale/amp/component/memcached_options.go
@@ -8,6 +8,7 @@ import (
 
 type MemcachedOptions struct {
 	AppLabel             string                  `validate:"required"`
+	ImageTag             string                  `validate:"required"`
 	ResourceRequirements v1.ResourceRequirements `validate:"-"`
 }
 

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -128,7 +130,7 @@ func (redis *Redis) buildDeploymentConfigTriggers() appsv1.DeploymentTriggerPoli
 				},
 				From: v1.ObjectReference{
 					Kind: "ImageStreamTag",
-					Name: "backend-redis:latest",
+					Name: fmt.Sprintf("backend-redis:%s", redis.Options.BackendImageTag),
 				},
 			},
 		},
@@ -461,16 +463,6 @@ func (redis *Redis) BackendImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "Backend Redis (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: redis.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: redis.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "Backend " + redis.Options.AmpRelease + " Redis",
@@ -532,7 +524,7 @@ func (redis *Redis) SystemDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "system-redis:latest",
+							Name: fmt.Sprintf("system-redis:%s", redis.Options.SystemImageTag),
 						},
 					},
 				},
@@ -679,16 +671,6 @@ func (redis *Redis) SystemImageStream() *imagev1.ImageStream {
 		TypeMeta: metav1.TypeMeta{APIVersion: "image.openshift.io/v1", Kind: "ImageStream"},
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
-				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "System Redis (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: redis.Options.AmpRelease,
-					},
-				},
 				imagev1.TagReference{
 					Name: redis.Options.AmpRelease,
 					Annotations: map[string]string{

--- a/pkg/3scale/amp/component/redis_options.go
+++ b/pkg/3scale/amp/component/redis_options.go
@@ -10,7 +10,9 @@ type RedisOptions struct {
 	AppLabel                                  string                   `validate:"required"`
 	AmpRelease                                string                   `validate:"required"`
 	BackendImage                              string                   `validate:"required"`
+	BackendImageTag                           string                   `validate:"required"`
 	SystemImage                               string                   `validate:"required"`
+	SystemImageTag                            string                   `validate:"required"`
 	BackendRedisContainerResourceRequirements *v1.ResourceRequirements `validate:"required"`
 	SystemRedisContainerResourceRequirements  *v1.ResourceRequirements `validate:"required"`
 	InsecureImportPolicy                      *bool                    `validate:"required"`

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -1,8 +1,10 @@
 package component
 
 import (
-	"k8s.io/api/policy/v1beta1"
+	"fmt"
 	"sort"
+
+	"k8s.io/api/policy/v1beta1"
 
 	"github.com/3scale/3scale-operator/pkg/common"
 
@@ -597,7 +599,7 @@ func (system *System) AppDeploymentConfig() *appsv1.DeploymentConfig {
 						ContainerNames: []string{"system-provider", "system-developer", "system-master"},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-system:latest"}}},
+							Name: fmt.Sprintf("amp-system:%s", system.Options.ImageTag)}}},
 			},
 			Replicas: *system.Options.AppReplicas,
 			Selector: map[string]string{"deploymentConfig": "system-app"},
@@ -848,7 +850,7 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 						ContainerNames: []string{"check-svc", "system-sidekiq"},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-system:latest"}}},
+							Name: fmt.Sprintf("amp-system:%s", system.Options.ImageTag)}}},
 			},
 			Replicas: *system.Options.SidekiqReplicas,
 			Selector: map[string]string{"deploymentConfig": "system-sidekiq"},
@@ -1217,7 +1219,7 @@ func (system *System) SphinxDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-system:latest",
+							Name: fmt.Sprintf("amp-system:%s", system.Options.ImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/system_mysql.go
+++ b/pkg/3scale/amp/component/system_mysql.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -135,7 +137,7 @@ func (mysql *SystemMysql) DeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "system-mysql:latest",
+							Name: fmt.Sprintf("system-mysql:%s", mysql.Options.ImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/system_mysql_image.go
+++ b/pkg/3scale/amp/component/system_mysql_image.go
@@ -42,16 +42,6 @@ func (s *SystemMySQLImage) ImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "System MySQL (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: s.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: s.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "System " + s.Options.AmpRelease + " MySQL",

--- a/pkg/3scale/amp/component/system_mysql_options.go
+++ b/pkg/3scale/amp/component/system_mysql_options.go
@@ -11,6 +11,7 @@ import (
 
 type SystemMysqlOptions struct {
 	AppLabel                      string                  `validate:"required"`
+	ImageTag                      string                  `validate:"required"`
 	DatabaseName                  string                  `validate:"required"`
 	User                          string                  `validate:"required"`
 	Password                      string                  `validate:"required"`

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -42,6 +42,8 @@ type SystemOptions struct {
 	ApicastSystemMasterBaseURL             string  `validate:"required"`
 	AdminEmail                             *string `validate:"required"`
 
+	ImageTag string `validate:"required"`
+
 	AppMasterContainerResourceRequirements    *v1.ResourceRequirements `validate:"required"`
 	AppProviderContainerResourceRequirements  *v1.ResourceRequirements `validate:"required"`
 	AppDeveloperContainerResourceRequirements *v1.ResourceRequirements `validate:"required"`

--- a/pkg/3scale/amp/component/system_postgresql.go
+++ b/pkg/3scale/amp/component/system_postgresql.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -111,7 +113,7 @@ func (p *SystemPostgreSQL) DeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "system-postgresql:latest",
+							Name: fmt.Sprintf("system-postgresql:%s", p.Options.ImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/system_postgresql_image.go
+++ b/pkg/3scale/amp/component/system_postgresql_image.go
@@ -42,16 +42,6 @@ func (s *SystemPostgreSQLImage) ImageStream() *imagev1.ImageStream {
 		Spec: imagev1.ImageStreamSpec{
 			Tags: []imagev1.TagReference{
 				imagev1.TagReference{
-					Name: "latest",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "System PostgreSQL (latest)",
-					},
-					From: &v1.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: s.Options.AmpRelease,
-					},
-				},
-				imagev1.TagReference{
 					Name: s.Options.AmpRelease,
 					Annotations: map[string]string{
 						"openshift.io/display-name": "System " + s.Options.AmpRelease + " PostgreSQL",

--- a/pkg/3scale/amp/component/system_postgresql_options.go
+++ b/pkg/3scale/amp/component/system_postgresql_options.go
@@ -12,6 +12,7 @@ import (
 type SystemPostgreSQLOptions struct {
 	ContainerResourceRequirements v1.ResourceRequirements `validate:"-"`
 	AppLabel                      string                  `validate:"required"`
+	ImageTag                      string                  `validate:"required"`
 	User                          string                  `validate:"required"`
 	Password                      string                  `validate:"required"`
 	DatabaseName                  string                  `validate:"required"`

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -471,7 +471,7 @@ func (zync *Zync) DatabaseDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "zync-database-postgresql:latest",
+							Name: fmt.Sprintf("zync-database-postgresql:%s", zync.Options.DatabaseImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/common"
 	"k8s.io/api/policy/v1beta1"
 
@@ -224,7 +226,7 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-zync:latest",
+							Name: fmt.Sprintf("amp-zync:%s", zync.Options.ImageTag),
 						},
 					},
 				},
@@ -387,7 +389,7 @@ func (zync *Zync) QueDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "amp-zync:latest",
+							Name: fmt.Sprintf("amp-zync:%s", zync.Options.ImageTag),
 						},
 					},
 				},

--- a/pkg/3scale/amp/component/zync_options.go
+++ b/pkg/3scale/amp/component/zync_options.go
@@ -13,6 +13,7 @@ import (
 type ZyncOptions struct {
 	DatabaseURL                           string                  `validate:"required"`
 	ImageTag                              string                  `validate:"required"`
+	DatabaseImageTag                      string                  `validate:"required"`
 	ContainerResourceRequirements         v1.ResourceRequirements `validate:"-"`
 	QueContainerResourceRequirements      v1.ResourceRequirements `validate:"-"`
 	DatabaseContainerResourceRequirements v1.ResourceRequirements `validate:"-"`

--- a/pkg/3scale/amp/component/zync_options.go
+++ b/pkg/3scale/amp/component/zync_options.go
@@ -12,6 +12,7 @@ import (
 // ZyncOptions container object with all required to create components
 type ZyncOptions struct {
 	DatabaseURL                           string                  `validate:"required"`
+	ImageTag                              string                  `validate:"required"`
 	ContainerResourceRequirements         v1.ResourceRequirements `validate:"-"`
 	QueContainerResourceRequirements      v1.ResourceRequirements `validate:"-"`
 	DatabaseContainerResourceRequirements v1.ResourceRequirements `validate:"-"`

--- a/pkg/3scale/amp/operator/ampimages_reconciler.go
+++ b/pkg/3scale/amp/operator/ampimages_reconciler.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	imagev1 "github.com/openshift/api/image/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -22,7 +23,7 @@ func NewAMPImagesReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicRec
 }
 
 func (r *AMPImagesReconciler) Reconcile() (reconcile.Result, error) {
-	ampImages, err := r.ampImages()
+	ampImages, err := AmpImages(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -65,16 +66,6 @@ func (r *AMPImagesReconciler) Reconcile() (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }
 
-// TODO should this be performed in another place
-func (r *AMPImagesReconciler) ampImages() (*component.AmpImages, error) {
-	optsProvider := NewAmpImagesOptionsProvider(r.apiManager)
-	opts, err := optsProvider.GetAmpImagesOptions()
-	if err != nil {
-		return nil, err
-	}
-	return component.NewAmpImages(opts), nil
-}
-
 func (r *AMPImagesReconciler) reconcileBackendImageStream(desiredImageStream *imagev1.ImageStream) error {
 	reconciler := NewImageStreamBaseReconciler(r.BaseAPIManagerLogicReconciler, NewImageStreamGenericReconciler())
 	return reconciler.Reconcile(desiredImageStream)
@@ -108,4 +99,13 @@ func (r *AMPImagesReconciler) reconcileSystemMemcachedImageStream(desiredImageSt
 func (r *AMPImagesReconciler) reconcileDeploymentsServiceAccount(desiredServiceAccount *v1.ServiceAccount) error {
 	reconciler := NewServiceAccountBaseReconciler(r.BaseAPIManagerLogicReconciler, NewCreateOnlyServiceAccountReconciler())
 	return reconciler.Reconcile(desiredServiceAccount)
+}
+
+func AmpImages(apimanager *appsv1alpha1.APIManager) (*component.AmpImages, error) {
+	optsProvider := NewAmpImagesOptionsProvider(apimanager)
+	opts, err := optsProvider.GetAmpImagesOptions()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewAmpImages(opts), nil
 }

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 )
@@ -25,6 +26,7 @@ func (a *ApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions,
 	a.apicastOptions.TenantName = *a.apimanager.Spec.TenantName
 	a.apicastOptions.WildcardDomain = a.apimanager.Spec.WildcardDomain
 	a.apicastOptions.ManagementAPI = *a.apimanager.Spec.Apicast.ApicastManagementAPI
+	a.apicastOptions.ImageTag = product.ThreescaleRelease
 	a.apicastOptions.OpenSSLVerify = strconv.FormatBool(*a.apimanager.Spec.Apicast.OpenSSLVerify)
 	a.apicastOptions.ResponseCodes = strconv.FormatBool(*a.apimanager.Spec.Apicast.IncludeResponseCodes)
 

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -51,6 +52,7 @@ func defaultApicastOptions() *component.ApicastOptions {
 		ResponseCodes:                  strconv.FormatBool(responseCodes),
 		TenantName:                     tenantName,
 		WildcardDomain:                 wildcardDomain,
+		ImageTag:                       product.ThreescaleRelease,
 		ProductionResourceRequirements: component.DefaultProductionResourceRequirements(),
 		StagingResourceRequirements:    component.DefaultStagingResourceRequirements(),
 		ProductionReplicas:             int32(productionReplicaCount),

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -68,7 +69,7 @@ func NewApicastReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicRecon
 }
 
 func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
-	apicast, err := r.apicast()
+	apicast, err := Apicast(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -111,15 +112,6 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }
 
-func (r *ApicastReconciler) apicast() (*component.Apicast, error) {
-	optsProvider := NewApicastOptionsProvider(r.apiManager)
-	opts, err := optsProvider.GetApicastOptions()
-	if err != nil {
-		return nil, err
-	}
-	return component.NewApicast(opts), nil
-}
-
 func (r *ApicastReconciler) reconcileStagingDeploymentConfig(desiredDeploymentConfig *appsv1.DeploymentConfig) error {
 	reconciler := NewDeploymentConfigBaseReconciler(r.BaseAPIManagerLogicReconciler, NewApicastDCReconciler(r.BaseAPIManagerLogicReconciler))
 	return reconciler.Reconcile(desiredDeploymentConfig)
@@ -143,4 +135,13 @@ func (r *ApicastReconciler) reconcileProductionService(desiredService *v1.Servic
 func (r *ApicastReconciler) reconcileEnvironmentConfigMap(desiredConfigMap *v1.ConfigMap) error {
 	reconciler := NewConfigMapBaseReconciler(r.BaseAPIManagerLogicReconciler, NewApicastEnvCMReconciler())
 	return reconciler.Reconcile(desiredConfigMap)
+}
+
+func Apicast(apimanager *appsv1alpha1.APIManager) (*component.Apicast, error) {
+	optsProvider := NewApicastOptionsProvider(apimanager)
+	opts, err := optsProvider.GetApicastOptions()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewApicast(opts), nil
 }

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ func (o *OperatorBackendOptionsProvider) GetBackendOptions() (*component.Backend
 	o.backendOptions.AppLabel = *o.apimanager.Spec.AppLabel
 	o.backendOptions.TenantName = *o.apimanager.Spec.TenantName
 	o.backendOptions.WildcardDomain = o.apimanager.Spec.WildcardDomain
+	o.backendOptions.ImageTag = product.ThreescaleRelease
 
 	err := o.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -83,6 +84,7 @@ func defaultBackendOptions(opts *component.BackendOptions) *component.BackendOpt
 		SystemBackendPassword:        opts.SystemBackendPassword,
 		TenantName:                   tenantName,
 		WildcardDomain:               wildcardDomain,
+		ImageTag:                     product.ThreescaleRelease,
 	}
 }
 

--- a/pkg/3scale/amp/operator/memcached_options_provider.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 )
@@ -20,6 +21,7 @@ func NewMemcachedOptionsProvider(apimanager *appsv1alpha1.APIManager) *Memcached
 
 func (m *MemcachedOptionsProvider) GetMemcachedOptions() (*component.MemcachedOptions, error) {
 	m.memcachedOptions.AppLabel = *m.apimanager.Spec.AppLabel
+	m.memcachedOptions.ImageTag = product.ThreescaleRelease
 
 	m.setResourceRequirementsOptions()
 

--- a/pkg/3scale/amp/operator/memcached_options_provider_test.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -15,6 +16,7 @@ import (
 func defaultMemcachedOptions() *component.MemcachedOptions {
 	return &component.MemcachedOptions{
 		AppLabel:             appLabel,
+		ImageTag:             product.ThreescaleRelease,
 		ResourceRequirements: component.DefaultMemcachedResourceRequirements(),
 	}
 }

--- a/pkg/3scale/amp/operator/memcached_reconciler.go
+++ b/pkg/3scale/amp/operator/memcached_reconciler.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -39,7 +40,7 @@ func NewMemcachedReconciler(baseAPIManagerLogicReconciler BaseAPIManagerLogicRec
 }
 
 func (r *MemcachedReconciler) Reconcile() (reconcile.Result, error) {
-	memcached, err := r.memcached()
+	memcached, err := Memcached(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -52,16 +53,16 @@ func (r *MemcachedReconciler) Reconcile() (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }
 
-func (r *MemcachedReconciler) memcached() (*component.Memcached, error) {
-	optsProvider := NewMemcachedOptionsProvider(r.apiManager)
+func (r *MemcachedReconciler) reconcileMemcachedDeploymentConfig(desiredDeploymentConfig *appsv1.DeploymentConfig) error {
+	reconciler := NewDeploymentConfigBaseReconciler(r.BaseAPIManagerLogicReconciler, NewMemcachedDCReconciler(r.BaseAPIManagerLogicReconciler))
+	return reconciler.Reconcile(desiredDeploymentConfig)
+}
+
+func Memcached(apimanager *appsv1alpha1.APIManager) (*component.Memcached, error) {
+	optsProvider := NewMemcachedOptionsProvider(apimanager)
 	opts, err := optsProvider.GetMemcachedOptions()
 	if err != nil {
 		return nil, err
 	}
 	return component.NewMemcached(opts), nil
-}
-
-func (r *MemcachedReconciler) reconcileMemcachedDeploymentConfig(desiredDeploymentConfig *appsv1.DeploymentConfig) error {
-	reconciler := NewDeploymentConfigBaseReconciler(r.BaseAPIManagerLogicReconciler, NewMemcachedDCReconciler(r.BaseAPIManagerLogicReconciler))
-	return reconciler.Reconcile(desiredDeploymentConfig)
 }

--- a/pkg/3scale/amp/operator/redis_options_provider.go
+++ b/pkg/3scale/amp/operator/redis_options_provider.go
@@ -22,6 +22,9 @@ func NewRedisOptionsProvider(apimanager *appsv1alpha1.APIManager) *RedisOptionsP
 func (r *RedisOptionsProvider) GetRedisOptions() (*component.RedisOptions, error) {
 	r.options.AppLabel = *r.apimanager.Spec.AppLabel
 	r.options.AmpRelease = product.ThreescaleRelease
+	r.options.BackendImageTag = product.ThreescaleRelease
+	r.options.SystemImageTag = product.ThreescaleRelease
+
 	r.options.InsecureImportPolicy = r.apimanager.Spec.ImageStreamTagImportInsecure
 
 	r.options.BackendImage = BackendRedisImageURL()

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -16,10 +16,12 @@ import (
 func defaultRedisOptions() *component.RedisOptions {
 	tmpInsecure := insecureImportPolicy
 	return &component.RedisOptions{
-		AppLabel:     appLabel,
-		AmpRelease:   product.ThreescaleRelease,
-		BackendImage: component.BackendRedisImageURL(),
-		SystemImage:  component.SystemRedisImageURL(),
+		AppLabel:        appLabel,
+		AmpRelease:      product.ThreescaleRelease,
+		BackendImageTag: product.ThreescaleRelease,
+		SystemImageTag:  product.ThreescaleRelease,
+		BackendImage:    component.BackendRedisImageURL(),
+		SystemImage:     component.SystemRedisImageURL(),
 		BackendRedisContainerResourceRequirements: component.DefaultBackendRedisContainerResourceRequirements(),
 		SystemRedisContainerResourceRequirements:  component.DefaultSystemRedisContainerResourceRequirements(),
 		InsecureImportPolicy:                      &tmpInsecure,

--- a/pkg/3scale/amp/operator/system_mysql_image_reconciler.go
+++ b/pkg/3scale/amp/operator/system_mysql_image_reconciler.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	imagev1 "github.com/openshift/api/image/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -20,7 +21,7 @@ func NewSystemMySQLImageReconciler(baseAPIManagerLogicReconciler BaseAPIManagerL
 }
 
 func (r *SystemMySQLImageReconciler) Reconcile() (reconcile.Result, error) {
-	systemMySQLImage, err := r.systemMySQLImage()
+	systemMySQLImage, err := SystemMySQLImage(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -33,16 +34,16 @@ func (r *SystemMySQLImageReconciler) Reconcile() (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }
 
-func (r *SystemMySQLImageReconciler) systemMySQLImage() (*component.SystemMySQLImage, error) {
-	optsProvider := NewSystemMysqlImageOptionsProvider(r.apiManager)
+func (r *SystemMySQLImageReconciler) reconcileSystemMySQLImageStream(desiredImageStream *imagev1.ImageStream) error {
+	reconciler := NewImageStreamBaseReconciler(r.BaseAPIManagerLogicReconciler, NewImageStreamGenericReconciler())
+	return reconciler.Reconcile(desiredImageStream)
+}
+
+func SystemMySQLImage(apimanager *appsv1alpha1.APIManager) (*component.SystemMySQLImage, error) {
+	optsProvider := NewSystemMysqlImageOptionsProvider(apimanager)
 	opts, err := optsProvider.GetSystemMySQLImageOptions()
 	if err != nil {
 		return nil, err
 	}
 	return component.NewSystemMySQLImage(opts), nil
-}
-
-func (r *SystemMySQLImageReconciler) reconcileSystemMySQLImageStream(desiredImageStream *imagev1.ImageStream) error {
-	reconciler := NewImageStreamBaseReconciler(r.BaseAPIManagerLogicReconciler, NewImageStreamGenericReconciler())
-	return reconciler.Reconcile(desiredImageStream)
 }

--- a/pkg/3scale/amp/operator/system_mysql_options_provider.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ func NewSystemMysqlOptionsProvider(apimanager *appsv1alpha1.APIManager, namespac
 
 func (s *SystemMysqlOptionsProvider) GetMysqlOptions() (*component.SystemMysqlOptions, error) {
 	s.mysqlOptions.AppLabel = *s.apimanager.Spec.AppLabel
+	s.mysqlOptions.ImageTag = product.ThreescaleRelease
 
 	err := s.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -24,6 +25,7 @@ const (
 func defaultSystemMysqlOptions(opts *component.SystemMysqlOptions) *component.SystemMysqlOptions {
 	return &component.SystemMysqlOptions{
 		AppLabel:                      appLabel,
+		ImageTag:                      product.ThreescaleRelease,
 		DatabaseName:                  component.DefaultSystemMysqlDatabaseName(),
 		User:                          component.DefaultSystemMysqlUser(),
 		Password:                      opts.Password,

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -32,6 +32,7 @@ func NewSystemOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace str
 func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, error) {
 	s.options.AppLabel = *s.apimanager.Spec.AppLabel
 	s.options.AmpRelease = product.ThreescaleRelease
+	s.options.ImageTag = product.ThreescaleRelease
 	s.options.ApicastRegistryURL = *s.apimanager.Spec.Apicast.RegistryURL
 	s.options.TenantName = *s.apimanager.Spec.TenantName
 	s.options.WildcardDomain = s.apimanager.Spec.WildcardDomain

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -128,6 +128,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		TenantName:                               tenantName,
 		WildcardDomain:                           wildcardDomain,
 		AmpRelease:                               product.ThreescaleRelease,
+		ImageTag:                                 product.ThreescaleRelease,
 		ApicastRegistryURL:                       apicastRegistryURL,
 		AppMasterContainerResourceRequirements:   component.DefaultAppMasterContainerResourceRequirements(),
 		AppProviderContainerResourceRequirements: component.DefaultAppProviderContainerResourceRequirements(),

--- a/pkg/3scale/amp/operator/system_postgresql_image_reconciler.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image_reconciler.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	imagev1 "github.com/openshift/api/image/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -20,7 +21,7 @@ func NewSystemPostgreSQLImageReconciler(baseAPIManagerLogicReconciler BaseAPIMan
 }
 
 func (r *SystemPostgreSQLImageReconciler) Reconcile() (reconcile.Result, error) {
-	systemPostgreSQLImage, err := r.systemPostgreSQLImage()
+	systemPostgreSQLImage, err := SystemPostgreSQLImage(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -33,16 +34,16 @@ func (r *SystemPostgreSQLImageReconciler) Reconcile() (reconcile.Result, error) 
 	return reconcile.Result{}, nil
 }
 
-func (r *SystemPostgreSQLImageReconciler) systemPostgreSQLImage() (*component.SystemPostgreSQLImage, error) {
-	optsProvider := NewSystemPostgreSQLImageOptionsProvider(r.apiManager)
+func (r *SystemPostgreSQLImageReconciler) reconcileSystemPostgreSQLImageStream(desiredImageStream *imagev1.ImageStream) error {
+	reconciler := NewImageStreamBaseReconciler(r.BaseAPIManagerLogicReconciler, NewImageStreamGenericReconciler())
+	return reconciler.Reconcile(desiredImageStream)
+}
+
+func SystemPostgreSQLImage(apimanager *appsv1alpha1.APIManager) (*component.SystemPostgreSQLImage, error) {
+	optsProvider := NewSystemPostgreSQLImageOptionsProvider(apimanager)
 	opts, err := optsProvider.GetSystemPostgreSQLImageOptions()
 	if err != nil {
 		return nil, err
 	}
 	return component.NewSystemPostgreSQLImage(opts), nil
-}
-
-func (r *SystemPostgreSQLImageReconciler) reconcileSystemPostgreSQLImageStream(desiredImageStream *imagev1.ImageStream) error {
-	reconciler := NewImageStreamBaseReconciler(r.BaseAPIManagerLogicReconciler, NewImageStreamGenericReconciler())
-	return reconciler.Reconcile(desiredImageStream)
 }

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ func NewSystemPostgresqlOptionsProvider(apimanager *appsv1alpha1.APIManager, nam
 
 func (s *SystemPostgresqlOptionsProvider) GetSystemPostgreSQLOptions() (*component.SystemPostgreSQLOptions, error) {
 	s.options.AppLabel = *s.apimanager.Spec.AppLabel
+	s.options.ImageTag = product.ThreescaleRelease
 
 	err := s.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -25,6 +26,7 @@ const (
 func defaultSystemPostgreSQLOptions(opts *component.SystemPostgreSQLOptions) *component.SystemPostgreSQLOptions {
 	return &component.SystemPostgreSQLOptions{
 		AppLabel:                      appLabel,
+		ImageTag:                      product.ThreescaleRelease,
 		DatabaseName:                  component.DefaultSystemPostgresqlDatabaseName(),
 		User:                          component.DefaultSystemPostgresqlUser(),
 		Password:                      opts.Password,

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -147,6 +147,11 @@ func (u *UpgradeApiManager) upgradeZyncDeploymentConfigs() (reconcile.Result, er
 		return res, err
 	}
 
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(zync.DatabaseDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -293,6 +298,11 @@ func (u *UpgradeApiManager) deleteAmpOldImageStreamsTags() (reconcile.Result, er
 	}
 
 	res, err = u.deleteOldImageStreamTags(ampimages.ZyncImageStream().GetName())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteOldImageStreamTags(ampimages.ZyncDatabasePostgreSQLImageStream().GetName())
 	if res.Requeue || err != nil {
 		return res, err
 	}

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -80,6 +80,11 @@ func (u *UpgradeApiManager) upgradeDeploymentConfigs() (reconcile.Result, error)
 		return res, err
 	}
 
+	res, err = u.upgradeZyncDeploymentConfigs()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -119,6 +124,25 @@ func (u *UpgradeApiManager) upgradeBackendDeploymentConfigs() (reconcile.Result,
 	}
 
 	res, err = u.upgradeDeploymentConfigImageChangeTrigger(backend.CronDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeZyncDeploymentConfigs() (reconcile.Result, error) {
+	zync, err := Zync(u.Cr, u.Client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.upgradeDeploymentConfigImageChangeTrigger(zync.DeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(zync.QueDeploymentConfig())
 	if res.Requeue || err != nil {
 		return res, err
 	}
@@ -264,6 +288,11 @@ func (u *UpgradeApiManager) deleteAmpOldImageStreamsTags() (reconcile.Result, er
 	}
 
 	res, err = u.deleteOldImageStreamTags(ampimages.BackendImageStream().GetName())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteOldImageStreamTags(ampimages.ZyncImageStream().GetName())
 	if res.Requeue || err != nil {
 		return res, err
 	}

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -85,6 +85,11 @@ func (u *UpgradeApiManager) upgradeDeploymentConfigs() (reconcile.Result, error)
 		return res, err
 	}
 
+	res, err = u.upgradeSystemDeploymentConfigs()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -148,6 +153,30 @@ func (u *UpgradeApiManager) upgradeZyncDeploymentConfigs() (reconcile.Result, er
 	}
 
 	res, err = u.upgradeDeploymentConfigImageChangeTrigger(zync.DatabaseDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeSystemDeploymentConfigs() (reconcile.Result, error) {
+	system, err := System(u.Cr, u.Client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.upgradeDeploymentConfigImageChangeTrigger(system.AppDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(system.SidekiqDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(system.SphinxDeploymentConfig())
 	if res.Requeue || err != nil {
 		return res, err
 	}
@@ -303,6 +332,11 @@ func (u *UpgradeApiManager) deleteAmpOldImageStreamsTags() (reconcile.Result, er
 	}
 
 	res, err = u.deleteOldImageStreamTags(ampimages.ZyncDatabasePostgreSQLImageStream().GetName())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteOldImageStreamTags(ampimages.SystemImageStream().GetName())
 	if res.Requeue || err != nil {
 		return res, err
 	}

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -1,9 +1,17 @@
 package operator
 
 import (
+	"context"
+	"fmt"
+	"reflect"
+
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	appsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -48,7 +56,89 @@ func (u *UpgradeApiManager) upgradeImages() (reconcile.Result, error) {
 		}
 	}
 
+	res, err = u.upgradeDeploymentConfigs()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteOldImageStreamsTags()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeDeploymentConfigs() (reconcile.Result, error) {
+	res, err := u.upgradeAPIcastDeploymentConfigs()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeAPIcastDeploymentConfigs() (reconcile.Result, error) {
+	apicast, err := Apicast(u.Cr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.upgradeDeploymentConfigImageChangeTrigger(apicast.StagingDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(apicast.ProductionDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeDeploymentConfigImageChangeTrigger(desired *appsv1.DeploymentConfig) (reconcile.Result, error) {
+	existing := &appsv1.DeploymentConfig{}
+	err := u.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: u.Cr.Namespace}, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	changed, err := u.ensureDeploymentConfigImageChangeTrigger(desired, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if changed {
+		u.Logger.Info(fmt.Sprintf("Update object %s", ObjectInfo(existing)))
+		err := u.Client.Update(context.TODO(), existing)
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) ensureDeploymentConfigImageChangeTrigger(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	desiredDeploymentTriggerImageChangePos, err := u.findDeploymentTriggerOnImageChange(desired.Spec.Triggers)
+	if err != nil {
+		return false, fmt.Errorf("unexpected: '%s' in DeploymentConfig '%s'", err, desired.Name)
+
+	}
+	existingDeploymentTriggerImageChangePos, err := u.findDeploymentTriggerOnImageChange(existing.Spec.Triggers)
+	if err != nil {
+		return false, fmt.Errorf("unexpected: '%s' in DeploymentConfig '%s'", err, existing.Name)
+	}
+
+	desiredDeploymentTriggerImageChangeParams := desired.Spec.Triggers[desiredDeploymentTriggerImageChangePos].ImageChangeParams
+	existingDeploymentTriggerImageChangeParams := existing.Spec.Triggers[existingDeploymentTriggerImageChangePos].ImageChangeParams
+
+	if !reflect.DeepEqual(existingDeploymentTriggerImageChangeParams.From.Name, desiredDeploymentTriggerImageChangeParams.From.Name) {
+		diff := cmp.Diff(existingDeploymentTriggerImageChangeParams.From.Name, desiredDeploymentTriggerImageChangeParams.From.Name)
+		u.Logger.V(1).Info(fmt.Sprintf("%s ImageStream tag name in imageChangeParams trigger changed: %s", desired.Name, diff))
+		existingDeploymentTriggerImageChangeParams.From.Name = desiredDeploymentTriggerImageChangeParams.From.Name
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (u *UpgradeApiManager) upgradeAMPImageStreams() (reconcile.Result, error) {
@@ -104,4 +194,100 @@ func (u *UpgradeApiManager) upgradeSystemPostgreSQLImageStream() (reconcile.Resu
 	baseLogicReconciler := NewBaseLogicReconciler(baseReconciler)
 	reconciler := NewSystemPostgreSQLImageReconciler(NewBaseAPIManagerLogicReconciler(baseLogicReconciler, u.Cr))
 	return reconciler.Reconcile()
+}
+
+func (u *UpgradeApiManager) findDeploymentTriggerOnImageChange(triggerPolicies []appsv1.DeploymentTriggerPolicy) (int, error) {
+	result := -1
+	for i := range triggerPolicies {
+		if triggerPolicies[i].Type == appsv1.DeploymentTriggerOnImageChange {
+			if result != -1 {
+				return -1, fmt.Errorf("found more than one imageChangeParams Deployment trigger policy")
+			}
+			result = i
+		}
+	}
+
+	if result == -1 {
+		return -1, fmt.Errorf("no imageChangeParams deployment trigger policy found")
+	}
+
+	return result, nil
+}
+
+func (u *UpgradeApiManager) deleteOldImageStreamsTags() (reconcile.Result, error) {
+	res, err := u.deleteAmpOldImageStreamsTags()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) deleteAmpOldImageStreamsTags() (reconcile.Result, error) {
+	ampimages, err := AmpImages(u.Cr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.deleteOldImageStreamTags(ampimages.APICastImageStream().GetName())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) deleteOldImageStreamTags(imageStreamName string) (reconcile.Result, error) {
+	existingImageStream := &imagev1.ImageStream{}
+	err := u.Client.Get(context.TODO(), types.NamespacedName{Name: imageStreamName, Namespace: u.Cr.Namespace}, existingImageStream)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	latestTagName := "latest"
+	return u.deleteImageStreamTag(latestTagName, existingImageStream)
+}
+
+// deleteImageStreamTag deletes the corresponding ImageStreamTag object
+// in case the tag is found in the Spec definition of the existing ImageStream
+// object.
+// Deleting the tag element directly from the Spec section of the ImageStream
+// does not completely remove the tag: The ImageStream object still has the
+// removed tag in the status section of the object and the ImageStreamTag
+// object still exists.
+// Instead of doing that, this method searches for a tag in Spec section of the
+// existing ImageStream object and if it exists then it tries to delete the
+// corresponding ImageStreamTag object.
+// When deleting the ImageStreamTag object the tag is automatically removed
+// from the Spec and Status sections of the corresponding
+// ImageStream object
+func (u *UpgradeApiManager) deleteImageStreamTag(tagRefName string, existing *imagev1.ImageStream) (reconcile.Result, error) {
+	pos := u.findTagReference(tagRefName, existing.Spec.Tags)
+	if pos != -1 {
+		existingIsTag := &imagev1.ImageStreamTag{}
+		// We use ApiClientReader instead of the Client due to
+		// The operator-sdk Client automatically performs a Watch on all the objects
+		// That are obtained with Get, but the ImageStreamTag kind does not have
+		// the Watch verb, which caused errors.
+		err := u.ApiClientReader.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s:%s", existing.Name, tagRefName), Namespace: u.Cr.Namespace}, existingIsTag)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		u.Logger.Info(fmt.Sprintf("Delete object ImageStreamTag/%s", existingIsTag.GetName()))
+		err = u.Client.Delete(context.TODO(), existingIsTag)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) findTagReference(tagRefName string, tagRefs []imagev1.TagReference) int {
+	for i := range tagRefs {
+		if tagRefs[i].Name == tagRefName {
+			return i
+		}
+	}
+	return -1
 }

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -75,6 +75,11 @@ func (u *UpgradeApiManager) upgradeDeploymentConfigs() (reconcile.Result, error)
 		return res, err
 	}
 
+	res, err = u.upgradeBackendDeploymentConfigs()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -90,6 +95,30 @@ func (u *UpgradeApiManager) upgradeAPIcastDeploymentConfigs() (reconcile.Result,
 	}
 
 	res, err = u.upgradeDeploymentConfigImageChangeTrigger(apicast.ProductionDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeBackendDeploymentConfigs() (reconcile.Result, error) {
+	backend, err := Backend(u.Cr, u.Client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.upgradeDeploymentConfigImageChangeTrigger(backend.ListenerDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(backend.WorkerDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.upgradeDeploymentConfigImageChangeTrigger(backend.CronDeploymentConfig())
 	if res.Requeue || err != nil {
 		return res, err
 	}
@@ -230,6 +259,11 @@ func (u *UpgradeApiManager) deleteAmpOldImageStreamsTags() (reconcile.Result, er
 	}
 
 	res, err := u.deleteOldImageStreamTags(ampimages.APICastImageStream().GetName())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteOldImageStreamTags(ampimages.BackendImageStream().GetName())
 	if res.Requeue || err != nil {
 		return res, err
 	}

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -85,6 +85,11 @@ func (u *UpgradeApiManager) upgradeDeploymentConfigs() (reconcile.Result, error)
 		return res, err
 	}
 
+	res, err = u.upgradeMemcachedDeploymentConfig()
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
 	res, err = u.upgradeSystemDeploymentConfigs()
 	if res.Requeue || err != nil {
 		return res, err
@@ -153,6 +158,20 @@ func (u *UpgradeApiManager) upgradeZyncDeploymentConfigs() (reconcile.Result, er
 	}
 
 	res, err = u.upgradeDeploymentConfigImageChangeTrigger(zync.DatabaseDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeMemcachedDeploymentConfig() (reconcile.Result, error) {
+	memcached, err := Memcached(u.Cr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.upgradeDeploymentConfigImageChangeTrigger(memcached.DeploymentConfig())
 	if res.Requeue || err != nil {
 		return res, err
 	}
@@ -337,6 +356,11 @@ func (u *UpgradeApiManager) deleteAmpOldImageStreamsTags() (reconcile.Result, er
 	}
 
 	res, err = u.deleteOldImageStreamTags(ampimages.SystemImageStream().GetName())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteOldImageStreamTags(ampimages.SystemMemcachedImageStream().GetName())
 	if res.Requeue || err != nil {
 		return res, err
 	}

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ func NewZyncOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace strin
 
 func (z *ZyncOptionsProvider) GetZyncOptions() (*component.ZyncOptions, error) {
 	z.zyncOptions.AppLabel = *z.apimanager.Spec.AppLabel
+	z.zyncOptions.ImageTag = product.ThreescaleRelease
 
 	err := z.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -30,6 +30,7 @@ func NewZyncOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace strin
 func (z *ZyncOptionsProvider) GetZyncOptions() (*component.ZyncOptions, error) {
 	z.zyncOptions.AppLabel = *z.apimanager.Spec.AppLabel
 	z.zyncOptions.ImageTag = product.ThreescaleRelease
+	z.zyncOptions.DatabaseImageTag = product.ThreescaleRelease
 
 	err := z.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -48,6 +48,7 @@ func defaultZyncOptions(opts *component.ZyncOptions) *component.ZyncOptions {
 	expectedOpts := &component.ZyncOptions{
 		AppLabel:                              appLabel,
 		ImageTag:                              product.ThreescaleRelease,
+		DatabaseImageTag:                      product.ThreescaleRelease,
 		ContainerResourceRequirements:         component.DefaultZyncContainerResourceRequirements(),
 		QueContainerResourceRequirements:      component.DefaultZyncQueContainerResourceRequirements(),
 		DatabaseContainerResourceRequirements: component.DefaultZyncDatabaseContainerResourceRequirements(),

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -46,6 +47,7 @@ func basicApimanagerSpecTestZyncOptions() *appsv1alpha1.APIManager {
 func defaultZyncOptions(opts *component.ZyncOptions) *component.ZyncOptions {
 	expectedOpts := &component.ZyncOptions{
 		AppLabel:                              appLabel,
+		ImageTag:                              product.ThreescaleRelease,
 		ContainerResourceRequirements:         component.DefaultZyncContainerResourceRequirements(),
 		QueContainerResourceRequirements:      component.DefaultZyncQueContainerResourceRequirements(),
 		DatabaseContainerResourceRequirements: component.DefaultZyncDatabaseContainerResourceRequirements(),

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -11,7 +11,7 @@ type Apicast struct {
 }
 
 func NewApicastAdapter(generatePDB bool) Adapter {
-	return NewAppenderAdapter(&Apicast{generatePodDisruptionBudget:generatePDB})
+	return NewAppenderAdapter(&Apicast{generatePodDisruptionBudget: generatePDB})
 }
 
 func (a *Apicast) Parameters() []templatev1.Parameter {
@@ -71,6 +71,7 @@ func (a *Apicast) options() (*component.ApicastOptions, error) {
 	ao.ResponseCodes = "${APICAST_RESPONSE_CODES}"
 	ao.TenantName = "${TENANT_NAME}"
 	ao.WildcardDomain = "${WILDCARD_DOMAIN}"
+	ao.ImageTag = "${AMP_RELEASE}"
 
 	ao.ProductionResourceRequirements = component.DefaultProductionResourceRequirements()
 	ao.StagingResourceRequirements = component.DefaultStagingResourceRequirements()

--- a/pkg/3scale/amp/template/adapters/backend.go
+++ b/pkg/3scale/amp/template/adapters/backend.go
@@ -14,7 +14,7 @@ type Backend struct {
 
 func NewBackendAdapter(generatePDB bool) Adapter {
 	return NewAppenderAdapter(&Backend{
-		generatePodDisruptionBudget:generatePDB,
+		generatePodDisruptionBudget: generatePDB,
 	})
 }
 
@@ -42,6 +42,7 @@ func (b *Backend) options() (*component.BackendOptions, error) {
 	bo.SystemBackendPassword = "${SYSTEM_BACKEND_PASSWORD}"
 	bo.TenantName = "${TENANT_NAME}"
 	bo.WildcardDomain = "${WILDCARD_DOMAIN}"
+	bo.ImageTag = "${AMP_RELEASE}"
 	bo.RouteEndpoint = fmt.Sprintf("https://backend-%s.%s", "${TENANT_NAME}", "${WILDCARD_DOMAIN}")
 	bo.ServiceEndpoint = component.DefaultBackendServiceEndpoint()
 	bo.StorageURL = component.DefaultBackendRedisStorageURL()

--- a/pkg/3scale/amp/template/adapters/memcached.go
+++ b/pkg/3scale/amp/template/adapters/memcached.go
@@ -29,6 +29,7 @@ func (m *MemcachedAdapter) Objects() ([]common.KubernetesObject, error) {
 func (m *MemcachedAdapter) options() (*component.MemcachedOptions, error) {
 	mo := component.NewMemcachedOptions()
 	mo.AppLabel = "${APP_LABEL}"
+	mo.ImageTag = "${AMP_RELEASE}"
 	mo.ResourceRequirements = component.DefaultMemcachedResourceRequirements()
 
 	err := mo.Validate()

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -40,8 +40,11 @@ func (r *RedisAdapter) options() (*component.RedisOptions, error) {
 	ro := component.NewRedisOptions()
 	ro.AppLabel = "${APP_LABEL}"
 	ro.AmpRelease = "${AMP_RELEASE}"
+	ro.BackendImageTag = "${AMP_RELEASE}"
 	ro.BackendImage = "${REDIS_IMAGE}"
+	ro.SystemImageTag = "${AMP_RELEASE}"
 	ro.SystemImage = "${REDIS_IMAGE}"
+
 	ro.BackendRedisContainerResourceRequirements = component.DefaultBackendRedisContainerResourceRequirements()
 	ro.SystemRedisContainerResourceRequirements = component.DefaultSystemRedisContainerResourceRequirements()
 	tmp := component.InsecureImportPolicy

--- a/pkg/3scale/amp/template/adapters/system-mysql.go
+++ b/pkg/3scale/amp/template/adapters/system-mysql.go
@@ -60,6 +60,7 @@ func (m *SystemMysqlAdapter) Objects() ([]common.KubernetesObject, error) {
 func (a *SystemMysqlAdapter) options() (*component.SystemMysqlOptions, error) {
 	mo := component.NewSystemMysqlOptions()
 	mo.AppLabel = "${APP_LABEL}"
+	mo.ImageTag = "${AMP_RELEASE}"
 	mo.DatabaseName = "${SYSTEM_DATABASE}"
 	mo.User = "${SYSTEM_DATABASE_USER}"
 	mo.Password = "${SYSTEM_DATABASE_PASSWORD}"

--- a/pkg/3scale/amp/template/adapters/system-postgresql.go
+++ b/pkg/3scale/amp/template/adapters/system-postgresql.go
@@ -52,6 +52,7 @@ func (r *SystemPostgreSQLAdapter) Objects() ([]common.KubernetesObject, error) {
 func (r *SystemPostgreSQLAdapter) options() (*component.SystemPostgreSQLOptions, error) {
 	o := component.NewSystemPostgreSQLOptions()
 	o.AppLabel = "${APP_LABEL}"
+	o.ImageTag = "${AMP_RELEASE}"
 	o.DatabaseName = "${SYSTEM_DATABASE}"
 	o.User = "${SYSTEM_DATABASE_USER}"
 	o.Password = "${SYSTEM_DATABASE_PASSWORD}"

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -146,6 +146,7 @@ func (s *System) options() (*component.SystemOptions, error) {
 	adminEmail := "${ADMIN_EMAIL}"
 	o.AdminEmail = &adminEmail
 	o.AmpRelease = "${AMP_RELEASE}"
+	o.ImageTag = "${AMP_RELEASE}"
 	o.ApicastAccessToken = "${APICAST_ACCESS_TOKEN}"
 	o.ApicastRegistryURL = "${APICAST_REGISTRY_URL}"
 	o.MasterAccessToken = "${MASTER_ACCESS_TOKEN}"

--- a/pkg/3scale/amp/template/adapters/zync.go
+++ b/pkg/3scale/amp/template/adapters/zync.go
@@ -59,6 +59,7 @@ func (z *Zync) options() (*component.ZyncOptions, error) {
 	zo.DatabasePassword = "${ZYNC_DATABASE_PASSWORD}"
 	zo.SecretKeyBase = "${ZYNC_SECRET_KEY_BASE}"
 	zo.ImageTag = "${AMP_RELEASE}"
+	zo.DatabaseImageTag = "${AMP_RELEASE}"
 
 	zo.ZyncReplicas = 1
 	zo.ZyncQueReplicas = 1

--- a/pkg/3scale/amp/template/adapters/zync.go
+++ b/pkg/3scale/amp/template/adapters/zync.go
@@ -11,7 +11,7 @@ type Zync struct {
 }
 
 func NewZyncAdapter(generatePDB bool) Adapter {
-	return NewAppenderAdapter(&Zync{generatePodDisruptionBudget:generatePDB})
+	return NewAppenderAdapter(&Zync{generatePodDisruptionBudget: generatePDB})
 }
 
 func (z *Zync) Parameters() []templatev1.Parameter {
@@ -58,6 +58,7 @@ func (z *Zync) options() (*component.ZyncOptions, error) {
 	zo.AuthenticationToken = "${ZYNC_AUTHENTICATION_TOKEN}"
 	zo.DatabasePassword = "${ZYNC_DATABASE_PASSWORD}"
 	zo.SecretKeyBase = "${ZYNC_SECRET_KEY_BASE}"
+	zo.ImageTag = "${AMP_RELEASE}"
 
 	zo.ZyncReplicas = 1
 	zo.ZyncQueReplicas = 1

--- a/pkg/controller/apimanager/apimanager_controller_test.go
+++ b/pkg/controller/apimanager/apimanager_controller_test.go
@@ -2,13 +2,10 @@ package apimanager
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
-	"github.com/3scale/3scale-operator/version"
 	appsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -109,109 +106,5 @@ func TestAPIManagerControllerCreate(t *testing.T) {
 
 	if *backendListenerExistingReplicas != 1 {
 		t.Errorf("APIManager's backend listener replicas size (%d) is not the expected size (%d)", backendListenerExistingReplicas, 1)
-	}
-}
-
-func TestAPIManagerControllerUpgrade(t *testing.T) {
-	var (
-		name           = "example-apimanager"
-		namespace      = "operator-unittest"
-		wildcardDomain = "test.3scale.net"
-	)
-
-	apimanager := &appsv1alpha1.APIManager{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				appsv1alpha1.OperatorVersionAnnotation:   fmt.Sprintf("not_%s", version.Version),
-				appsv1alpha1.ThreescaleVersionAnnotation: "something",
-			},
-		},
-		Spec: appsv1alpha1.APIManagerSpec{
-			APIManagerCommonSpec: appsv1alpha1.APIManagerCommonSpec{
-				WildcardDomain: wildcardDomain,
-			},
-		},
-	}
-
-	// Objects to track in the fake client.
-	objs := []runtime.Object{apimanager}
-
-	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
-	s.AddKnownTypes(appsv1alpha1.SchemeGroupVersion, apimanager)
-	err := appsv1.AddToScheme(s)
-	if err != nil {
-		t.Fatalf("Unable to add Apps scheme: (%v)", err)
-	}
-	err = imagev1.AddToScheme(s)
-	if err != nil {
-		t.Fatalf("Unable to add Image scheme: (%v)", err)
-	}
-	err = routev1.AddToScheme(s)
-	if err != nil {
-		t.Fatalf("Unable to add Route scheme: (%v)", err)
-	}
-
-	// Create a fake client to mock API calls.
-	cl := fake.NewFakeClient(objs...)
-	clientAPIReader := fake.NewFakeClient(objs...)
-
-	baseReconciler := operator.NewBaseReconciler(cl, clientAPIReader, s, log)
-	baseControllerReconciler := operator.NewBaseControllerReconciler(baseReconciler)
-
-	// Create a ReconcileMemcached object with the scheme and fake client.
-	r := ReconcileAPIManager{
-		BaseControllerReconciler: baseControllerReconciler,
-	}
-
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-
-	res, err := r.Reconcile(req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	if !res.Requeue {
-		t.Error("reconcile did not requeue request as expected. Requeuing due to setting of defaults should have been performed")
-	}
-
-	res, err = r.Reconcile(req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	if !res.Requeue {
-		t.Error("upgrade procedure should request requeue when job is done")
-	}
-
-	finalAPIManager := &appsv1alpha1.APIManager{}
-	err = r.Client().Get(context.TODO(), req.NamespacedName, finalAPIManager)
-	if err != nil {
-		t.Fatalf("get APIManager: (%v)", err)
-	}
-
-	threeScaleVersion, ok := finalAPIManager.Annotations[appsv1alpha1.ThreescaleVersionAnnotation]
-	if !ok {
-		t.Errorf("APIManager cr does not have ThreescaleVersionAnnotation annotation set")
-	}
-
-	if threeScaleVersion != product.ThreescaleRelease {
-		t.Errorf("APIManager cr ThreescaleVersionAnnotation value (%s) not the expected (%s)", threeScaleVersion, product.ThreescaleRelease)
-	}
-
-	operatorVersion, ok := finalAPIManager.Annotations[appsv1alpha1.OperatorVersionAnnotation]
-	if !ok {
-		t.Errorf("APIManager cr does not have OperatorVersionAnnotation annotation set")
-	}
-
-	if operatorVersion != version.Version {
-		t.Errorf("APIManager cr OperatorVersionAnnotation value (%s) not the expected (%s)", operatorVersion, version.Version)
 	}
 }


### PR DESCRIPTION
Currently DeploymentConfigs use "latest" ImageStream tag as the image change trigger.
We update that ImageStream tag to point to every 3scale new release version. This means that when upgrading 3scale version, upgrading the ImageStream tag latest pointing to a new 3scale version the DeploymentConfigs that use that tag are automatically updated.

This makes performing several changes to a DeploymentConfig together with an image change in a single update not possible, due to  the change to the DC is triggered by a change in the ImageStream.
This PR removes the usage of the "latest" tag from the DCs and uses version-specific tag in the DeploymentConfig image change triggers. In this way we can control the moment of the image change at will at DC level

Implement for:

- [x] APIcast
- [x] Backend
- [x] System
- [x] System MySQL
- [x] System PostgreSQL
- [x] System Memcached
- [x] System Redis
- [x] Backend Redis
- [x] Zync
- [x] Zync PostgreSQL

Also:
- [x] Implement the upgrade procedure for all the previous changes. EDIT: Discarded unit testing of it as it involves too much setup (creating stub objects for all existing DCs, all existing ImageStreams, and all needed secrets to be able to instantiate the component objects that use them when creating the Option objects) for a content that will be deprecated on next release or even in future PRs.
