### PR TITLE
Add restore wait for apimanager readiness and resync of zync routes

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -63,6 +63,12 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
   - apps
   resources:
   - replicasets

--- a/doc/apimanagerrestore-reference.md
+++ b/doc/apimanagerrestore-reference.md
@@ -45,6 +45,8 @@ Is not the scope of restore functionality of the operator:
     * When the backed up System's FileStorage data was stored in a PersistentVolumeClaim
     * **CURRENTLY UNSUPPORTED**  When the backed up System's FileStorage data was stored in a S3 API-compatible storage
 
+* 3scale related OpenShift routes (master, tenants, ...)
+
 ## Data that is not restored
 
 Restore of the backed up external databases data used by 3scale is not part of
@@ -59,15 +61,6 @@ and has to be performed by the user appropriately:
 
 The reason of this is to allow the user to configure different database endpoints
 than the ones used in the previous 3scale installation that was backed up
-
-Currently recreation of OpenShift routes is not automatically performed during
-the restore process. To manually restore them execute the following command
-when the restored 3scale API Management solution has been restored and is running
-and ready:
-
-```
-oc exec -it <a-system-app-pod> bash -- -c "bundle exec rake zync:resync:domains"
-```
 
 ## APIManagerRestore
 

--- a/doc/operator-backup-and-restore.md
+++ b/doc/operator-backup-and-restore.md
@@ -127,9 +127,3 @@ following one:
 1. At this point the restore has finished. You should see a new APIManager custom
    resource has been created and a 3scale installation deployed by it being
    deployed and eventually running.
-1. When the 3scale installation is running and ready the OpenShift routes
-   have to be restored from the existing database data. To do so execute the
-   following command:
-   ```
-   oc exec -it <a-system-app-pod> bash -- -c "bundle exec rake zync:resync:domains"
-   ```


### PR DESCRIPTION
This PR adds the following:
* Waits until APIManager resource has all non-external Deployments in "ready" state.
* Trigger of zync domains resync via a Kubernetes Job

This PR is built on top of PR https://github.com/3scale/3scale-operator/pull/358 and the base merge branch is the one from that PR.

We also should evaluate/consider whether we want to include the functionality in the restore itself. Doing so implies that the restore does not finish until the deployments are ready (it keeps waiting) and the domains resync finishes without an exit code error