### PR TITLE
Create APIManagerBackup/Restore unique predictable K8s job names from CRs UIDs

### DIFF
--- a/pkg/backup/apimanager_backup.go
+++ b/pkg/backup/apimanager_backup.go
@@ -102,6 +102,11 @@ func (b *APIManagerBackup) BackupSecretsAndConfigMapsToPVCJob() *batchv1.Job {
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("backup-cfgmaps-secrets", b.options.APIManagerBackupUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -109,7 +114,7 @@ func (b *APIManagerBackup) BackupSecretsAndConfigMapsToPVCJob() *batchv1.Job {
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("job-backup-cfgmaps-secrets-%s", b.options.APIManagerBackupName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -151,6 +156,11 @@ func (b *APIManagerBackup) BackupAPIManagerCustomResourceToPVCJob() *batchv1.Job
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("backup-apimanager-cr", b.options.APIManagerBackupUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -158,7 +168,7 @@ func (b *APIManagerBackup) BackupAPIManagerCustomResourceToPVCJob() *batchv1.Job
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("job-backup-apimanager-cr-%s", b.options.APIManagerBackupName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -200,6 +210,11 @@ func (b *APIManagerBackup) BackupSystemFileStoragePVCToPVCJob() *batchv1.Job {
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("backup-system-fs-pvc", b.options.APIManagerBackupUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -207,7 +222,7 @@ func (b *APIManagerBackup) BackupSystemFileStoragePVCToPVCJob() *batchv1.Job {
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("job-backup-system-filestorage-pvc-%s", b.options.APIManagerBackupName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/helper/job.go
+++ b/pkg/helper/job.go
@@ -1,0 +1,28 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// UIDBasedJobName returns a Job name that is compromised of the provided prefix,
+// a hyphen and the provided uid: "<prefix>-<uid>". The returned name is a
+// DNS1123 Label compliant name. Due to UIDs are 36 characters of length this
+// means that the maximum prefix lenght that can be provided is of 26
+// characters. If the generated name is not DNS1123 compliant an error is
+// returned
+func UIDBasedJobName(prefix string, uid types.UID) (string, error) {
+	uidStr := string(uid)
+	jobName := fmt.Sprintf("%s-%s", prefix, uidStr)
+	errStrings := validation.IsDNS1123Label(jobName)
+	var err error
+
+	if len(errStrings) > 0 {
+		err = fmt.Errorf("Error generating UID-based K8s Job Name: '%s'", strings.Join(errStrings, "\n"))
+	}
+
+	return jobName, err
+}

--- a/pkg/restore/apimanager_restore.go
+++ b/pkg/restore/apimanager_restore.go
@@ -88,6 +88,11 @@ func (b *APIManagerRestore) RestoreSecretsAndConfigMapsFromPVCJob() *batchv1.Job
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("restore-cfgmaps-secrets", b.options.APIManagerRestoreUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -95,7 +100,7 @@ func (b *APIManagerRestore) RestoreSecretsAndConfigMapsFromPVCJob() *batchv1.Job
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("job-restore-cfgmaps-secrets-%s", b.options.APIManagerRestoreName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -137,6 +142,11 @@ func (b *APIManagerRestore) RestoreSystemFileStoragePVCFromPVCJob() *batchv1.Job
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("restore-system-fs", b.options.APIManagerRestoreUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -144,7 +154,7 @@ func (b *APIManagerRestore) RestoreSystemFileStoragePVCFromPVCJob() *batchv1.Job
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("restore-system-fs-%s", b.options.APIManagerRestoreName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -188,6 +198,11 @@ func (b *APIManagerRestore) CreateAPIManagerSharedSecretJob() *batchv1.Job {
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("restore-apm-tosecret", b.options.APIManagerRestoreUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -195,7 +210,7 @@ func (b *APIManagerRestore) CreateAPIManagerSharedSecretJob() *batchv1.Job {
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("job-restore-apimanager-tosecret-%s", b.options.APIManagerRestoreName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -237,6 +252,11 @@ func (b *APIManagerRestore) ZyncResyncDomainsJob() *batchv1.Job {
 		return nil
 	}
 
+	jobName, err := helper.UIDBasedJobName("resync-domains", b.options.APIManagerRestoreUID)
+	if err != nil {
+		panic(err)
+	}
+
 	var completions int32 = 1
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -244,7 +264,7 @@ func (b *APIManagerRestore) ZyncResyncDomainsJob() *batchv1.Job {
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("job-resync-domains-%s", b.options.APIManagerRestoreName),
+			Name:      jobName,
 			Namespace: b.options.Namespace,
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/restore/apimanager_restore_options.go
+++ b/pkg/restore/apimanager_restore_options.go
@@ -2,11 +2,14 @@ package restore
 
 import (
 	validator "github.com/go-playground/validator/v10"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type APIManagerRestoreOptions struct {
-	Namespace                   string                       `validate:"required"` // Namespace where the K8s related objects to the restore will be created/looked
-	APIManagerRestoreName       string                       `validate:"required"` // Name of the APIManagerRestore CR. NOT the backup or APIManager name
+	Namespace             string    `validate:"required"` // Namespace where the K8s related objects to the restore will be created/looked
+	APIManagerRestoreName string    `validate:"required"` // Name of the APIManagerRestore CR. NOT the backup or APIManager name
+	APIManagerRestoreUID  types.UID `validate:"required"` // UID of the APIManagerRestore CR
+
 	APIManagerRestorePVCOptions *APIManagerRestorePVCOptions `validate:"required"`
 	OCCLIImageURL               string                       `validate:"required"`
 }

--- a/pkg/restore/apimanager_restore_options_provider.go
+++ b/pkg/restore/apimanager_restore_options_provider.go
@@ -24,6 +24,7 @@ func NewAPIManagerRestoreOptionsProvider(cr *appsv1alpha1.APIManagerRestore, cli
 func (a *APIManagerRestoreOptionsProvider) Options() (*APIManagerRestoreOptions, error) {
 	res := NewAPIManagerRestoreOptions()
 	res.APIManagerRestoreName = a.APIManagerRestoreCR.Name
+	res.APIManagerRestoreUID = a.APIManagerRestoreCR.UID
 	res.Namespace = a.APIManagerRestoreCR.Namespace
 
 	res.OCCLIImageURL = a.ocCLIImageURL()


### PR DESCRIPTION
Until now K8s Job names created by APIManagerBackup and APIManagerRestore controllers were created using the APIManagerBackup/Restore CR name as part of the K8s Job and a unique job suffix. This was done in order to have predictable Job names and with multiple existing APIManagerBackup/APIManagerRestore CR objects at the same time.

The problem with that approach is that the size of the name of the resulting K8s was depending on the CR name length that the user provided when creating the CRs. K8s labels have a limitation of 63 characters and the combination of the CR name + the unique job suffix made K8s Job names reach the limit of characters for labels in some occasions.

The new approach creates K8s job names based on a prefix job name (defined by us in code) and the UID of the APIManagerBackup/APIManagerRestore. This makes Job names unique among CR instantiations and allows us to control the length of the created Job names (UIDs are always 36 characters long)

For example, if a user has created the following APIManagerBackup:

```
apiVersion: apps.3scale.net/v1alpha1
kind: APIManagerBackup
metadata:
  name: example-apimanagerbackup-pvc
spec:
  backupDestination:
    persistentVolumeClaim:
      resources:
        requests: "1Gi"
```

and the APIManagerBackup has the UID `174fdad6-9121-4217-9a0c-19b2f52555d6` assigned once created.

The K8s Jobs created would be:
```
msoriano@localhost:~/go/src/github.com/3scale/3scale-operator/example-manifests/backuprestore (backuprestore-uid-based-jobnames)$ oc get jobs
NAME                                                          COMPLETIONS   DURATION   AGE
backup-apimanager-cr-174fdad6-9121-4217-9a0c-19b2f52555d6     1/1           13s        21s
backup-cfgmaps-secrets-174fdad6-9121-4217-9a0c-19b2f52555d6   1/1           28s        53s
backup-system-fs-pvc-174fdad6-9121-4217-9a0c-19b2f52555d6     0/1           6s         6s
```

And the K8s Pods that would be automatically created by the Jobs K8s controller would be:
```
backup-apimanager-cr-174fdad6-9121-4217-9a0c-19b2f52555d6-4q6wx   0/1     Completed           0          27s
backup-cfgmaps-secrets-174fdad6-9121-4217-9a0c-19b2f52555d6bpnp   0/1     Completed           0          59s
backup-system-fs-pvc-174fdad6-9121-4217-9a0c-19b2f52555d6-skt9r   0/1     ContainerCreating   0          12s
```

Notice how in the case of pods, random characters are added by K8s Jobs controller automatically (this is a behavior that always happens with pods managed by other K8s elements like Jobs, DeploymentConfigs, Jobs...), and that the original name might be truncated if necessary to allow the random characters that K8s. This can be observed in the example above ( a '-' character is removed in one of the pod names above). That is expected and shouldn't be a problem as the pods are managed by the K8s Job controller.