### PR TITLE
enabling go modules circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,21 +46,21 @@ commands:
             curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_RELEASE_VERSION}/operator-sdk-${OPERATOR_SDK_RELEASE_VERSION}-x86_64-linux-gnu
             chmod +x operator-sdk-${OPERATOR_SDK_RELEASE_VERSION}-x86_64-linux-gnu && sudo cp operator-sdk-${OPERATOR_SDK_RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${OPERATOR_SDK_RELEASE_VERSION}-x86_64-linux-gnu
 
-  install-operator-dependencies:
+  install-dependencies:
     steps:
       - restore_cache:
           keys:
-            - v4-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+            - go-mod-v1-{{ arch }}-{{ checksum "go.sum" }}
             # Find the most recently generated cache used from any branch
-            - v4-3scaleoperator-vendor-{{ arch }}
+            - go-mod-v1-{{ arch }}
       - run:
-          name: Install operator dependencies
+          name: Install go dependencies
           command: |
-            make vendor
+            go mod download
       - save_cache:
-          key: v4-3scaleoperator-vendor-{{ arch }}-{{ checksum "go.sum" }}
+          key: go-mod-v1-{{ arch }}-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg"
+            - "/go/pkg/mod"
 
   install-openshift:
     steps:
@@ -98,20 +98,23 @@ commands:
   install-golang:
     steps:
       - run:
+          name: Install Golang
+          command: |
+            curl --fail -L https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz | sudo tar -C /opt -xzf-
+      - run:
           name: Setup GO env
           command: |
             mkdir -p ~/tmp
             echo 'export TMPDIR=~/tmp/' >> $BASH_ENV
             echo 'export GOROOT=/opt/go' >> $BASH_ENV
-            echo 'export GOPATH=~/go' >> $BASH_ENV
-            sudo mkdir -p /opt/go/bin
-            mkdir -p ~/go/bin
+            echo 'export GOPATH=/go' >> $BASH_ENV
             echo 'export PATH=$GOROOT/bin:$PATH' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
       - run:
-          name: Install Golang
+          name: Setup GOPATH
           command: |
-            curl --fail -L https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz | sudo tar -C /opt -xzf-
+            sudo mkdir -p "$GOPATH/src" "$GOPATH/bin"
+            sudo chmod -R 777 "$GOPATH"
 
   deploy-3scale-eval-from-template-imagestreamsless:
     steps:
@@ -262,7 +265,7 @@ commands:
     steps:
       - checkout
       - install-operator-sdk
-      - install-operator-dependencies
+      - install-dependencies
       - run:
           name: Build Operator
           command: |
@@ -271,7 +274,7 @@ commands:
   unit-tests:
     steps:
       - checkout
-      - run: make vendor
+      - install-dependencies
       - run:
           name: Run unit tests in pkg folder
           command: |
@@ -280,7 +283,7 @@ jobs:
   install-operator:
     docker:
       - image: circleci/golang:1.13.7
-    working_directory: /go/src/github.com/3scale/3scale-operator
+    working_directory: ~/project/3scale-operator
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -372,7 +375,6 @@ jobs:
   run-unit-tests:
     docker:
       - image: circleci/golang:1.13.7
-    working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - unit-tests
 
@@ -381,14 +383,13 @@ jobs:
       image: circleci/classic:latest
       docker_layer_caching: true
     resource_class: large
-    working_directory: ~/go/src/github.com/3scale/3scale-operator
     steps:
       - attach-workspace
       - install-openshift
       - install-golang
       - install-operator-sdk
       - checkout
-      - install-operator-dependencies
+      - install-dependencies
       - run:
           name: Unpack and push operator to internal registry
           command: |
@@ -411,29 +412,46 @@ jobs:
   generator:
     docker:
       - image: circleci/golang:1.13.7
-    working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - checkout
-      - run: make vendor
+      - install-dependencies
       - run: make templates
       - run: make test -j 2 --directory pkg/3scale/amp
 
   test-crds:
     docker:
       - image: circleci/golang:1.13.7
-    working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - checkout
-      - run: make vendor
+      - install-dependencies
       - run: make test-crds
 
   license-check:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/golang:1.13.7
     steps:
-      - install-golang
+      - run:
+          name: Installing ruby
+          command: |
+            # Determine if sudo is neccessary
+            SUDO=""
+            if [[ $EUID -ne 0 ]]; then
+            SUDO=sudo
+            fi
+            # Install ruby
+            $SUDO apt-get update && $SUDO apt-get install -y ruby-full
+      - run:
+          name: Installing License tool
+          command: |
+            # Determine if sudo is neccessary
+            SUDO=""
+            if [[ $EUID -ne 0 ]]; then
+            SUDO=sudo
+            fi
+            # Install ruby
+            $SUDO gem install license_finder --version 5.7.1
       - checkout
-      - run: sudo gem install license_finder --version 5.7.1
+      - install-dependencies
       - run: make licenses-check
 
   verify-manifest:
@@ -447,7 +465,6 @@ jobs:
   unit-tests-coverage:
     docker:
       - image: circleci/golang:1.13.7
-    working_directory: /go/src/github.com/3scale/3scale-operator
     steps:
       - unit-tests
       - run:


### PR DESCRIPTION
Following guidelines (but for Go 1.13.7 where go modules is by default on)
https://circleci.com/blog/go-v1.11-modules-and-circleci/