### PR TITLE
Add optional comment tag to system's appspec and sidekiqspec

### DIFF
--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -222,7 +222,6 @@ type SystemSpec struct {
 	// something)
 
 	// +optional
-
 	FileStorageSpec *SystemFileStorageSpec `json:"fileStorage,omitempty"`
 
 	// TODO should union fields be optional?
@@ -230,7 +229,9 @@ type SystemSpec struct {
 	// +optional
 	DatabaseSpec *SystemDatabaseSpec `json:"database,omitempty"`
 
-	AppSpec     *SystemAppSpec     `json:"appSpec,omitempty"`
+	// +optional
+	AppSpec *SystemAppSpec `json:"appSpec,omitempty"`
+	// +optional
 	SidekiqSpec *SystemSidekiqSpec `json:"sidekiqSpec,omitempty"`
 }
 


### PR DESCRIPTION
It does not change existing behaviour due to omitempty automatically
implies optional but it's still recommended the optional comment
tag to be added