### PR TITLE
backport 3scale-2.8-stable-prod #314 Update s3 fields in user guide

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -338,7 +338,7 @@ The available configurable secrets are:
 The name of this secret can be any name as long as does not collide with other
 existing secret names.
 
-| **Field** | **Description** | | **Required** |
+| **Field** | **Description** | **Required** |
 | --- | --- | --- |
 | AWS_ACCESS_KEY_ID | AWS Access Key ID to use in S3 Storage for System's file storage | Y |
 | AWS_SECRET_ACCESS_KEY | AWS Access Key Secret to use in S3 Storage for System's file storage | Y |

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -261,19 +261,14 @@ spec:
   wildcardDomain: lvh.me
   system:
     fileStorage:
-      amazonSimpleStorageService:
-        awsRegion: ""
-        awsBucket: ""
-        awsCredentialsSecret:
+      simpleStorageService:
+        configurationSecretRef:
           name: aws-auth
 ```
 
 Note that S3 secret name is provided directly in the APIManager custom resource.
 
 Check [*APIManager SystemS3Spec*](apimanager-reference.md#SystemS3Spec) for reference.
-
-**Deprecation Note**
-**awsRegion** and **awsBucket** attributes are deprecated. They must exist and left with empty value.
 
 #### PostgreSQL Installation
 


### PR DESCRIPTION
Some deprecated field names documentation update in the user-guide (they were in the reference) were not backported into the 3scale-2.8-stable-prod

This PR Backports #314 