### PR TITLE
Fix CI jobs that create the ImageStreams separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,9 @@ commands:
           no_output_timeout: 30m
       - check-3scale-templates-deployed-routes
   push-3scale-images-to-quay:
+    parameters:
+      components_imagestream_tag_name:
+        type: string
     steps:
       - docker-login
       - run:
@@ -185,11 +188,12 @@ commands:
           command: |
             oc whoami --show-token | docker login -u $(oc whoami) --password-stdin 172.30.1.1:5000
             project=$(oc project -q)
+            imagestream_tag_name=<< parameters.components_imagestream_tag_name >>
 
             oc image mirror $(for component in apicast zync ; do
-              echo 172.30.1.1:5000/$project/amp-$component:latest=quay.io/3scale/$component:nightly
-            done) 172.30.1.1:5000/$project/amp-backend:latest=quay.io/3scale/apisonator:nightly \
-            172.30.1.1:5000/$project/amp-system:latest=quay.io/3scale/porta:nightly --insecure
+              echo 172.30.1.1:5000/$project/amp-$component:${imagestream_tag_name}=quay.io/3scale/$component:nightly
+            done) 172.30.1.1:5000/$project/amp-backend:${imagestream_tag_name}=quay.io/3scale/apisonator:nightly \
+            172.30.1.1:5000/$project/amp-system:${imagestream_tag_name}=quay.io/3scale/porta:nightly --insecure
 
   create-secrets:
     steps:
@@ -201,21 +205,25 @@ commands:
               --docker-username="${DOCKER_USERNAME}" \
               --docker-server="${DOCKER_REGISTRY}"
   build-nightly-amp:
+    parameters:
+      components_imagestream_tag_name:
+        type: string
     steps:
       - run:
           name: Build nightly images
           no_output_timeout: 30m
           command: |
             set -o errexit
+            imagestream_tag_name=<< parameters.components_imagestream_tag_name >>
             oc new-app -f pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml \
               --param AMP_BACKEND_IMAGE=quay.io/3scale/apisonator:nightly \
               --param AMP_ZYNC_IMAGE=quay.io/3scale/zync:nightly \
               --param AMP_APICAST_IMAGE=quay.io/3scale/apicast:nightly \
               --param AMP_SYSTEM_IMAGE=quay.io/3scale/porta:nightly \
-              -o json --param WILDCARD_DOMAIN=lvh/me --param AMP_RELEASE=master | \
+              -o json --param WILDCARD_DOMAIN=lvh/me --param AMP_RELEASE="${imagestream_tag_name}" | \
               jq -j '.items[] | select(.kind == "ImageStream")' | \
               oc create -f -
-            oc new-app -f pkg/3scale/amp/manual-templates/amp/build.yml --allow-missing-imagestream-tags
+            oc new-app -f pkg/3scale/amp/manual-templates/amp/build.yml --allow-missing-imagestream-tags --param IMAGESTREAM_TAG_NAME="${imagestream_tag_name}"
             until (oc get is s2i-openresty-centos7 -o json || echo '{}') | jq '[.status.tags[] | select(.tag == "builder")] | length == 1' --exit-status; do
               echo "wating for s2i-openresty-centos7:builder imagestream"
               sleep 1
@@ -358,6 +366,9 @@ jobs:
       - oc-status
 
   build-push-3scale-nightly-images:
+    parameters:
+      components_imagestream_tag_name:
+        type: string
     machine:
       image: circleci/classic:latest
       docker_layer_caching: true
@@ -366,11 +377,13 @@ jobs:
       - checkout
       - install-openshift
       - create-secrets
-      - build-nightly-amp
+      - build-nightly-amp:
+          components_imagestream_tag_name: << parameters.components_imagestream_tag_name >>
       - oc-observe
       - deploy-3scale-eval-from-template-imagestreamsless
       - oc-status
-      - push-3scale-images-to-quay
+      - push-3scale-images-to-quay:
+          components_imagestream_tag_name: << parameters.components_imagestream_tag_name >>
 
   run-unit-tests:
     docker:
@@ -499,6 +512,7 @@ workflows:
     jobs:
       - build-push-3scale-nightly-images:
           context: org-global
+          components_imagestream_tag_name: "master"
       - deploy_templates:
           requires:
             - build-push-3scale-nightly-images

--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -30,7 +30,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: amp-zync:latest
+        name: "amp-zync:${IMAGESTREAM_TAG_NAME}"
     source:
       git:
         uri: https://github.com/3scale/zync.git
@@ -51,7 +51,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: amp-system:latest
+        name: "amp-system:${IMAGESTREAM_TAG_NAME}"
     source:
       git:
         uri: "https://github.com/3scale/porta.git"
@@ -73,7 +73,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: amp-apicast:latest
+        name: "amp-apicast:${IMAGESTREAM_TAG_NAME}"
     source:
       contextDir: gateway
       git:
@@ -120,7 +120,7 @@ objects:
       output:
           to:
               kind: ImageStreamTag
-              name: amp-backend:latest
+              name: "amp-backend:${IMAGESTREAM_TAG_NAME}"
       source:
           git:
               uri: "https://github.com/3scale/apisonator.git"
@@ -148,4 +148,8 @@ parameters:
 - name: APISONATOR_GIT_REF
   description: "Apisonator git reference to use. Can be a tag or branch."
   value: "master"
+  required: true
+- name: IMAGESTREAM_TAG_NAME
+  description: "Value of the ImageStream tags to be used"
+  value: "latest"
   required: true


### PR DESCRIPTION
Since PR https://github.com/3scale/3scale-operator/pull/292 ImageStreams are no longer created with the "latest" tag but with the version-specific tag.
CircleCI tasks that relied on ImageStream building via the build.yml template to create the ImageStreams independently were always being created with "latest" tags.

This PR makes the name of the ImageStream tags of the 3scale components configurable in the build.yml and updates CircleCI jobs that rely on them to use the version-specific tag. In the case of this PR, "master".