### PR TITLE
Upgrade tool to migrate template based deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ endif
 templates:
 	$(MAKE) -C $(TEMPLATES_MAKEFILE_PATH) clean all
 
+## upgrade-tool: Build upgrade tool
+upgrade-tool: $(TEMPLATES_MAKEFILE_PATH)/main.go $(TEMPLATES_MAKEFILE_PATH)/cmd/upgrader.go $(shell find $(TEMPLATES_MAKEFILE_PATH)/cmd/upgrader -name '*.go')
+	go build -o $@ $<
+
 ## clean: Clean build resources
 clean:
 	rm -rf $(PROJECT_PATH)/_output

--- a/pkg/3scale/amp/cmd/upgrader.go
+++ b/pkg/3scale/amp/cmd/upgrader.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/cmd/upgrader"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// upgradeCmd represents the upgrade command
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade your 3scale installation",
+	Long:  "Upgrade your 3scale installation",
+	Run:   upgradeCommandEntrypoint,
+}
+
+func upgradeCommandEntrypoint(cmd *cobra.Command, args []string) {
+	upgradeScheme := scheme.Scheme
+	if err := upgrader.RegisterOpenShiftAPIGroups(upgradeScheme); err != nil {
+		fmt.Fprintf(os.Stderr, fmt.Sprint(err))
+		os.Exit(1)
+	}
+
+	configuration := config.GetConfigOrDie()
+	cl, err := client.New(configuration, client.Options{Scheme: upgradeScheme})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.CheckCurrentInstallation(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to check current 3scale installation: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.MigrateSystemSMTPData(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to migrate System SMTP data: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.UpgradeSystemPreHook(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to migrate System pre hook config: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.UpgradeSystemAppContainerEnvs(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to migrate System containers env: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.UpgradeSystemSidekiqEnvs(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to migrate System sidekiq env: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.MigrateS3Deployment(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to migrate S3 deployment: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.PatchAMPRelese(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to patch amp release: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.UpgradeImages(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to upgrade images: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = upgrader.DeleteSMTPConfigMap(cl, upgradeNamespace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to delete smtp config map: %v\n", err)
+		os.Exit(1)
+	}
+
+	if !upgrader.VerifyUpgrade(cl, upgradeNamespace) {
+		os.Exit(1)
+	}
+
+	fmt.Println("3scale successfully upgraded to release 2.8")
+}
+
+var upgradeNamespace string
+
+func init() {
+	upgradeCmd.Flags().StringVarP(&upgradeNamespace, "namespace", "n", "", "Cluster namespace (required)")
+	upgradeCmd.MarkFlagRequired("namespace")
+	rootCmd.AddCommand(upgradeCmd)
+
+}

--- a/pkg/3scale/amp/cmd/upgrader/delete_smtp_configmap.go
+++ b/pkg/3scale/amp/cmd/upgrader/delete_smtp_configmap.go
@@ -1,0 +1,28 @@
+package upgrader
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func DeleteSMTPConfigMap(cl client.Client, ns string) error {
+	existing := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "smtp", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, existing)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	if !k8serrors.IsNotFound(err) {
+		err := cl.Delete(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/helper.go
+++ b/pkg/3scale/amp/cmd/upgrader/helper.go
@@ -1,0 +1,114 @@
+package upgrader
+
+import (
+	"fmt"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	THREESCALEIMAGES = [...]string{
+		"amp-system",
+		"amp-apicast",
+		"amp-backend",
+		"amp-zync",
+		"system-memcached",
+		"zync-database-postgresql",
+		"backend-redis",
+		"system-redis",
+	}
+
+	SMTPVARS = [...]string{
+		"SMTP_ADDRESS", "SMTP_USER_NAME", "SMTP_PASSWORD",
+		"SMTP_DOMAIN", "SMTP_PORT", "SMTP_AUTHENTICATION", "SMTP_OPENSSL_VERIFY_MODE",
+	}
+
+	AWSVARS = [...]string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_BUCKET", "AWS_REGION",
+		"AWS_PROTOCOL", "AWS_HOSTNAME", "AWS_PATH_STYLE",
+	}
+)
+
+func FindEnvByNameOrPanic(a []v1.EnvVar, x string) v1.EnvVar {
+	for _, n := range a {
+		if x == n.Name {
+			return n
+		}
+	}
+
+	panic(fmt.Sprintf("env var %s not found", x))
+}
+
+func FindEnvByName(a []v1.EnvVar, x string) (v1.EnvVar, bool) {
+	for _, n := range a {
+		if x == n.Name {
+			return n, true
+		}
+	}
+	return v1.EnvVar{}, false
+}
+
+func FindContainerEnvByNameOrPanic(a []v1.Container, containerName, envVarName string) v1.EnvVar {
+	container := FindContainerByNameOrPanic(a, containerName)
+	for _, n := range container.Env {
+		if envVarName == n.Name {
+			return n
+		}
+	}
+
+	panic(fmt.Sprintf("env var %s not found", envVarName))
+}
+
+func FindContainerByNameOrPanic(a []v1.Container, containerName string) v1.Container {
+	for _, n := range a {
+		if containerName == n.Name {
+			return n
+		}
+	}
+
+	panic(fmt.Sprintf("container %s not found", containerName))
+}
+
+func RegisterOpenShiftAPIGroups(s *runtime.Scheme) error {
+	var addToSchemes runtime.SchemeBuilder
+	addToSchemes = append(addToSchemes,
+		appsv1.Install,
+		imagev1.Install,
+		routev1.Install,
+	)
+
+	return addToSchemes.AddToScheme(s)
+}
+
+func GetSystemComponent() (*component.System, error) {
+	optProv := component.SystemOptionsBuilder{}
+
+	// Maybe implement option provider to gather all information from existing installation???
+	// Not required for the upgrade 2.7 -> 2.8, but could be done.
+	optProv.AppLabel(appsv1alpha1.DefaultAppLabel)
+	optProv.AmpRelease("-")
+	optProv.ApicastRegistryURL("-")
+	optProv.TenantName("-")
+	optProv.WildcardDomain("-")
+	optProv.AdminAccessToken("-")
+	optProv.AdminPassword("-")
+	optProv.AdminUsername("-")
+	optProv.ApicastAccessToken("-")
+	optProv.MasterAccessToken("-")
+	optProv.MasterUsername("-")
+	optProv.MasterPassword("-")
+	optProv.AppSecretKeyBase("-")
+	optProv.BackendSharedSecret("-")
+	optProv.MasterName("-")
+	systemOptions, err := optProv.Build()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewSystem(systemOptions), nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/installation_check.go
+++ b/pkg/3scale/amp/cmd/upgrader/installation_check.go
@@ -1,0 +1,36 @@
+package upgrader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CheckCurrentInstallation(cl client.Client, ns string) error {
+	existing := &v1.ConfigMap{}
+	err := cl.Get(
+		context.TODO(),
+		types.NamespacedName{Name: "system-environment", Namespace: ns},
+		existing)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return fmt.Errorf("3scale installation not found in %s. Maybe different namespace?", ns)
+		}
+		return err
+	}
+
+	ampRelease, exists := existing.Data["AMP_RELEASE"]
+	if !exists {
+		return errors.New("AMP_RELEASE not found in system-environment configmap. Corrupted installation?")
+	}
+
+	if ampRelease != "2.7" && ampRelease != "2.8" {
+		return fmt.Errorf("3scale release %s installation found. This tool is meant to upgrade from release 2.7", ampRelease)
+	}
+	return nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/migrate_s3_deployment.go
+++ b/pkg/3scale/amp/cmd/upgrader/migrate_s3_deployment.go
@@ -1,0 +1,278 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
+	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func MigrateS3Deployment(cl client.Client, ns string) error {
+	existingSecret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{Name: "aws-auth", Namespace: ns}
+	err := cl.Get(context.TODO(), secretNamespacedName, existingSecret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	if k8serrors.IsNotFound(err) {
+		// S3 deployment not found
+		// Maybe there is a better automatic way to detect S3 deployment
+		return nil
+	}
+
+	err = migrateS3Secret(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = migrateS3SystemAppDC(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = migrateS3SystemSidekiqDC(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = deleteUnusedS3DataConfigmap(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func migrateS3Secret(cl client.Client, ns string) error {
+	existingSecret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{Name: "aws-auth", Namespace: ns}
+	err := cl.Get(context.TODO(), secretNamespacedName, existingSecret)
+	if err != nil {
+		return err
+	}
+
+	existingConfigMap := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "system-environment", Namespace: ns}
+	err = cl.Get(context.TODO(), configMapNamespacedName, existingConfigMap)
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	if existingSecret.StringData == nil {
+		existingSecret.StringData = map[string]string{}
+	}
+	secretData := helper.GetSecretStringDataFromData(existingSecret.Data)
+	if _, exists := secretData["AWS_BUCKET"]; !exists {
+		existingSecret.StringData["AWS_BUCKET"] = existingConfigMap.Data["AWS_BUCKET"]
+		changed = true
+	}
+
+	if _, exists := secretData["AWS_REGION"]; !exists {
+		existingSecret.StringData["AWS_REGION"] = existingConfigMap.Data["AWS_REGION"]
+		changed = true
+	}
+
+	if changed {
+		err := cl.Update(context.TODO(), existingSecret)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existingSecret))
+	}
+
+	return nil
+}
+
+func migrateS3SystemAppDC(cl client.Client, ns string) error {
+	changed := false
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-app", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	system, err := GetS3SystemComponent()
+	desired := system.AppDeploymentConfig()
+
+	// pre hook: replace AWS_BUCKET, AWS_REGION vars
+	desiredPreHookPod := desired.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	existingPreHookPod := existing.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	for i := range existingPreHookPod.Env {
+		envVars := []string{"AWS_BUCKET", "AWS_REGION"}
+		for _, envVar := range envVars {
+			if existingPreHookPod.Env[i].Name == envVar {
+				desiredEnvVar := FindEnvByNameOrPanic(desiredPreHookPod.Env, envVar)
+				if !reflect.DeepEqual(existingPreHookPod.Env[i].ValueFrom, desiredEnvVar.ValueFrom) {
+					existingPreHookPod.Env[i].ValueFrom = desiredEnvVar.ValueFrom
+					changed = true
+				}
+			}
+		}
+	}
+	// pre hook: add new vars
+	envVars := []string{"AWS_PROTOCOL", "AWS_HOSTNAME", "AWS_PATH_STYLE"}
+	for _, envVar := range envVars {
+		if _, ok := FindEnvByName(existingPreHookPod.Env, envVar); !ok {
+			existingPreHookPod.Env = append(existingPreHookPod.Env, FindEnvByNameOrPanic(desiredPreHookPod.Env, envVar))
+			changed = true
+		}
+	}
+
+	// containers env: replace AWS_BUCKET, AWS_REGION vars
+	desiredContainers := desired.Spec.Template.Spec.Containers
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		for i := range container.Env {
+			envVars := []string{"AWS_BUCKET", "AWS_REGION"}
+			for _, envVar := range envVars {
+				if container.Env[i].Name == envVar {
+					desiredEnvVar := FindContainerEnvByNameOrPanic(desiredContainers, container.Name, envVar)
+					if !reflect.DeepEqual(container.Env[i].ValueFrom, desiredEnvVar.ValueFrom) {
+						container.Env[i].ValueFrom = desiredEnvVar.ValueFrom
+						changed = true
+					}
+				}
+			}
+		}
+	}
+	// containers env: add new vars
+	for i, container := range existing.Spec.Template.Spec.Containers {
+		envVars := []string{"AWS_PROTOCOL", "AWS_HOSTNAME", "AWS_PATH_STYLE"}
+		for _, envVar := range envVars {
+			if _, ok := FindEnvByName(existing.Spec.Template.Spec.Containers[i].Env, envVar); !ok {
+				desiredEnvVar := FindContainerEnvByNameOrPanic(desiredContainers, container.Name, envVar)
+				existing.Spec.Template.Spec.Containers[i].Env = append(existing.Spec.Template.Spec.Containers[i].Env, desiredEnvVar)
+				changed = true
+			}
+		}
+	}
+
+	// update on any change
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func migrateS3SystemSidekiqDC(cl client.Client, ns string) error {
+	changed := false
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-sidekiq", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	system, err := GetS3SystemComponent()
+	desired := system.SidekiqDeploymentConfig()
+
+	// containers env: replace AWS_BUCKET, AWS_REGION vars
+	desiredContainers := desired.Spec.Template.Spec.Containers
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		for i := range container.Env {
+			envVars := []string{"AWS_BUCKET", "AWS_REGION"}
+			for _, envVar := range envVars {
+				if container.Env[i].Name == envVar {
+					desiredEnvVar := FindContainerEnvByNameOrPanic(desiredContainers, container.Name, envVar)
+					if !reflect.DeepEqual(container.Env[i].ValueFrom, desiredEnvVar.ValueFrom) {
+						container.Env[i].ValueFrom = desiredEnvVar.ValueFrom
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	// containers env: add new vars
+	for i, container := range existing.Spec.Template.Spec.Containers {
+		envVars := []string{"AWS_PROTOCOL", "AWS_HOSTNAME", "AWS_PATH_STYLE"}
+		for _, envVar := range envVars {
+			if _, ok := FindEnvByName(existing.Spec.Template.Spec.Containers[i].Env, envVar); !ok {
+				desiredEnvVar := FindContainerEnvByNameOrPanic(desiredContainers, container.Name, envVar)
+				existing.Spec.Template.Spec.Containers[i].Env = append(existing.Spec.Template.Spec.Containers[i].Env, desiredEnvVar)
+				changed = true
+			}
+		}
+	}
+
+	// update on any change
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteUnusedS3DataConfigmap(cl client.Client, ns string) error {
+	changed := false
+	existing := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "system-environment", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, existing)
+	if err != nil {
+		return err
+	}
+
+	keys := []string{"AWS_BUCKET", "AWS_REGION"}
+	for _, key := range keys {
+		if _, exists := existing.Data[key]; exists {
+			delete(existing.Data, key)
+			changed = true
+		}
+	}
+
+	// update on any change
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func GetS3SystemComponent() (*component.System, error) {
+	optProv := component.SystemOptionsBuilder{}
+	optProv.AppLabel(appsv1alpha1.DefaultAppLabel)
+	optProv.AmpRelease("-")
+	optProv.ApicastRegistryURL("-")
+	optProv.TenantName("-")
+	optProv.WildcardDomain("-")
+	optProv.AdminAccessToken("-")
+	optProv.AdminPassword("-")
+	optProv.AdminUsername("-")
+	optProv.ApicastAccessToken("-")
+	optProv.MasterAccessToken("-")
+	optProv.MasterUsername("-")
+	optProv.MasterPassword("-")
+	optProv.AppSecretKeyBase("-")
+	optProv.BackendSharedSecret("-")
+	optProv.MasterName("-")
+	optProv.S3FileStorageOptions(component.S3FileStorageOptions{
+		ConfigurationSecretName: "aws-auth",
+	})
+	systemOptions, err := optProv.Build()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewSystem(systemOptions), nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/migrate_system_smtp_data.go
+++ b/pkg/3scale/amp/cmd/upgrader/migrate_system_smtp_data.go
@@ -1,0 +1,72 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	"github.com/3scale/3scale-operator/pkg/helper"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func MigrateSystemSMTPData(cl client.Client, ns string) error {
+	existingConfigMap := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "smtp", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, existingConfigMap)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	if k8serrors.IsNotFound(err) {
+		// has been deleted, nothing to do
+		return nil
+	}
+
+	existingSecret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{Name: component.SystemSecretSystemSMTPSecretName, Namespace: ns}
+	err = cl.Get(context.TODO(), secretNamespacedName, existingSecret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	if k8serrors.IsNotFound(err) {
+		system, err := GetSystemComponent()
+		if err != nil {
+			return err
+		}
+		existingSecret = system.SMTPSecret()
+		existingSecret.SetNamespace(ns)
+		// We make sure StringData is nil so it does not get precedence over Data.
+		// We use Data to set the secret and not StringData due to at the time
+		// of writing this comment when using the Kubernetes FakeClient the
+		// mocked client does not convert from StringData to Data, producing a
+		// different behavior than with the real code execution
+		existingSecret.StringData = nil
+		existingSecret.Data = helper.GetSecretDataFromStringData(existingConfigMap.Data)
+
+		err = cl.Create(context.TODO(), existingSecret)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Created object %s\n", operator.ObjectInfo(existingSecret))
+	} else {
+		changed := false
+		secretStringData := helper.GetSecretStringDataFromData(existingSecret.Data)
+		changed = !reflect.DeepEqual(existingConfigMap.Data, secretStringData)
+		if changed {
+			existingSecret.Data = helper.GetSecretDataFromStringData(existingConfigMap.Data)
+			err := cl.Update(context.TODO(), existingSecret)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Update object %s\n", operator.ObjectInfo(existingSecret))
+		}
+	}
+
+	return nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/patch_amp_release.go
+++ b/pkg/3scale/amp/cmd/upgrader/patch_amp_release.go
@@ -1,0 +1,38 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func PatchAMPRelese(cl client.Client, ns string) error {
+	changed := false
+	existing := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "system-environment", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, existing)
+	if err != nil {
+		return err
+	}
+
+	ampRelease := existing.Data["AMP_RELEASE"]
+
+	if ampRelease != "2.8" {
+		existing.Data["AMP_RELEASE"] = "2.8"
+		changed = true
+	}
+
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/upgrade_images.go
+++ b/pkg/3scale/amp/cmd/upgrader/upgrade_images.go
@@ -1,0 +1,279 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	imagev1 "github.com/openshift/api/image/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func UpgradeImages(cl client.Client, ns string) error {
+	err := upgradeAmpImages(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = upgradeBackendRedis(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = upgradeSystemRedis(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = upgradeSystemMysql(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	err = upgradeSystemPostgresql(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func upgradeSystemMysql(cl client.Client, ns string) error {
+	mysqlImage, err := getMysqlImage()
+	if err != nil {
+		return err
+	}
+
+	desired := mysqlImage.ImageStream()
+
+	existing := &imagev1.ImageStream{}
+	err = cl.Get(
+		context.TODO(),
+		types.NamespacedName{Name: desired.Name, Namespace: ns},
+		existing)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	} else if err != nil && k8serrors.IsNotFound(err) {
+		// imagestream not deployed, no need to upgrade
+		return nil
+	}
+
+	reconciler := operator.NewImageStreamGenericReconciler()
+	if reconciler.IsUpdateNeeded(desired, existing) {
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+	}
+	return nil
+}
+
+func upgradeSystemPostgresql(cl client.Client, ns string) error {
+	postgresqlImage, err := getPostgresqlImage()
+	if err != nil {
+		return err
+	}
+
+	desired := postgresqlImage.ImageStream()
+
+	existing := &imagev1.ImageStream{}
+	err = cl.Get(
+		context.TODO(),
+		types.NamespacedName{Name: desired.Name, Namespace: ns},
+		existing)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	} else if err != nil && k8serrors.IsNotFound(err) {
+		// imagestream not deployed, no need to upgrade
+		return nil
+	}
+
+	reconciler := operator.NewImageStreamGenericReconciler()
+	if reconciler.IsUpdateNeeded(desired, existing) {
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+	}
+	return nil
+}
+
+func upgradeSystemRedis(cl client.Client, ns string) error {
+	redis, err := getRedisComponent()
+	if err != nil {
+		return err
+	}
+
+	desired := redis.SystemImageStream()
+
+	existing := &imagev1.ImageStream{}
+	err = cl.Get(
+		context.TODO(),
+		types.NamespacedName{Name: desired.Name, Namespace: ns},
+		existing)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	} else if err != nil && k8serrors.IsNotFound(err) {
+		// imagestream not deployed, no need to upgrade
+		return nil
+	}
+
+	reconciler := operator.NewImageStreamGenericReconciler()
+	if reconciler.IsUpdateNeeded(desired, existing) {
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+	}
+	return nil
+}
+
+func upgradeBackendRedis(cl client.Client, ns string) error {
+	redis, err := getRedisComponent()
+	if err != nil {
+		return err
+	}
+
+	desired := redis.BackendImageStream()
+
+	existing := &imagev1.ImageStream{}
+	err = cl.Get(
+		context.TODO(),
+		types.NamespacedName{Name: desired.Name, Namespace: ns},
+		existing)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	} else if err != nil && k8serrors.IsNotFound(err) {
+		// imagestream not deployed, no need to upgrade
+		return nil
+	}
+
+	reconciler := operator.NewImageStreamGenericReconciler()
+	if reconciler.IsUpdateNeeded(desired, existing) {
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+	}
+	return nil
+}
+
+func upgradeAmpImages(cl client.Client, ns string) error {
+	ampImages, err := getAMPImagesComponent()
+	if err != nil {
+		return err
+	}
+
+	imagestreams := []*imagev1.ImageStream{
+		ampImages.SystemImageStream(),
+		ampImages.APICastImageStream(),
+		ampImages.BackendImageStream(),
+		ampImages.ZyncImageStream(),
+		ampImages.SystemMemcachedImageStream(),
+		ampImages.ZyncDatabasePostgreSQLImageStream(),
+	}
+	reconciler := operator.NewImageStreamGenericReconciler()
+
+	for _, desired := range imagestreams {
+		existing := &imagev1.ImageStream{}
+		err := cl.Get(
+			context.TODO(),
+			types.NamespacedName{Name: desired.Name, Namespace: ns},
+			existing)
+		if err != nil {
+			return err
+		}
+
+		if reconciler.IsUpdateNeeded(desired, existing) {
+			err := cl.Update(context.TODO(), existing)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		}
+	}
+	return nil
+}
+
+func getAMPImagesComponent() (*component.AmpImages, error) {
+	optProv := component.AmpImagesOptionsBuilder{}
+	// should be read from installed 3scale?
+	optProv.AppLabel(appsv1alpha1.DefaultAppLabel)
+	optProv.AMPRelease(product.ThreescaleRelease)
+	optProv.ApicastImage(component.ApicastImageURL())
+	optProv.BackendImage(component.BackendImageURL())
+	optProv.SystemImage(component.SystemImageURL())
+	optProv.ZyncImage(component.ZyncImageURL())
+	optProv.ZyncDatabasePostgreSQLImage(component.ZyncPostgreSQLImageURL())
+	optProv.SystemMemcachedImage(component.SystemMemcachedImageURL())
+	// should be read from installed 3scale?
+	optProv.InsecureImportPolicy(v1alpha1.DefaultImageStreamImportInsecure)
+
+	otions, err := optProv.Build()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewAmpImages(otions), nil
+}
+
+func getRedisComponent() (*component.Redis, error) {
+	optProv := component.RedisOptionsBuilder{}
+	// should be read from installed 3scale?
+	optProv.AppLabel(appsv1alpha1.DefaultAppLabel)
+	optProv.AMPRelease(product.ThreescaleRelease)
+	optProv.BackendImage(component.BackendRedisImageURL())
+	optProv.SystemImage(component.SystemRedisImageURL())
+	// should be read from installed 3scale?
+	optProv.InsecureImportPolicy(v1alpha1.DefaultImageStreamImportInsecure)
+	// resource requirements only required for deployment config, not required for image change
+
+	options, err := optProv.Build()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewRedis(options), nil
+}
+
+func getPostgresqlImage() (*component.SystemPostgreSQLImage, error) {
+	optProv := component.SystemPostgreSQLImageOptionsBuilder{}
+	// should be read from installed 3scale?
+	optProv.AppLabel(appsv1alpha1.DefaultAppLabel)
+	optProv.AmpRelease(product.ThreescaleRelease)
+	optProv.Image(component.SystemPostgreSQLImageURL())
+	// should be read from installed 3scale?
+	optProv.InsecureImportPolicy(v1alpha1.DefaultImageStreamImportInsecure)
+
+	options, err := optProv.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return component.NewSystemPostgreSQLImage(options), nil
+}
+
+func getMysqlImage() (*component.SystemMySQLImage, error) {
+	optProv := component.SystemMySQLImageOptionsBuilder{}
+	// should be read from installed 3scale?
+	optProv.AppLabel(appsv1alpha1.DefaultAppLabel)
+	optProv.AmpRelease(product.ThreescaleRelease)
+	optProv.Image(component.SystemPostgreSQLImageURL())
+	// should be read from installed 3scale?
+	optProv.InsecureImportPolicy(v1alpha1.DefaultImageStreamImportInsecure)
+
+	options, err := optProv.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return component.NewSystemMySQLImage(options), nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/upgrade_system_app_env.go
+++ b/pkg/3scale/amp/cmd/upgrader/upgrade_system_app_env.go
@@ -1,0 +1,62 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func UpgradeSystemAppContainerEnvs(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-app", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	system, err := GetSystemComponent()
+	if err != nil {
+		return err
+	}
+
+	desiredContainers := system.AppDeploymentConfig().Spec.Template.Spec.Containers
+
+	changed := false
+
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		for i := range container.Env {
+			envVars := []string{
+				"SMTP_ADDRESS",
+				"SMTP_USER_NAME",
+				"SMTP_PASSWORD",
+				"SMTP_DOMAIN",
+				"SMTP_PORT",
+				"SMTP_AUTHENTICATION",
+				"SMTP_OPENSSL_VERIFY_MODE"}
+			for _, envVar := range envVars {
+				if container.Env[i].Name == envVar {
+					desiredEnvVar := FindContainerEnvByNameOrPanic(desiredContainers, container.Name, envVar)
+					if !reflect.DeepEqual(container.Env[i].ValueFrom, desiredEnvVar.ValueFrom) {
+						container.Env[i].ValueFrom = desiredEnvVar.ValueFrom
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/upgrade_system_prehook.go
+++ b/pkg/3scale/amp/cmd/upgrader/upgrade_system_prehook.go
@@ -1,0 +1,100 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func UpgradeSystemPreHook(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-app", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	system, err := GetSystemComponent()
+	if err != nil {
+		return err
+	}
+
+	desiredDeploymentConfig := system.AppDeploymentConfig()
+	changed := ensureDeploymentConfigPreHookPodEnvVars(desiredDeploymentConfig, existing)
+	tmpChanged := ensureDeploymentConfigPreHookPodCommand(desiredDeploymentConfig, existing)
+	changed = changed || tmpChanged
+
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureDeploymentConfigPreHookPodEnvVars(desired, existing *appsv1.DeploymentConfig) bool {
+	changed := false
+	desiredPreHookPod := desired.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	existingPreHookPod := existing.Spec.Strategy.RollingParams.Pre.ExecNewPod
+
+	// replace SMTP_* vars
+	for i := range existingPreHookPod.Env {
+		envVars := []string{
+			"SMTP_ADDRESS",
+			"SMTP_USER_NAME",
+			"SMTP_PASSWORD",
+			"SMTP_DOMAIN",
+			"SMTP_PORT",
+			"SMTP_AUTHENTICATION",
+			"SMTP_OPENSSL_VERIFY_MODE"}
+		for _, envVar := range envVars {
+			if existingPreHookPod.Env[i].Name == envVar {
+				desiredEnvVar := FindEnvByNameOrPanic(desiredPreHookPod.Env, envVar)
+				if !reflect.DeepEqual(existingPreHookPod.Env[i].ValueFrom, desiredEnvVar.ValueFrom) {
+					existingPreHookPod.Env[i].ValueFrom = desiredEnvVar.ValueFrom
+					changed = true
+				}
+			}
+		}
+	}
+
+	if _, ok := FindEnvByName(existingPreHookPod.Env, component.SystemSecretSystemSeedMasterAccessTokenFieldName); !ok {
+		// Add MASTER_ACCESS_TOKEN ref
+		existingPreHookPod.Env = append(existingPreHookPod.Env,
+			v1.EnvVar{
+				Name: component.SystemSecretSystemSeedMasterAccessTokenFieldName,
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: component.SystemSecretSystemSeedSecretName,
+						},
+						Key: component.SystemSecretSystemSeedMasterAccessTokenFieldName,
+					},
+				},
+			})
+		changed = true
+	}
+
+	return changed
+}
+
+func ensureDeploymentConfigPreHookPodCommand(desired, existing *appsv1.DeploymentConfig) bool {
+	changed := false
+	desiredPreHookPod := desired.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	existingPrehookPod := existing.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	if !reflect.DeepEqual(existingPrehookPod.Command, desiredPreHookPod.Command) {
+		existingPrehookPod.Command = desiredPreHookPod.Command
+		changed = true
+	}
+	return changed
+}

--- a/pkg/3scale/amp/cmd/upgrader/upgrade_system_sidekiq_env.go
+++ b/pkg/3scale/amp/cmd/upgrader/upgrade_system_sidekiq_env.go
@@ -1,0 +1,62 @@
+package upgrader
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func UpgradeSystemSidekiqEnvs(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-sidekiq", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	system, err := GetSystemComponent()
+	if err != nil {
+		return err
+	}
+
+	desiredContainers := system.SidekiqDeploymentConfig().Spec.Template.Spec.Containers
+
+	changed := false
+
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		for i := range container.Env {
+			envVars := []string{
+				"SMTP_ADDRESS",
+				"SMTP_USER_NAME",
+				"SMTP_PASSWORD",
+				"SMTP_DOMAIN",
+				"SMTP_PORT",
+				"SMTP_AUTHENTICATION",
+				"SMTP_OPENSSL_VERIFY_MODE"}
+			for _, envVar := range envVars {
+				if container.Env[i].Name == envVar {
+					desiredEnvVar := FindContainerEnvByNameOrPanic(desiredContainers, container.Name, envVar)
+					if !reflect.DeepEqual(container.Env[i].ValueFrom, desiredEnvVar.ValueFrom) {
+						container.Env[i].ValueFrom = desiredEnvVar.ValueFrom
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	if changed {
+		fmt.Printf("Update object %s\n", operator.ObjectInfo(existing))
+		err := cl.Update(context.TODO(), existing)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/3scale/amp/cmd/upgrader/verify_upgrade.go
+++ b/pkg/3scale/amp/cmd/upgrader/verify_upgrade.go
@@ -1,0 +1,344 @@
+package upgrader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Maybe there is a better automatic way to detect S3 deployment
+func checkS3Deployment(cl client.Client, ns string) (bool, error) {
+	secret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{Name: "aws-auth", Namespace: ns}
+	err := cl.Get(context.TODO(), secretNamespacedName, secret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return false, err
+	}
+
+	return !k8serrors.IsNotFound(err), nil
+}
+
+func VerifyUpgrade(cl client.Client, ns string) bool {
+	validations := []struct {
+		ValidateFunc func(client.Client, string) error
+		TestName     string
+	}{
+		{verifySMTPSecret, "SMTP secret exists"},
+		{verifySystemAppPreHookPodCommand, "System app pre hook pod command upgraded"},
+		{verifySystemAppPreHookPodEnv, "System app pre hook pod env upgraded"},
+		{verifySystemAppContainersEnv, "System app containers env upgraded"},
+		{verifySystemSidekiqContainersEnv, "System app containers env upgraded"},
+		{verifyAWSSecret, "AWS secret upgraded"},
+		{verifyAWSInfoDeletedFromConfigMap, "AWS info deleted from configmap"},
+		{verifyAMPRelease, "AMP_RELEASE patched"},
+		{verifyImages, "Images upgraded"},
+		{verifySMTPConfigMapDeleted, "old SMTP configmap deleted"},
+	}
+
+	failed := false
+
+	fmt.Println("########\n## Check upgrade\n########")
+	for _, validation := range validations {
+		err := validation.ValidateFunc(cl, ns)
+		if err != nil {
+			fmt.Printf("\033[1;31m[FAIL]\033[0m %s: %v\n", validation.TestName, err)
+			failed = true
+		} else {
+			fmt.Printf("\033[1;32m[OK]\033[0m %s\n", validation.TestName)
+		}
+	}
+
+	return !failed
+}
+
+func verifyImagestream(is *imagev1.ImageStream) bool {
+	tag28found := false
+	latestTagUpgraded := false
+	for _, tag := range is.Spec.Tags {
+		if tag.Name == "2.8" {
+			tag28found = true
+		}
+
+		if tag.Name == "latest" &&
+			tag.From != nil &&
+			tag.From.Name == "2.8" {
+			latestTagUpgraded = true
+		}
+	}
+
+	return tag28found && latestTagUpgraded
+}
+
+func verifyImages(cl client.Client, ns string) error {
+	for _, imageName := range THREESCALEIMAGES {
+		is := &imagev1.ImageStream{}
+		err := cl.Get(context.TODO(), types.NamespacedName{Name: imageName, Namespace: ns}, is)
+		if err != nil {
+			return err
+		}
+
+		if !verifyImagestream(is) {
+			return fmt.Errorf("%s is not upgraded", imageName)
+		}
+	}
+
+	// optional imagestreams
+	for _, imageName := range []string{"system-mysql", "system-postgresql"} {
+		is := &imagev1.ImageStream{}
+		err := cl.Get(context.TODO(), types.NamespacedName{Name: imageName, Namespace: ns}, is)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+
+		if err == nil && !verifyImagestream(is) {
+			return fmt.Errorf("%s is not upgraded", imageName)
+		}
+	}
+
+	return nil
+}
+
+func verifyAMPRelease(cl client.Client, ns string) error {
+	configMap := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "system-environment", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, configMap)
+	if err != nil {
+		return err
+	}
+
+	if configMap.Data["AMP_RELEASE"] != "2.8" {
+		return errors.New("system-environment AMP_RELEASE key not patched")
+	}
+	return nil
+}
+
+func verifyAWSInfoDeletedFromConfigMap(cl client.Client, ns string) error {
+	configMap := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "system-environment", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, configMap)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := configMap.Data["AWS_BUCKET"]; ok {
+		return errors.New("system-environment configmap still has AWS_BUCKET key")
+	}
+
+	if _, ok := configMap.Data["AWS_REGION"]; ok {
+		return errors.New("system-environment configmap still has AWS_REGION key")
+	}
+
+	return nil
+}
+
+func verifyAWSSecret(cl client.Client, ns string) error {
+	s3Deployment, err := checkS3Deployment(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	if !s3Deployment {
+		return nil
+	}
+
+	secret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{Name: "aws-auth", Namespace: ns}
+	err = cl.Get(context.TODO(), secretNamespacedName, secret)
+	if err != nil {
+		return err
+	}
+
+	for _, envVarName := range []string{"AWS_BUCKET", "AWS_REGION"} {
+		if _, ok := secret.Data[envVarName]; !ok {
+			return fmt.Errorf("%s key not found aws secret", envVarName)
+		}
+	}
+
+	return nil
+}
+
+func verifySystemSidekiqContainersEnv(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-sidekiq", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		for _, envVarName := range SMTPVARS {
+			envVar, ok := FindEnvByName(container.Env, envVarName)
+			if !ok {
+				return fmt.Errorf("%s env var not found in container %s", envVarName, container.Name)
+			}
+
+			if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+				return fmt.Errorf("%s env var from container %s is not reference to secret", envVarName, container.Name)
+			}
+		}
+	}
+
+	s3Deployment, err := checkS3Deployment(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	if s3Deployment {
+		for _, container := range existing.Spec.Template.Spec.Containers {
+			for _, envVarName := range AWSVARS {
+				envVar, ok := FindEnvByName(container.Env, envVarName)
+				if !ok {
+					return fmt.Errorf("%s env var not found in container %s", envVarName, container.Name)
+				}
+
+				if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+					return fmt.Errorf("%s env var from container %s is not reference to secret", envVarName, container.Name)
+				}
+			}
+		}
+	}
+
+	return nil
+
+}
+
+func verifySystemAppContainersEnv(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-app", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		for _, envVarName := range SMTPVARS {
+			envVar, ok := FindEnvByName(container.Env, envVarName)
+			if !ok {
+				return fmt.Errorf("%s env var not found in container %s", envVarName, container.Name)
+			}
+
+			if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+				return fmt.Errorf("%s env var from container %s is not reference to secret", envVarName, container.Name)
+			}
+		}
+	}
+
+	s3Deployment, err := checkS3Deployment(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	if s3Deployment {
+		for _, container := range existing.Spec.Template.Spec.Containers {
+			for _, envVarName := range AWSVARS {
+				envVar, ok := FindEnvByName(container.Env, envVarName)
+				if !ok {
+					return fmt.Errorf("%s env var not found in container %s", envVarName, container.Name)
+				}
+
+				if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+					return fmt.Errorf("%s env var from container %s is not reference to secret", envVarName, container.Name)
+				}
+			}
+		}
+	}
+
+	return nil
+
+}
+
+func verifySystemAppPreHookPodEnv(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-app", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	for _, envVarName := range append(SMTPVARS[:], component.SystemSecretSystemSeedMasterAccessTokenFieldName) {
+		envVar, ok := FindEnvByName(existing.Spec.Strategy.RollingParams.Pre.ExecNewPod.Env, envVarName)
+		if !ok {
+			return fmt.Errorf("%s env var not found", envVarName)
+		}
+
+		if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+			return fmt.Errorf("%s env var is not reference to secret", envVarName)
+		}
+	}
+
+	s3Deployment, err := checkS3Deployment(cl, ns)
+	if err != nil {
+		return err
+	}
+
+	if s3Deployment {
+		for _, envVarName := range AWSVARS {
+			envVar, ok := FindEnvByName(existing.Spec.Strategy.RollingParams.Pre.ExecNewPod.Env, envVarName)
+			if !ok {
+				return fmt.Errorf("%s env var not found", envVarName)
+			}
+
+			if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+				return fmt.Errorf("%s env var is not reference to secret", envVarName)
+			}
+		}
+	}
+
+	return nil
+
+}
+
+func verifySystemAppPreHookPodCommand(cl client.Client, ns string) error {
+	existing := &appsv1.DeploymentConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "system-app", Namespace: ns}, existing)
+	if err != nil {
+		return err
+	}
+
+	system, err := GetSystemComponent()
+	desired := system.AppDeploymentConfig()
+
+	desiredPreHookPod := desired.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	existingPrehookPod := existing.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	if !reflect.DeepEqual(existingPrehookPod.Command, desiredPreHookPod.Command) {
+		return errors.New("system app pre hook pod command not upgraded")
+	}
+	return nil
+}
+
+func verifySMTPSecret(cl client.Client, ns string) error {
+	secret := &v1.Secret{}
+	secretNamespacedName := types.NamespacedName{Name: component.SystemSecretSystemSMTPSecretName, Namespace: ns}
+	err := cl.Get(context.TODO(), secretNamespacedName, secret)
+	if err != nil {
+		return err
+	}
+
+	if len(secret.Data) < 1 {
+		return fmt.Errorf("secret %s is empty", component.SystemSecretSystemSMTPSecretName)
+	}
+
+	return nil
+}
+
+func verifySMTPConfigMapDeleted(cl client.Client, ns string) error {
+	configMap := &v1.ConfigMap{}
+	configMapNamespacedName := types.NamespacedName{Name: "smtp", Namespace: ns}
+	err := cl.Get(context.TODO(), configMapNamespacedName, configMap)
+
+	if err == nil {
+		return errors.New("smtp configmap still exists")
+	}
+
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
+}

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -21,9 +21,9 @@ const (
 )
 
 const (
-	defaultAppLabel                    = "3scale-api-management"
+	DefaultAppLabel                    = "3scale-api-management"
 	defaultTenantName                  = "3scale"
-	defaultImageStreamImportInsecure   = false
+	DefaultImageStreamImportInsecure   = false
 	defaultResourceRequirementsEnabled = true
 )
 
@@ -47,7 +47,7 @@ type APIManagerSpec struct {
 	// +optional
 	Zync *ZyncSpec `json:"zync,omitempty"`
 	// +optional
-	HighAvailability    *HighAvailabilitySpec    `json:"highAvailability,omitempty"`
+	HighAvailability *HighAvailabilitySpec `json:"highAvailability,omitempty"`
 	// +optional
 	PodDisruptionBudget *PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
 }
@@ -454,9 +454,9 @@ func (apimanager *APIManager) setAPIManagerCommonSpecDefaults() bool {
 	changed := false
 	spec := &apimanager.Spec
 
-	tmpDefaultAppLabel := defaultAppLabel
+	tmpDefaultAppLabel := DefaultAppLabel
 	tmpDefaultTenantName := defaultTenantName
-	tmpDefaultImageStreamTagImportInsecure := defaultImageStreamImportInsecure
+	tmpDefaultImageStreamTagImportInsecure := DefaultImageStreamImportInsecure
 	tmpDefaultResourceRequirementsEnabled := defaultResourceRequirementsEnabled
 
 	if spec.AppLabel == nil {


### PR DESCRIPTION
This is a PoC to evaluate a new upgrade tool to migrate template based deployments. 

Currently, template based deployments are upgraded manually by the customer based on customer oriented documentation. This upgrade procedure doc contains lots of (more than 20) commands based on the `oc` and `jq` tools. These commands patch current 3scale deployment to upgrade it and also verify that the upgrade process has been done successfully. 

This documented upgrade procedure is then reviewed by tech writers and validated by QE team. After that, it is published in official doc site. [See example of 3scale release 2.7 template based deployment upgrade doc](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/migrating_3scale/upgrading-3scale).

The main motivation of an upgrade tool is to be less error prone, have programmatic upgrade procedure and validation checks. The 3scale operator upgrading mechanisms and code base are reused to implement the upgrading tool, so consistency is enforced between operator and templates based installations. Besides, the customer can install several template profiles. So, documentation has to ask the customer about installed profile and run commands accordingly. The automated tool can be smart enough to figure out installed profile and upgrade accordingly. The customer does not need to run specific commands for the specific 3scale deployment profile.

The main drawback would be this tool would need to be productized as a new deliverable to the customers.

The tool has been designed to be idempotent. Thus, it can be safely run any number of times. The used pattern is:
```
if not DesiredState(3scaleComponent) then Upgrade(3scaleComponent) end
```
The tool only works to upgrade from the previous 3scale release of the latest 3scale release to the latest one. So, only 1 step upgrade is allowed. 

Compiling the tool:

```
$ make upgrade-tool 
go build -o upgrade-tool /gopath/src/github.com/3scale/3scale-operator/pkg/3scale/amp/main.go
```
Signature of the command

```
$ ./upgrade-tool upgrade -h
Upgrade your 3scale installation

Usage:
  generator upgrade [flags]

Flags:
  -h, --help               help for upgrade
  -n, --namespace string   Cluster namespace (required)
```

The tool will first upgrade all required components and then run verification checks. 

Run example

```
$ ./upgrade-tool upgrade -n myproject
Created object /system-smtp
Update object /system-app
Update object /system-app
Update object /system-sidekiq
Update object /aws-auth
Update object /system-app
Update object /system-sidekiq
Update object /system-environment
Update object /system-environment
Update object /amp-system
Update object /amp-apicast
Update object /amp-backend
Update object /amp-zync
Update object /system-memcached
Update object /zync-database-postgresql
Update object /backend-redis
Update object /system-redis
Update object /system-mysql
########
## Check upgrade
########
[OK] SMTP secret exists
[OK] System app pre hook pod command upgraded
[OK] System app pre hook pod env upgraded
[OK] System app containers env upgraded
[OK] System app containers env upgraded
[OK] AWS secret upgraded
[OK] AWS info deleted from configmap
[OK] AMP_RELEASE patched
[OK] Images upgraded
[OK] old SMTP configmap deleted
3scale successfully upgraded to release 2.8
```


