### PR TITLE
Add step to cleanup Backup/Restore K8s jobs

### DIFF
--- a/deploy/crds/apps.3scale.net_apimanagerbackups_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagerbackups_crd.yaml
@@ -110,6 +110,11 @@ spec:
                 - type
                 type: object
               type: array
+            mainStepsCompleted:
+              description: Set to true when main steps have been completed. At this
+                point backup still cannot be considered  fully completed due to some
+                remaining post-backup tasks are pending (cleanup, ...)
+              type: boolean
             startTime:
               description: Backup start time. It is represented in RFC3339 form and
                 is in UTC.

--- a/deploy/crds/apps.3scale.net_apimanagerrestores_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagerrestores_crd.yaml
@@ -82,6 +82,11 @@ spec:
                 and is in UTC.
               format: date-time
               type: string
+            mainStepsCompleted:
+              description: Set to true when main steps have been completed. At this
+                point restore still cannot be considered fully completed due to some
+                remaining post-backup tasks are pending (cleanup, ...)
+              type: boolean
             startTime:
               description: Restore start time. It is represented in RFC3339 form and
                 is in UTC.

--- a/doc/operator-backup-and-restore.md
+++ b/doc/operator-backup-and-restore.md
@@ -76,10 +76,6 @@ workflow is the following one:
    like the name of the PersistentVolumeClaim where the data has been backed up when
    the configured backup destination has been a PersistentVolumeClaim. Make sure
    you take note of the value of `status.backupPersistentVolumeClaimName` field
-1. Delete the created APIManagerBackup custom resource created previously. This
-   action is required to cleanup elements used by APIManagerBackup. The
-   backup PersistentVolumeClaim will still exist after deleting the custom
-   resource
 
 ## Restoring 3scale
 

--- a/pkg/apis/apps/v1alpha1/apimanagerbackup_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanagerbackup_types.go
@@ -88,6 +88,12 @@ type APIManagerBackupStatus struct {
 	// +optional
 	Completed *bool `json:"completed,omitempty"`
 
+	// Set to true when main steps have been completed. At this point
+	// backup still cannot be considered  fully completed due to some remaining
+	// post-backup tasks are pending (cleanup, ...)
+	// +optional
+	MainStepsCompleted *bool `json:"mainStepsCompleted,omitempty"`
+
 	// Name of the APIManager from which the backup has been performed
 	// +optional
 	APIManagerSourceName *string `json:"apiManagerSourceName,omitempty"`
@@ -130,6 +136,10 @@ func (a *APIManagerBackup) SetDefaults() (bool, error) {
 
 func (a *APIManagerBackup) BackupCompleted() bool {
 	return a.Status.Completed != nil && *a.Status.Completed
+}
+
+func (a *APIManagerBackup) MainStepsCompleted() bool {
+	return a.Status.MainStepsCompleted != nil && *a.Status.MainStepsCompleted
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/apps/v1alpha1/apimanagerrestore_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanagerrestore_types.go
@@ -50,6 +50,12 @@ type APIManagerRestoreStatus struct {
 	// +optional
 	Completed *bool `json:"completed,omitempty"`
 
+	// Set to true when main steps have been completed. At this point
+	// restore still cannot be considered fully completed due to some remaining
+	// post-backup tasks are pending (cleanup, ...)
+	// +optional
+	MainStepsCompleted *bool `json:"mainStepsCompleted,omitempty"`
+
 	// Restore start time. It is represented in RFC3339 form and is in UTC.
 	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
@@ -78,6 +84,10 @@ func (a *APIManagerRestore) SetDefaults() (bool, error) {
 
 func (a *APIManagerRestore) RestoreCompleted() bool {
 	return a.Status.Completed != nil && *a.Status.Completed
+}
+
+func (a *APIManagerRestore) MainStepsCompleted() bool {
+	return a.Status.MainStepsCompleted != nil && *a.Status.MainStepsCompleted
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -171,6 +171,11 @@ func (in *APIManagerBackupStatus) DeepCopyInto(out *APIManagerBackupStatus) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MainStepsCompleted != nil {
+		in, out := &in.MainStepsCompleted, &out.MainStepsCompleted
+		*out = new(bool)
+		**out = **in
+	}
 	if in.APIManagerSourceName != nil {
 		in, out := &in.APIManagerSourceName, &out.APIManagerSourceName
 		*out = new(string)
@@ -403,6 +408,11 @@ func (in *APIManagerRestoreStatus) DeepCopyInto(out *APIManagerRestoreStatus) {
 	}
 	if in.Completed != nil {
 		in, out := &in.Completed, &out.Completed
+		*out = new(bool)
+		**out = **in
+	}
+	if in.MainStepsCompleted != nil {
+		in, out := &in.MainStepsCompleted, &out.MainStepsCompleted
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.openapi.go
@@ -147,6 +147,13 @@ func schema_pkg_apis_apps_v1alpha1_APIManagerBackupStatus(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"mainStepsCompleted": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set to true when main steps have been completed. At this point backup still cannot be considered  fully completed due to some remaining post-backup tasks are pending (cleanup, ...)",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"apiManagerSourceName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the APIManager from which the backup has been performed",
@@ -282,6 +289,13 @@ func schema_pkg_apis_apps_v1alpha1_APIManagerRestoreStatus(ref common.ReferenceC
 					"completed": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Set to true when backup has been completed",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"mainStepsCompleted": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set to true when main steps have been completed. At this point restore still cannot be considered fully completed due to some remaining post-backup tasks are pending (cleanup, ...)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -139,7 +139,7 @@ func (b *BaseReconciler) UpdateResource(obj common.KubernetesObject) error {
 
 func (b *BaseReconciler) DeleteResource(obj common.KubernetesObject, options ...client.DeleteOption) error {
 	b.Logger().Info(fmt.Sprintf("Delete object '%s/%s'", strings.Replace(fmt.Sprintf("%T", obj), "*", "", 1), obj.GetName()))
-	return b.Client().Delete(context.TODO(), obj)
+	return b.Client().Delete(context.TODO(), obj, options...)
 }
 
 func (b *BaseReconciler) UpdateResourceStatus(obj common.KubernetesObject) error {

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -143,6 +143,6 @@ func (b *BaseReconciler) DeleteResource(obj common.KubernetesObject, options ...
 }
 
 func (b *BaseReconciler) UpdateResourceStatus(obj common.KubernetesObject) error {
-	b.Logger().Info(fmt.Sprintf("Updated status of object object '%s/%s'", strings.Replace(fmt.Sprintf("%T", obj), "*", "", 1), obj.GetName()))
+	b.Logger().Info(fmt.Sprintf("Updated status of object '%s/%s'", strings.Replace(fmt.Sprintf("%T", obj), "*", "", 1), obj.GetName()))
 	return b.Client().Status().Update(context.TODO(), obj)
 }


### PR DESCRIPTION
Volumes that are mounted in the Backup/Restore jobs (like system-storage) cannot be deleted even if the jobs (and its pods) are in 'Completed' state.

This prevented the full deletion of an APIManager object while an APIManagerBackup existed.

Add a step that cleanups the K8s jobs.
