### PR TITLE
Zync BuildConfig with UBI7 base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,16 @@ commands:
             done) 172.30.1.1:5000/$project/amp-backend:${imagestream_tag_name}=quay.io/3scale/apisonator:nightly \
             172.30.1.1:5000/$project/amp-system:${imagestream_tag_name}=quay.io/3scale/porta:nightly --insecure
 
+  create-redhat-registry-io-secret:
+    steps:
+      - run:
+          name: Create registry.redhat.io secret
+          command: |
+            oc create secret docker-registry threescale-registry-auth \
+              --docker-password="${REGISTRY_REDHAT_IO_PASSWORD}" \
+              --docker-username="${REGISTRY_REDHAT_IO_USERNAME}" \
+              --docker-server="${REGISTRY_REDHAT_IO_SERVER}"
+
   create-secrets:
     steps:
       - run:
@@ -377,6 +387,7 @@ jobs:
       - checkout
       - install-openshift
       - create-secrets
+      - create-redhat-registry-io-secret
       - build-nightly-amp:
           components_imagestream_tag_name: << parameters.components_imagestream_tag_name >>
       - oc-observe

--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -11,12 +11,12 @@ objects:
     annotations:
     labels:
       app: zync
-    name: ruby-24-centos7
+    name: ruby-25-ubi7
   spec:
     tags:
     - from:
         kind: DockerImage
-        name: centos/ruby-24-centos7
+        name: registry.access.redhat.com/ubi7/ruby-25
       name: latest
 
 - apiVersion: v1
@@ -40,7 +40,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: ruby-24-centos7:latest
+          name: ruby-25-ubi7:latest
       type: Docker
 
 - apiVersion: v1

--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -16,7 +16,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/ubi7/ruby-25
+        name: registry.redhat.io/ubi7/ruby-25
       name: latest
 
 - apiVersion: v1


### PR DESCRIPTION
Changes the image of the base ImageStream used by the zync BuildConfig from `centos/ruby-24-centos7` to `registry.access.redhat.com/ubi7/ruby-25`. This not only changes the underlying operating system to RHEL7, but also upgrades Ruby to 2.5.

This change follows https://github.com/3scale/zync/pull/328, which aligned the recommended settings for building Zync in Opesnhift with its current Dockerfile in the upstream and Ruby version upon which CI tests are run and downstream images are built.

I understand this will change the nightly builds, making them aligned to current development stage of the upstream. https://github.com/3scale/3scale-operator/blob/cc029c11494d99c91fb94e9778fb6a713373dfa7/.circleci/config.yml#L226.