### PR TITLE
Set expected go version in go.mod to 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/3scale/3scale-operator
 
+go 1.12
+
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	github.com/3scale/3scale-porta-go-client v0.0.3


### PR DESCRIPTION
The expected language version, set by the go directive, determines
which language features are available when compiling the module.
Language features available in that version will be available for use.
Language features removed in earlier versions, or added in later versions,
will not be available. Note that the language version does not affect
build tags, which are determined by the Go release being used.

One of the motivations of this change is that later Go versions automatically
add the directive in the go.mod file if it is not set previously. By
explicitely setting it we ensure that this does not happen.

It is important to remark that this directive does NOT set the minimum version
or maximum version allowed to compile. It specifies which language features are available
to the code. This does not include compiler flags. This means:
· Building with an older Go version is possible as long as the code does
  not use features introduced with the newer version
· Building with an older version will produce a syntax error if the code uses
  newer features, and a hint is provided as to the version that is required based
  on the contents of go.mod
· Building with a compiler version that does support the features in the code
  with a go.mod file specifying an older version will NOT produce a syntax error
  but it will cause an error indicating the specific version required to build the
  code

A good explanation with examples that I've found can be found here: https://blog.ksub.org/bytes/2019/09/15/go.mods-go-directive/