### PR TITLE
Metering labels validate label max length

### DIFF
--- a/pkg/helper/labels.go
+++ b/pkg/helper/labels.go
@@ -2,6 +2,8 @@ package helper
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 type ComponentType string
@@ -12,11 +14,16 @@ const (
 )
 
 func MeteringLabels(componentName, componentVersion string, componentType ComponentType) map[string]string {
-	return map[string]string{
-		"com.redhat.product-name":      "3scale",
-		"com.redhat.component-name":    componentName,
-		"com.redhat.product-version":   product.ThreescaleRelease,
-		"com.redhat.component-version": componentVersion,
-		"com.redhat.component-type":    string(componentType),
+	labels := map[string]string{
+		"com.redhat.product-name":    "3scale",
+		"com.redhat.component-name":  componentName,
+		"com.redhat.product-version": product.ThreescaleRelease,
+		"com.redhat.component-type":  string(componentType),
 	}
+
+	if len(componentVersion) <= validation.LabelValueMaxLength {
+		labels["com.redhat.component-version"] = componentVersion
+	}
+
+	return labels
 }


### PR DESCRIPTION
Fix error about Reconciler error in SHA-based deployment

https://issues.redhat.com/browse/THREESCALE-5476