### PR TITLE
Make OC CLI Image configurable in backup/restore

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -40,3 +40,5 @@ spec:
               value: "quay.io/3scale/zync:nightly"
             - name: SYSTEM_MEMCACHED_IMAGE
               value: "memcached:1.5"
+            - name: OC_CLI_IMAGE
+              value: "quay.io/openshift/origin-cli:4.2"

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -39,3 +39,7 @@ func SystemMemcachedImageURL() string {
 func ZyncPostgreSQLImageURL() string {
 	return "centos/postgresql-10-centos7"
 }
+
+func OCCLIImageURL() string {
+	return "quay.io/openshift/origin-cli:4.2"
+}

--- a/pkg/backup/apimanager_backup.go
+++ b/pkg/backup/apimanager_backup.go
@@ -117,7 +117,7 @@ func (b *APIManagerBackup) BackupSecretsAndConfigMapsToPVCJob() *batchv1.Job {
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "backup-cfgmaps-secrets",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -166,7 +166,7 @@ func (b *APIManagerBackup) BackupAPIManagerCustomResourceToPVCJob() *batchv1.Job
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "backup-apimanager-cr",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -216,7 +216,7 @@ func (b *APIManagerBackup) BackupSystemFileStoragePVCToPVCJob() *batchv1.Job {
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "backup-system-filestorage-pvc",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},

--- a/pkg/backup/apimanager_backup_options.go
+++ b/pkg/backup/apimanager_backup_options.go
@@ -11,6 +11,7 @@ type APIManagerBackupOptions struct {
 	APIManagerName             string                      `validate:"required"` // Name of the APIManager CR. NOT the backup cr name
 	APIManager                 *appsv1alpha1.APIManager    `validate:"required"` // Should we make this required?
 	APIManagerBackupPVCOptions *APIManagerBackupPVCOptions `validate:"required"`
+	OCCLIImageURL              string                      `validate:"required"`
 }
 
 func NewAPIManagerBackupOptions() *APIManagerBackupOptions {

--- a/pkg/backup/apimanager_backup_options_provider.go
+++ b/pkg/backup/apimanager_backup_options_provider.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -36,6 +38,7 @@ func (a *APIManagerBackupOptionsProvider) Options() (*APIManagerBackupOptions, e
 	}
 	res.APIManager = apiManager
 	res.APIManagerName = apiManager.Name
+	res.OCCLIImageURL = a.ocCLIImageURL()
 
 	pvcOptions, err := a.pvcBackupOptions()
 	if err != nil {
@@ -96,4 +99,8 @@ func (a *APIManagerBackupOptionsProvider) apiManagerFromName(name string) (*apps
 	res := &appsv1alpha1.APIManager{}
 	err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.APIManagerBackupCR.Namespace}, res)
 	return res, err
+}
+
+func (a *APIManagerBackupOptionsProvider) ocCLIImageURL() string {
+	return helper.GetEnvVar("OSE_CLI_IMAGE", component.OCCLIImageURL())
 }

--- a/pkg/restore/apimanager_restore.go
+++ b/pkg/restore/apimanager_restore.go
@@ -109,7 +109,7 @@ func (b *APIManagerRestore) RestoreSecretsAndConfigMapsFromPVCJob() *batchv1.Job
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "restore-cfgmaps-secrets",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -159,7 +159,7 @@ func (b *APIManagerRestore) RestoreSystemFileStoragePVCFromPVCJob() *batchv1.Job
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "backup-system-filestorage-pvc",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -209,7 +209,7 @@ func (b *APIManagerRestore) CreateAPIManagerSharedSecretJob() *batchv1.Job {
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "job",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},
@@ -255,7 +255,7 @@ func (b *APIManagerRestore) ZyncResyncDomainsJob() *batchv1.Job {
 					Containers: []v1.Container{
 						v1.Container{
 							Name:  "job",
-							Image: "registry.redhat.io/openshift4/ose-cli:4.2",
+							Image: b.options.OCCLIImageURL,
 							Command: []string{
 								"/bin/bash",
 							},

--- a/pkg/restore/apimanager_restore_options.go
+++ b/pkg/restore/apimanager_restore_options.go
@@ -8,6 +8,7 @@ type APIManagerRestoreOptions struct {
 	Namespace                   string                       `validate:"required"` // Namespace where the K8s related objects to the restore will be created/looked
 	APIManagerRestoreName       string                       `validate:"required"` // Name of the APIManagerRestore CR. NOT the backup or APIManager name
 	APIManagerRestorePVCOptions *APIManagerRestorePVCOptions `validate:"required"`
+	OCCLIImageURL               string                       `validate:"required"`
 }
 
 func NewAPIManagerRestoreOptions() *APIManagerRestoreOptions {

--- a/pkg/restore/apimanager_restore_options_provider.go
+++ b/pkg/restore/apimanager_restore_options_provider.go
@@ -3,7 +3,9 @@ package restore
 import (
 	"fmt"
 
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,6 +25,8 @@ func (a *APIManagerRestoreOptionsProvider) Options() (*APIManagerRestoreOptions,
 	res := NewAPIManagerRestoreOptions()
 	res.APIManagerRestoreName = a.APIManagerRestoreCR.Name
 	res.Namespace = a.APIManagerRestoreCR.Namespace
+
+	res.OCCLIImageURL = a.ocCLIImageURL()
 
 	pvcOptions, err := a.pvcRestoreOptions()
 	if err != nil {
@@ -48,4 +52,8 @@ func (a *APIManagerRestoreOptionsProvider) pvcRestoreOptions() (*APIManagerResto
 	res.PersistentVolumeClaimVolumeSource = a.APIManagerRestoreCR.Spec.RestoreSource.PersistentVolumeClaim.ClaimSource
 
 	return res, res.Validate()
+}
+
+func (a *APIManagerRestoreOptionsProvider) ocCLIImageURL() string {
+	return helper.GetEnvVar("OC_CLI_IMAGE", component.OCCLIImageURL())
 }


### PR DESCRIPTION
Currently backup/restore K8s Jobs use the hardcoded `registry.redhat.io/openshift4/ose-cli:4.2` image.

Update code to make the image configurable through an environment variable.
This change will allow us to configure a productized environment where direct SHA images are used in order to be able to support disconnected installs.

The PR also changes the default image to `quay.io/openshift/origin-cli:4.2` which is the upstream version of the cli image. When creating the productized branch of the operator and when productizing the operator manifests we should update values of the image to the productized image `registry.redhat.io/openshift4/ose-cli:4.2`

