### PR TITLE
Add APIManagerBackup information in destination backup PVC annotations

### DIFF
--- a/pkg/backup/apimanager_backup.go
+++ b/pkg/backup/apimanager_backup.go
@@ -72,6 +72,12 @@ func (b *APIManagerBackup) BackupDestinationPVC() *v1.PersistentVolumeClaim {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      b.options.APIManagerBackupName,
 			Namespace: b.options.Namespace,
+			Annotations: map[string]string{
+				"apiManagerName":       b.APIManager().Name,
+				"apiManagerUID":        string(b.APIManager().GetUID()),
+				"apiManagerBackupName": b.options.APIManagerBackupName,
+				"apiManagerBackupUID":  string(b.options.APIManagerBackupUID),
+			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{

--- a/pkg/backup/apimanager_backup_options.go
+++ b/pkg/backup/apimanager_backup_options.go
@@ -3,12 +3,14 @@ package backup
 import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	validator "github.com/go-playground/validator/v10"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type APIManagerBackupOptions struct {
 	Namespace                  string                      `validate:"required"` // Namespace where the K8s related objects to the backup will be created/looked
-	APIManagerBackupName       string                      `validate:"required"` // Name of the APIManager CR. NOT the APIManager cr name
-	APIManagerName             string                      `validate:"required"` // Name of the APIManager CR. NOT the backup cr name
+	APIManagerBackupName       string                      `validate:"required"` // Name of the APIManagerBackup CR. NOT the APIManager cr name
+	APIManagerBackupUID        types.UID                   `validate:"required"` // UID of the APIManagerBackup CR
+	APIManagerName             string                      `validate:"required"` // Name of the APIManager CR. NOT the APIManagerBackup cr name
 	APIManager                 *appsv1alpha1.APIManager    `validate:"required"` // Should we make this required?
 	APIManagerBackupPVCOptions *APIManagerBackupPVCOptions `validate:"required"`
 	OCCLIImageURL              string                      `validate:"required"`

--- a/pkg/backup/apimanager_backup_options_provider.go
+++ b/pkg/backup/apimanager_backup_options_provider.go
@@ -26,6 +26,7 @@ func NewAPIManagerBackupOptionsProvider(cr *appsv1alpha1.APIManagerBackup, clien
 func (a *APIManagerBackupOptionsProvider) Options() (*APIManagerBackupOptions, error) {
 	res := NewAPIManagerBackupOptions()
 	res.APIManagerBackupName = a.APIManagerBackupCR.Name
+	res.APIManagerBackupUID = a.APIManagerBackupCR.UID
 	res.Namespace = a.APIManagerBackupCR.Namespace
 
 	// Should we rely on always having the APIManager existing before doing something?


### PR DESCRIPTION
To provide contextual information to the backup PVC. Useful in the case APIManagerBackup CR is deleted to still have some information regarding where that PVC came from.