### PR TITLE
Aws path style envvar

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -328,8 +328,9 @@ existing secret names.
 | AWS_SECRET_ACCESS_KEY | AWS Access Key Secret to use in S3 Storage for System's file storage | Y |
 | AWS_BUCKET | S3 bucket to be used as System's FileStorage for assets | Y |
 | AWS_REGION | Region of the S3 bucket to be used as Sytem's FileStorage for assets | Y |
-| AWS_HOSTNAME | AWS S3 compatible provider endpoint hostname | N |
-| AWS_PROTOCOL | AWS S3 compatible provider endpoint protocol | N |
+| AWS_HOSTNAME | Default: Amazon endpoints - AWS S3 compatible provider endpoint hostname | N |
+| AWS_PROTOCOL | Default: HTTPS - AWS S3 compatible provider endpoint protocol | N |
+| AWS_PATH_STYLE | Default: false - When set to true, the bucket name is always left in the request URI and never moved to the host as a sub-domain | N |
 
 #### system-smtp
 

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -238,8 +238,9 @@ Secret name can be anyone, as it will be referenced in the *APIManager* custom r
 
 **AWS S3 compatible provider**
 
-AWS S3 compatible provider endpoint hostname can be configured in the S3 secret with
-*AWS_HOSTNAME* and *AWS_PROTOCOL* optional keys. Check [S3 secret reference](apimanager-reference.md#fileStorage-S3-credentials-secret) for reference.
+AWS S3 compatible provider can be configured in the S3 secret with *AWS_HOSTNAME*,
+*AWS_PATH_STYLE* and *AWS_PROTOCOL* optional keys.
+Check [S3 secret reference](apimanager-reference.md#fileStorage-S3-credentials-secret) for reference.
 
 Finally, create *APIManager* custom resource to deploy 3scale
 

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1914,6 +1914,12 @@ objects:
                   key: AWS_HOSTNAME
                   name: aws-auth
                   optional: true
+            - name: AWS_PATH_STYLE
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_PATH_STYLE
+                  name: aws-auth
+                  optional: true
           failurePolicy: Retry
         timeoutSeconds: 1200
         updatePeriodSeconds: 1
@@ -2223,6 +2229,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: AWS_HOSTNAME
+                name: aws-auth
+                optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
                 name: aws-auth
                 optional: true
           image: amp-system:latest
@@ -2552,6 +2564,12 @@ objects:
                 key: AWS_HOSTNAME
                 name: aws-auth
                 optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
+                name: aws-auth
+                optional: true
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2876,6 +2894,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: AWS_HOSTNAME
+                name: aws-auth
+                optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
                 name: aws-auth
                 optional: true
           image: amp-system:latest
@@ -3261,6 +3285,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: AWS_HOSTNAME
+                name: aws-auth
+                optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
                 name: aws-auth
                 optional: true
           image: amp-system:latest
@@ -4323,6 +4353,7 @@ objects:
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
     AWS_BUCKET: ${AWS_BUCKET}
     AWS_HOSTNAME: ${AWS_HOSTNAME}
+    AWS_PATH_STYLE: ${AWS_PATH_STYLE}
     AWS_PROTOCOL: ${AWS_PROTOCOL}
     AWS_REGION: ${AWS_REGION}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -4512,3 +4543,6 @@ parameters:
   name: AWS_PROTOCOL
 - description: AWS S3 compatible provider endpoint hostname
   name: AWS_HOSTNAME
+- description: When set to true, the bucket name is always left in the request URI
+    and never moved to the host as a sub-domain
+  name: AWS_PATH_STYLE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1955,6 +1955,12 @@ objects:
                   key: AWS_HOSTNAME
                   name: aws-auth
                   optional: true
+            - name: AWS_PATH_STYLE
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_PATH_STYLE
+                  name: aws-auth
+                  optional: true
           failurePolicy: Retry
         timeoutSeconds: 1200
         updatePeriodSeconds: 1
@@ -2264,6 +2270,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: AWS_HOSTNAME
+                name: aws-auth
+                optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
                 name: aws-auth
                 optional: true
           image: amp-system:latest
@@ -2599,6 +2611,12 @@ objects:
                 key: AWS_HOSTNAME
                 name: aws-auth
                 optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
+                name: aws-auth
+                optional: true
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2929,6 +2947,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: AWS_HOSTNAME
+                name: aws-auth
+                optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
                 name: aws-auth
                 optional: true
           image: amp-system:latest
@@ -3320,6 +3344,12 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: AWS_HOSTNAME
+                name: aws-auth
+                optional: true
+          - name: AWS_PATH_STYLE
+            valueFrom:
+              secretKeyRef:
+                key: AWS_PATH_STYLE
                 name: aws-auth
                 optional: true
           image: amp-system:latest
@@ -4424,6 +4454,7 @@ objects:
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
     AWS_BUCKET: ${AWS_BUCKET}
     AWS_HOSTNAME: ${AWS_HOSTNAME}
+    AWS_PATH_STYLE: ${AWS_PATH_STYLE}
     AWS_PROTOCOL: ${AWS_PROTOCOL}
     AWS_REGION: ${AWS_REGION}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -4613,3 +4644,6 @@ parameters:
   name: AWS_PROTOCOL
 - description: AWS S3 compatible provider endpoint hostname
   name: AWS_HOSTNAME
+- description: When set to true, the bucket name is always left in the request URI
+    and never moved to the host as a sub-domain
+  name: AWS_PATH_STYLE

--- a/pkg/3scale/amp/component/s3.go
+++ b/pkg/3scale/amp/component/s3.go
@@ -16,6 +16,7 @@ const (
 	AwsRegion          = "AWS_REGION"
 	AwsProtocol        = "AWS_PROTOCOL"
 	AwsHostname        = "AWS_HOSTNAME"
+	AwsPathStyle       = "AWS_PATH_STYLE"
 )
 
 type S3 struct {
@@ -107,6 +108,7 @@ func (s3 *S3) getNewCfgMapElements() []v1.EnvVar {
 		envVarFromSecret(AwsRegion, s3.Options.awsCredentialsSecret, AwsRegion),
 		envVarFromSecretOptional(AwsProtocol, s3.Options.awsCredentialsSecret, AwsProtocol),
 		envVarFromSecretOptional(AwsHostname, s3.Options.awsCredentialsSecret, AwsHostname),
+		envVarFromSecretOptional(AwsPathStyle, s3.Options.awsCredentialsSecret, AwsPathStyle),
 	}
 }
 
@@ -178,6 +180,7 @@ func (s3 *S3) S3AWSSecret() *v1.Secret {
 			AwsBucket:          s3.Options.awsBucket,
 			AwsProtocol:        s3.Options.awsProtocol,
 			AwsHostname:        s3.Options.awsHostname,
+			AwsPathStyle:       s3.Options.awsPathStyle,
 		},
 		Type: v1.SecretTypeOpaque,
 	}

--- a/pkg/3scale/amp/component/s3_options_builder.go
+++ b/pkg/3scale/amp/component/s3_options_builder.go
@@ -12,6 +12,7 @@ type S3Options struct {
 	awsBucket            string
 	awsProtocol          string
 	awsHostname          string
+	awsPathStyle         string
 	awsCredentialsSecret string
 }
 
@@ -41,6 +42,10 @@ func (s3 *S3OptionsBuilder) AWSProtocol(awsProtocol string) {
 
 func (s3 *S3OptionsBuilder) AWSHostname(awsHostname string) {
 	s3.options.awsHostname = awsHostname
+}
+
+func (s3 *S3OptionsBuilder) AWSPathStyle(awsPathStyle string) {
+	s3.options.awsPathStyle = awsPathStyle
 }
 
 func (s3 *S3OptionsBuilder) AWSCredentialsSecret(awsCredentials string) {

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -275,6 +275,7 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 			envVarFromSecret(AwsRegion, system.Options.s3FileStorageOptions.AWSCredentialsSecret, AwsRegion),
 			envVarFromSecretOptional(AwsProtocol, system.Options.s3FileStorageOptions.AWSCredentialsSecret, AwsProtocol),
 			envVarFromSecretOptional(AwsHostname, system.Options.s3FileStorageOptions.AWSCredentialsSecret, AwsHostname),
+			envVarFromSecretOptional(AwsPathStyle, system.Options.s3FileStorageOptions.AWSCredentialsSecret, AwsPathStyle),
 		)
 	}
 

--- a/pkg/3scale/amp/template/adapters/s3.go
+++ b/pkg/3scale/amp/template/adapters/s3.go
@@ -55,6 +55,7 @@ func (s *S3) options() (*component.S3Options, error) {
 	sob.AwsBucket("${AWS_BUCKET}")
 	sob.AWSProtocol("${AWS_PROTOCOL}")
 	sob.AWSHostname("${AWS_HOSTNAME}")
+	sob.AWSPathStyle("${AWS_PATH_STYLE}")
 	sob.AWSCredentialsSecret("aws-auth")
 	return sob.Build()
 }
@@ -89,6 +90,11 @@ func (s3 *S3) parameters() []templatev1.Parameter {
 		templatev1.Parameter{
 			Name:        "AWS_HOSTNAME",
 			Description: "AWS S3 compatible provider endpoint hostname",
+			Required:    false,
+		},
+		templatev1.Parameter{
+			Name:        "AWS_PATH_STYLE",
+			Description: "When set to true, the bucket name is always left in the request URI and never moved to the host as a sub-domain",
 			Required:    false,
 		},
 	}


### PR DESCRIPTION
New env var for system-app:

`AWS_PATH_STYLE: Default: false - When set to true, the bucket name is always left in the request URI and never moved to the host as a sub-domain` 

