### PR TITLE
Use public images for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,14 +129,9 @@ commands:
   deploy-3scale-eval-from-template:
     steps:
       - run:
-          name: Deploy 3scale from amp-eval template with nightly images
+          name: Deploy 3scale from amp-eval template
           command: |
             oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml \
-              --param AMP_BACKEND_IMAGE=quay.io/3scale/apisonator:nightly \
-              --param AMP_ZYNC_IMAGE=quay.io/3scale/zync:nightly \
-              --param AMP_APICAST_IMAGE=quay.io/3scale/apicast:nightly \
-              --param AMP_SYSTEM_IMAGE=quay.io/3scale/porta:nightly \
-              --param MEMCACHED_IMAGE=registry.redhat.io/3scale-amp2/memcached-rhel7:3scale2.7 \
               --param WILDCARD_DOMAIN=lvh.me --param TENANT_NAME=3scale
             oc wait --for=condition=available --timeout=-1s $(oc get dc --output=name)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
             oc wait --for=condition=available --timeout=-1s $(oc get dc --output=name)
 
             oc get events | egrep ' Failed ' || :
-            oc get events -o json | jq '[.items[] | select(.reason == "Failed") | debug ] | length == 0'  --exit-status
+            oc get events -o json | jq '[.items[] | select(.reason == "Failed") | debug ] | length == 0'
           no_output_timeout: 30m
 
   deploy-3scale-eval-from-template:
@@ -136,7 +136,7 @@ commands:
             oc wait --for=condition=available --timeout=-1s $(oc get dc --output=name)
 
             oc get events | egrep ' Failed ' || :
-            oc get events -o json | jq '[.items[] | select(.reason == "Failed") | debug ] | length == 0'  --exit-status
+            oc get events -o json | jq '[.items[] | select(.reason == "Failed") | debug ] | length == 0'
           no_output_timeout: 30m
 
   push-3scale-images-to-quay:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -30,12 +30,12 @@ spec:
             - name: OPERATOR_NAME
               value: "threescale-operator"
             - name: BACKEND_IMAGE
-              value: "quay.io/3scale/apisonator:nightly"
+              value: "registry.redhat.io/3scale-amp2/backend-rhel7:3scale2.8"
             - name: APICAST_IMAGE
-              value: "quay.io/3scale/apicast:nightly"
+              value: "registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.8"
             - name: SYSTEM_IMAGE
-              value: "quay.io/3scale/porta:nightly"
+              value: "registry.redhat.io/3scale-amp2/system-rhel7:3scale2.8"
             - name: ZYNC_IMAGE
-              value: "quay.io/3scale/zync:nightly"
+              value: "registry.redhat.io/3scale-amp2/zync-rhel7:3scale2.8"
             - name: SYSTEM_MEMCACHED_IMAGE
-              value: "registry.stage.redhat.io/3scale-amp2/memcached-rhel7:3scale2.8"
+              value: "registry.redhat.io/3scale-amp2/memcached-rhel7:3scale2.8"

--- a/test/e2e/apimanager_controller_test.go
+++ b/test/e2e/apimanager_controller_test.go
@@ -141,30 +141,12 @@ func productizedUnconstrainedDeploymentSubtest(t *testing.T) {
 	t.Log("operator Deployment is ready")
 
 	enableResourceRequirements := false
-	apicastNightlyImage := "quay.io/3scale/apicast:nightly"
-	backendNightlyImage := "quay.io/3scale/apisonator:nightly"
-	systemNightlyImage := "quay.io/3scale/porta:nightly"
-	zyncNightlyImage := "quay.io/3scale/zync:nightly"
 	wildcardDomain := "test1.127.0.0.1.nip.io"
-	memcachedLastProductizedImage := "registry.redhat.io/3scale-amp2/memcached-rhel7:3scale2.7"
 	apimanager := &appsv1alpha1.APIManager{
 		Spec: appsv1alpha1.APIManagerSpec{
 			APIManagerCommonSpec: appsv1alpha1.APIManagerCommonSpec{
 				WildcardDomain:              wildcardDomain,
 				ResourceRequirementsEnabled: &enableResourceRequirements,
-			},
-			Apicast: &appsv1alpha1.ApicastSpec{
-				Image: &apicastNightlyImage,
-			},
-			Backend: &appsv1alpha1.BackendSpec{
-				Image: &backendNightlyImage,
-			},
-			System: &appsv1alpha1.SystemSpec{
-				Image:          &systemNightlyImage,
-				MemcachedImage: &memcachedLastProductizedImage,
-			},
-			Zync: &appsv1alpha1.ZyncSpec{
-				Image: &zyncNightlyImage,
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Production urls are only valid after GA. Before GA, production urls will return 404 Not found because it is on GA when images are made public.

So before GA, the operator stable branch should be using 3scale operand images from the component's stable branches. Even nightly images are wrong. That is because some component could be merging to master some new feature (maybe breaking thing) just after creating component's stable branch.

After GA, before any update in the operator code, the stable branch of the operator should be updated with a PR like this. That is the main reason of this PR.