### PR TITLE
unit makefile target always cleans first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(PROJECT_PATH)/_output/unit.cov:
 
 ## unit: Run unit tests in pkg directory
 .PHONY: unit
-unit: $(PROJECT_PATH)/_output/unit.cov
+unit: $(PROJECT_PATH)/_output/unit.cov clean
 
 ## coverage_analysis: Analyze coverage via a browse
 .PHONY: coverage_analysis


### PR DESCRIPTION
Tired of doing `make clean unit`

`make unit` should be enough