### PR TITLE
Bump minimum Go version to 1.13.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       - run:
           name: Install Golang
           command: |
-            curl --fail -L https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | sudo tar -C /opt -xzf-
+            curl --fail -L https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz | sudo tar -C /opt -xzf-
 
   deploy-3scale-eval-from-template-imagestreamsless:
     steps:
@@ -283,7 +283,7 @@ commands:
 jobs:
   install-operator:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - setup_remote_docker:
@@ -375,7 +375,7 @@ jobs:
 
   run-unit-tests:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - unit-tests
@@ -414,7 +414,7 @@ jobs:
 
   generator:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - checkout
@@ -423,7 +423,7 @@ jobs:
 
   test-crds:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - checkout
@@ -449,7 +449,7 @@ jobs:
 
   unit-tests-coverage:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - unit-tests

--- a/doc/development.md
+++ b/doc/development.md
@@ -21,7 +21,7 @@
 
 * [operator-sdk] version v0.8.0
 * [git][git_tool]
-* [go] version 1.12.5+
+* [go] version 1.13+
 * [kubernetes] version v1.13.0+
 * [oc] version v4.1+
 * Access to a Openshift v4.1.0+ cluster.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/3scale/3scale-operator
 
-go 1.12
+go 1.13
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect


### PR DESCRIPTION
Since operator-sdk v0.12.0 minimum Go version for operator-based projects is Go 1.13.x https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md#changed-5