### PR TITLE
Fix apicast 3scale portal endpoint

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3479,7 +3479,6 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
     PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3296,7 +3296,6 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
     PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2845,7 +2845,6 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
     PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3318,7 +3318,6 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
     PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3550,7 +3550,6 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
     PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3367,7 +3367,6 @@ objects:
     name: system-master-apicast
   stringData:
     ACCESS_TOKEN: ${APICAST_ACCESS_TOKEN}
-    BASE_URL: http://${APICAST_ACCESS_TOKEN}@system-master:3000
     PROXY_CONFIGS_ENDPOINT: http://${APICAST_ACCESS_TOKEN}@system-master:3000/master/api/proxy/configs
   type: Opaque
 - apiVersion: v1

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -356,7 +356,7 @@ func (apicast *Apicast) ProductionDeploymentConfig() *appsv1.DeploymentConfig {
 
 func (apicast *Apicast) buildApicastCommonEnv() []v1.EnvVar {
 	return []v1.EnvVar{
-		envVarFromSecret("THREESCALE_PORTAL_ENDPOINT", "system-master-apicast", "PROXY_CONFIGS_ENDPOINT"),
+		envVarFromSecret("THREESCALE_PORTAL_ENDPOINT", "system-master-apicast", SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName),
 		envVarFromSecret("BACKEND_ENDPOINT_OVERRIDE", "backend-listener", "service_endpoint"),
 		envVarFromConfigMap("APICAST_MANAGEMENT_API", "apicast-environment", "APICAST_MANAGEMENT_API"),
 		envVarFromConfigMap("OPENSSL_VERIFY", "apicast-environment", "OPENSSL_VERIFY"),

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -11,8 +11,6 @@ type ApicastOptions struct {
 	ManagementAPI                  string                  `validate:"required"`
 	OpenSSLVerify                  string                  `validate:"required"`
 	ResponseCodes                  string                  `validate:"required"`
-	TenantName                     string                  `validate:"required"`
-	WildcardDomain                 string                  `validate:"required"`
 	ImageTag                       string                  `validate:"required"`
 	ProductionResourceRequirements v1.ResourceRequirements `validate:"-"`
 	StagingResourceRequirements    v1.ResourceRequirements `validate:"-"`

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -74,7 +74,6 @@ const (
 const (
 	SystemSecretSystemMasterApicastSecretName                    = "system-master-apicast"
 	SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName = "PROXY_CONFIGS_ENDPOINT"
-	SystemSecretSystemMasterApicastBaseURL                       = "BASE_URL"
 	SystemSecretSystemMasterApicastAccessToken                   = "ACCESS_TOKEN"
 )
 
@@ -497,7 +496,6 @@ func (system *System) MasterApicastSecret() *v1.Secret {
 		},
 		StringData: map[string]string{
 			SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName: system.Options.ApicastSystemMasterProxyConfigEndpoint,
-			SystemSecretSystemMasterApicastBaseURL:                       system.Options.ApicastSystemMasterBaseURL,
 			SystemSecretSystemMasterApicastAccessToken:                   system.Options.ApicastAccessToken,
 		},
 		Type: v1.SecretTypeOpaque,

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -39,7 +39,6 @@ type SystemOptions struct {
 	MessageBusRedisSentinelRole            *string `validate:"required"`
 	MessageBusRedisNamespace               *string `validate:"required"`
 	ApicastSystemMasterProxyConfigEndpoint string  `validate:"required"`
-	ApicastSystemMasterBaseURL             string  `validate:"required"`
 	AdminEmail                             *string `validate:"required"`
 
 	ImageTag string `validate:"required"`
@@ -87,10 +86,6 @@ func (s *SystemOptions) Validate() error {
 
 func DefaultApicastSystemMasterProxyConfigEndpoint(token string) string {
 	return fmt.Sprintf("http://%s@system-master:3000/master/api/proxy/configs", token)
-}
-
-func DefaultApicastSystemMasterBaseURL(token string) string {
-	return fmt.Sprintf("http://%s@system-master:3000", token)
 }
 
 func DefaultMemcachedServers() string {

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -23,8 +23,6 @@ func NewApicastOptionsProvider(apimanager *appsv1alpha1.APIManager) *ApicastOpti
 
 func (a *ApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions, error) {
 	a.apicastOptions.AppLabel = *a.apimanager.Spec.AppLabel
-	a.apicastOptions.TenantName = *a.apimanager.Spec.TenantName
-	a.apicastOptions.WildcardDomain = a.apimanager.Spec.WildcardDomain
 	a.apicastOptions.ManagementAPI = *a.apimanager.Spec.Apicast.ApicastManagementAPI
 	a.apicastOptions.ImageTag = product.ThreescaleRelease
 	a.apicastOptions.OpenSSLVerify = strconv.FormatBool(*a.apimanager.Spec.Apicast.OpenSSLVerify)

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -50,8 +50,6 @@ func defaultApicastOptions() *component.ApicastOptions {
 		ManagementAPI:                  apicastManagementAPI,
 		OpenSSLVerify:                  strconv.FormatBool(openSSLVerify),
 		ResponseCodes:                  strconv.FormatBool(responseCodes),
-		TenantName:                     tenantName,
-		WildcardDomain:                 wildcardDomain,
 		ImageTag:                       product.ThreescaleRelease,
 		ProductionResourceRequirements: component.DefaultProductionResourceRequirements(),
 		StagingResourceRequirements:    component.DefaultStagingResourceRequirements(),

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -316,9 +316,14 @@ func (s *SystemOptionsProvider) setSystemMasterApicastOptions() error {
 	}
 	s.options.ApicastAccessToken = val
 
-	// TODO we do not reconcile ProxyConfigEndpoint nor BaseURL fields because they are dependant on the TenantName
-	s.options.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(s.options.ApicastAccessToken)
-	s.options.ApicastSystemMasterBaseURL = component.DefaultApicastSystemMasterBaseURL(s.options.ApicastAccessToken)
+	val, err = s.secretSource.FieldValue(
+		component.SystemSecretSystemMasterApicastSecretName,
+		component.SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName,
+		component.DefaultApicastSystemMasterProxyConfigEndpoint(s.options.ApicastAccessToken))
+	if err != nil {
+		return err
+	}
+	s.options.ApicastSystemMasterProxyConfigEndpoint = val
 
 	return nil
 }

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -173,7 +173,6 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 	}
 
 	expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(opts.ApicastAccessToken)
-	expectedOpts.ApicastSystemMasterBaseURL = component.DefaultApicastSystemMasterBaseURL(opts.ApicastAccessToken)
 	return expectedOpts
 }
 
@@ -294,7 +293,6 @@ func TestGetSystemOptionsProvider(t *testing.T) {
 				expectedOpts := defaultSystemOptions(opts)
 				expectedOpts.ApicastAccessToken = "apicastAccessToken"
 				expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint("apicastAccessToken")
-				expectedOpts.ApicastSystemMasterBaseURL = component.DefaultApicastSystemMasterBaseURL("apicastAccessToken")
 				return opts
 			},
 		},

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -69,8 +69,6 @@ func (a *Apicast) options() (*component.ApicastOptions, error) {
 	ao.ManagementAPI = "${APICAST_MANAGEMENT_API}"
 	ao.OpenSSLVerify = "${APICAST_OPENSSL_VERIFY}"
 	ao.ResponseCodes = "${APICAST_RESPONSE_CODES}"
-	ao.TenantName = "${TENANT_NAME}"
-	ao.WildcardDomain = "${WILDCARD_DOMAIN}"
 	ao.ImageTag = "${AMP_RELEASE}"
 
 	ao.ProductionResourceRequirements = component.DefaultProductionResourceRequirements()

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -181,7 +181,6 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.MemcachedServers = component.DefaultMemcachedServers()
 	o.EventHooksURL = component.DefaultEventHooksURL()
 	o.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(o.ApicastAccessToken)
-	o.ApicastSystemMasterBaseURL = component.DefaultApicastSystemMasterBaseURL(o.ApicastAccessToken)
 	o.AppProviderContainerResourceRequirements = component.DefaultAppProviderContainerResourceRequirements()
 	o.AppMasterContainerResourceRequirements = component.DefaultAppMasterContainerResourceRequirements()
 	o.AppDeveloperContainerResourceRequirements = component.DefaultAppDeveloperContainerResourceRequirements()


### PR DESCRIPTION
Simplifying `system-master-apicast` secret and apicast options structure. Master base Url not required.

- [x] upgrade procedure