### PR TITLE
Simplify monitoring 

### DIFF
--- a/deploy/olm-catalog/3scale-operator-master/0.0.0/3scale-operator-master.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/3scale-operator-master/0.0.0/3scale-operator-master.v0.0.0.clusterserviceversion.yaml
@@ -675,6 +675,7 @@ spec:
         - apiGroups:
           - monitoring.coreos.com
           resources:
+          - podmonitors
           - servicemonitors
           - prometheusrules
           verbs:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -172,6 +172,7 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - podmonitors 
   - servicemonitors
   - prometheusrules
   verbs:

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -6,7 +6,7 @@ The 3scale monitoring resources are (optionally) installed when 3scale is instal
 
 * [prometheus-operator](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus#quickstart) needs to be deployed in the cluster.
 
-The prometheus operator is an operator that creates, configures, and manages Prometheus clusters atop Kubernetes. It provides `ServiceMonitor` and `PrometheusRule` custom resources required by 3scale monitoring.
+The prometheus operator is an operator that creates, configures, and manages Prometheus clusters atop Kubernetes. It provides `ServiceMonitor`, `PodMonitor` and `PrometheusRule` custom resources required by 3scale monitoring.
 
 * [grafana-operator](https://github.com/integr8ly/grafana-operator) needs to be deployed in the cluster.
 
@@ -40,7 +40,7 @@ spec:
 
 ## Exposing monitoring resources
 
-3scale operator created monitoring resources, i.e. `ServiceMonitor`, `PrometheusRule` and `ServiceMonitor`, will all be labeled with
+`GrafanaDashboard` resources will all be labeled with
 
 ```
 monitoring-key: middleware

--- a/pkg/3scale/amp/component/apicast_monitoring.go
+++ b/pkg/3scale/amp/component/apicast_monitoring.go
@@ -20,7 +20,7 @@ func (apicast *Apicast) ApicastProductionMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-production-metrics",
-			Labels: apicast.Options.ProductionMonitoringLabels,
+			Labels: apicast.Options.CommonProductionLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -44,7 +44,7 @@ func (apicast *Apicast) ApicastStagingMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-staging-metrics",
-			Labels: apicast.Options.StagingMonitoringLabels,
+			Labels: apicast.Options.CommonStagingLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -64,7 +64,7 @@ func (apicast *Apicast) ApicastProductionServiceMonitor() *monitoringv1.ServiceM
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-production",
-			Labels: apicast.Options.ProductionMonitoringLabels,
+			Labels: apicast.Options.CommonProductionLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -73,7 +73,7 @@ func (apicast *Apicast) ApicastProductionServiceMonitor() *monitoringv1.ServiceM
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: apicast.Options.ProductionMonitoringLabels,
+				MatchLabels: apicast.Options.CommonProductionLabels,
 			},
 		},
 	}
@@ -83,7 +83,7 @@ func (apicast *Apicast) ApicastStagingServiceMonitor() *monitoringv1.ServiceMoni
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-staging",
-			Labels: apicast.Options.StagingMonitoringLabels,
+			Labels: apicast.Options.CommonStagingLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -92,7 +92,7 @@ func (apicast *Apicast) ApicastStagingServiceMonitor() *monitoringv1.ServiceMoni
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: apicast.Options.StagingMonitoringLabels,
+				MatchLabels: apicast.Options.CommonStagingLabels,
 			},
 		},
 	}
@@ -143,9 +143,8 @@ func ApicastPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "apicast",
 			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-				"prometheus":     "application-monitoring",
-				"role":           "alert-rules",
+				"prometheus": "application-monitoring",
+				"role":       "alert-rules",
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/pkg/3scale/amp/component/apicast_monitoring.go
+++ b/pkg/3scale/amp/component/apicast_monitoring.go
@@ -7,67 +7,18 @@ import (
 	"github.com/3scale/3scale-operator/pkg/common"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (apicast *Apicast) ApicastProductionMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "apicast-production-metrics",
-			Labels: apicast.Options.CommonProductionLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       9421,
-					TargetPort: intstr.FromInt(9421),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "apicast-production"},
-		},
-	}
-}
-
-func (apicast *Apicast) ApicastStagingMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "apicast-staging-metrics",
-			Labels: apicast.Options.CommonStagingLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       9421,
-					TargetPort: intstr.FromInt(9421),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "apicast-staging"},
-		},
-	}
-}
-
-func (apicast *Apicast) ApicastProductionServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (apicast *Apicast) ApicastProductionPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-production",
 			Labels: apicast.Options.CommonProductionLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",
@@ -79,14 +30,14 @@ func (apicast *Apicast) ApicastProductionServiceMonitor() *monitoringv1.ServiceM
 	}
 }
 
-func (apicast *Apicast) ApicastStagingServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (apicast *Apicast) ApicastStagingPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "apicast-staging",
 			Labels: apicast.Options.CommonStagingLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -25,8 +25,6 @@ type ApicastOptions struct {
 	ProductionTolerations          []v1.Toleration   `validate:"-"`
 	StagingAffinity                *v1.Affinity      `validate:"-"`
 	StagingTolerations             []v1.Toleration   `validate:"-"`
-	StagingMonitoringLabels        map[string]string `validate:"required"`
-	ProductionMonitoringLabels     map[string]string `validate:"required"`
 }
 
 func NewApicastOptions() *ApicastOptions {

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -126,6 +126,9 @@ func (backend *Backend) WorkerDeploymentConfig() *appsv1.DeploymentConfig {
 							Env:             backend.buildBackendWorkerEnv(),
 							Resources:       backend.Options.WorkerResourceRequirements,
 							ImagePullPolicy: v1.PullIfNotPresent,
+							Ports: []v1.ContainerPort{
+								v1.ContainerPort{Name: "metrics", ContainerPort: BackendWorkerMetricsPort, Protocol: v1.ProtocolTCP},
+							},
 						},
 					},
 					ServiceAccountName: "amp"}},
@@ -264,6 +267,7 @@ func (backend *Backend) ListenerDeploymentConfig() *appsv1.DeploymentConfig {
 								v1.ContainerPort{HostPort: 0,
 									ContainerPort: 3000,
 									Protocol:      v1.ProtocolTCP},
+								v1.ContainerPort{Name: "metrics", ContainerPort: BackendListenerMetricsPort, Protocol: v1.ProtocolTCP},
 							},
 							Env:       backend.buildBackendListenerEnv(),
 							Resources: backend.Options.ListenerResourceRequirements,

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -549,7 +549,7 @@ func (backend *Backend) listenerPorts() []v1.ContainerPort {
 }
 
 func (backend *Backend) workerPorts() []v1.ContainerPort {
-	ports := []v1.ContainerPort{}
+	var ports []v1.ContainerPort
 
 	if backend.Options.WorkerMetrics {
 		ports = append(ports, v1.ContainerPort{Name: "metrics", ContainerPort: BackendWorkerMetricsPort, Protocol: v1.ProtocolTCP})

--- a/pkg/3scale/amp/component/backend_monitoring.go
+++ b/pkg/3scale/amp/component/backend_monitoring.go
@@ -7,43 +7,18 @@ import (
 	"github.com/3scale/3scale-operator/pkg/common"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (backend *Backend) BackendListenerMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "backend-listener-metrics",
-			Labels: backend.Options.CommonListenerLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       BackendListenerMetricsPort,
-					TargetPort: intstr.FromInt(BackendListenerMetricsPort),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "backend-listener"},
-		},
-	}
-}
-
-func (backend *Backend) BackendListenerServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (backend *Backend) BackendListenerPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-listener",
 			Labels: backend.Options.CommonListenerLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",
@@ -55,38 +30,14 @@ func (backend *Backend) BackendListenerServiceMonitor() *monitoringv1.ServiceMon
 	}
 }
 
-func (backend *Backend) BackendWorkerMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "backend-worker-metrics",
-			Labels: backend.Options.CommonWorkerLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       BackendWorkerMetricsPort,
-					TargetPort: intstr.FromInt(BackendWorkerMetricsPort),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "backend-worker"},
-		},
-	}
-}
-
-func (backend *Backend) BackendWorkerServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (backend *Backend) BackendWorkerPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-worker",
 			Labels: backend.Options.CommonWorkerLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",

--- a/pkg/3scale/amp/component/backend_monitoring.go
+++ b/pkg/3scale/amp/component/backend_monitoring.go
@@ -20,7 +20,7 @@ func (backend *Backend) BackendListenerMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-listener-metrics",
-			Labels: backend.Options.ListenerMonitoringLabels,
+			Labels: backend.Options.CommonListenerLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -40,7 +40,7 @@ func (backend *Backend) BackendListenerServiceMonitor() *monitoringv1.ServiceMon
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-listener",
-			Labels: backend.Options.ListenerMonitoringLabels,
+			Labels: backend.Options.CommonListenerLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -49,7 +49,7 @@ func (backend *Backend) BackendListenerServiceMonitor() *monitoringv1.ServiceMon
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: backend.Options.ListenerMonitoringLabels,
+				MatchLabels: backend.Options.CommonListenerLabels,
 			},
 		},
 	}
@@ -63,7 +63,7 @@ func (backend *Backend) BackendWorkerMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-worker-metrics",
-			Labels: backend.Options.WorkerMonitoringLabels,
+			Labels: backend.Options.CommonWorkerLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -83,7 +83,7 @@ func (backend *Backend) BackendWorkerServiceMonitor() *monitoringv1.ServiceMonit
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "backend-worker",
-			Labels: backend.Options.WorkerMonitoringLabels,
+			Labels: backend.Options.CommonWorkerLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -92,7 +92,7 @@ func (backend *Backend) BackendWorkerServiceMonitor() *monitoringv1.ServiceMonit
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: backend.Options.WorkerMonitoringLabels,
+				MatchLabels: backend.Options.CommonWorkerLabels,
 			},
 		},
 	}
@@ -123,9 +123,8 @@ func BackendWorkerPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "backend-worker",
 			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-				"prometheus":     "application-monitoring",
-				"role":           "alert-rules",
+				"prometheus": "application-monitoring",
+				"role":       "alert-rules",
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -40,8 +40,6 @@ type BackendOptions struct {
 	ListenerPodTemplateLabels    map[string]string `validate:"required"`
 	WorkerPodTemplateLabels      map[string]string `validate:"required"`
 	CronPodTemplateLabels        map[string]string `validate:"required"`
-	ListenerMonitoringLabels     map[string]string `validate:"required"`
-	WorkerMonitoringLabels       map[string]string `validate:"required"`
 	WorkerMetrics                bool
 	ListenerMetrics              bool
 }

--- a/pkg/3scale/amp/component/generic_monitoring.go
+++ b/pkg/3scale/amp/component/generic_monitoring.go
@@ -56,9 +56,8 @@ func KubeStateMetricsPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "threescale-kube-state-metrics",
 			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-				"prometheus":     "application-monitoring",
-				"role":           "alert-rules",
+				"prometheus": "application-monitoring",
+				"role":       "alert-rules",
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -92,6 +92,10 @@ const (
 )
 
 const (
+	SystemSidekiqName = "system-sidekiq"
+)
+
+const (
 	SystemSidekiqMetricsPort = 9394
 )
 
@@ -743,7 +747,7 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 			APIVersion: "apps.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "system-sidekiq",
+			Name:   SystemSidekiqName,
 			Labels: system.Options.CommonSidekiqLabels,
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -769,13 +773,13 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 					Type: appsv1.DeploymentTriggerOnImageChange,
 					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
 						Automatic:      true,
-						ContainerNames: []string{"check-svc", "system-sidekiq"},
+						ContainerNames: []string{"check-svc", SystemSidekiqName},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
 							Name: fmt.Sprintf("amp-system:%s", system.Options.ImageTag)}}},
 			},
 			Replicas: *system.Options.SidekiqReplicas,
-			Selector: map[string]string{"deploymentConfig": "system-sidekiq"},
+			Selector: map[string]string{"deploymentConfig": SystemSidekiqName},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: system.Options.SidekiqPodTemplateLabels,
@@ -798,7 +802,7 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 					},
 					Containers: []v1.Container{
 						v1.Container{
-							Name:            "system-sidekiq",
+							Name:            SystemSidekiqName,
 							Image:           "amp-system:latest",
 							Args:            []string{"rake", "sidekiq:worker", "RAILS_MAX_THREADS=25"},
 							Env:             system.buildSystemBaseEnv(),

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -91,6 +91,10 @@ const (
 	SystemFileStoragePVCName = "system-storage"
 )
 
+const (
+	SystemSidekiqMetricsPort = 9394
+)
+
 type System struct {
 	Options *SystemOptions
 }
@@ -801,6 +805,9 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 							Resources:       *system.Options.SidekiqContainerResourceRequirements,
 							VolumeMounts:    system.sidekiqContainerVolumeMounts(),
 							ImagePullPolicy: v1.PullIfNotPresent,
+							Ports: []v1.ContainerPort{
+								v1.ContainerPort{ContainerPort: SystemSidekiqMetricsPort, Protocol: v1.ProtocolTCP, Name: "metrics"},
+							},
 						},
 					},
 					ServiceAccountName: "amp",

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -805,9 +805,7 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 							Resources:       *system.Options.SidekiqContainerResourceRequirements,
 							VolumeMounts:    system.sidekiqContainerVolumeMounts(),
 							ImagePullPolicy: v1.PullIfNotPresent,
-							Ports: []v1.ContainerPort{
-								v1.ContainerPort{ContainerPort: SystemSidekiqMetricsPort, Protocol: v1.ProtocolTCP, Name: "metrics"},
-							},
+							Ports:           system.sideKiqPorts(),
 						},
 					},
 					ServiceAccountName: "amp",
@@ -1233,4 +1231,14 @@ func (system *System) SidekiqPodDisruptionBudget() *v1beta1.PodDisruptionBudget 
 			MaxUnavailable: &intstr.IntOrString{IntVal: PDB_MAX_UNAVAILABLE_POD_NUMBER},
 		},
 	}
+}
+
+func (system *System) sideKiqPorts() []v1.ContainerPort {
+	ports := []v1.ContainerPort{}
+
+	if system.Options.SideKiqMetrics {
+		ports = append(ports, v1.ContainerPort{Name: "metrics", ContainerPort: SystemSidekiqMetricsPort, Protocol: v1.ProtocolTCP})
+	}
+
+	return ports
 }

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -1238,7 +1238,7 @@ func (system *System) SidekiqPodDisruptionBudget() *v1beta1.PodDisruptionBudget 
 }
 
 func (system *System) sideKiqPorts() []v1.ContainerPort {
-	ports := []v1.ContainerPort{}
+	var ports []v1.ContainerPort
 
 	if system.Options.SideKiqMetrics {
 		ports = append(ports, v1.ContainerPort{Name: "metrics", ContainerPort: SystemSidekiqMetricsPort, Protocol: v1.ProtocolTCP})

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -7,43 +7,18 @@ import (
 	"github.com/3scale/3scale-operator/pkg/common"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (system *System) SystemSidekiqMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "system-sidekiq-metrics",
-			Labels: system.Options.CommonSidekiqLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       9394,
-					TargetPort: intstr.FromInt(9394),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "system-sidekiq"},
-		},
-	}
-}
-
-func (system *System) SystemSidekiqServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (system *System) SystemSidekiqPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-sidekiq",
 			Labels: system.Options.CommonSidekiqLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -20,7 +20,7 @@ func (system *System) SystemSidekiqMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-sidekiq-metrics",
-			Labels: system.Options.SidekiqMonitoringLabels,
+			Labels: system.Options.CommonSidekiqLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -40,7 +40,7 @@ func (system *System) SystemSidekiqServiceMonitor() *monitoringv1.ServiceMonitor
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "system-sidekiq",
-			Labels: system.Options.SidekiqMonitoringLabels,
+			Labels: system.Options.CommonSidekiqLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -49,7 +49,7 @@ func (system *System) SystemSidekiqServiceMonitor() *monitoringv1.ServiceMonitor
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: system.Options.SidekiqMonitoringLabels,
+				MatchLabels: system.Options.CommonSidekiqLabels,
 			},
 		},
 	}
@@ -80,9 +80,8 @@ func SystemSidekiqPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "system-sidekiq",
 			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-				"prometheus":     "application-monitoring",
-				"role":           "alert-rules",
+				"prometheus": "application-monitoring",
+				"role":       "alert-rules",
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -92,6 +92,7 @@ type SystemOptions struct {
 	SphinxPodTemplateLabels  map[string]string `validate:"required"`
 	MemcachedLabels          map[string]string `validate:"required"`
 	SMTPLabels               map[string]string `validate:"required"`
+	SideKiqMetrics           bool
 }
 
 func NewSystemOptions() *SystemOptions {

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -92,7 +92,6 @@ type SystemOptions struct {
 	SphinxPodTemplateLabels  map[string]string `validate:"required"`
 	MemcachedLabels          map[string]string `validate:"required"`
 	SMTPLabels               map[string]string `validate:"required"`
-	SidekiqMonitoringLabels  map[string]string `validate:"required"`
 }
 
 func NewSystemOptions() *SystemOptions {

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -21,6 +21,11 @@ const (
 	ZyncSecretAuthenticationTokenFieldName = "ZYNC_AUTHENTICATION_TOKEN"
 )
 
+const (
+	ZyncMetricsPort    = 9393
+	ZyncQueMetricsPort = 9394
+)
+
 type Zync struct {
 	Options *ZyncOptions
 }
@@ -235,6 +240,7 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 								v1.ContainerPort{
 									ContainerPort: 8080,
 									Protocol:      v1.ProtocolTCP},
+								v1.ContainerPort{Name: "metrics", ContainerPort: ZyncMetricsPort, Protocol: v1.ProtocolTCP},
 							},
 							Env: zync.commonZyncEnvVars(),
 							LivenessProbe: &v1.Probe{
@@ -384,7 +390,7 @@ func (zync *Zync) QueDeploymentConfig() *appsv1.DeploymentConfig {
 								},
 							},
 							Ports: []v1.ContainerPort{
-								v1.ContainerPort{Name: "metrics", ContainerPort: 9394, Protocol: v1.ProtocolTCP},
+								v1.ContainerPort{Name: "metrics", ContainerPort: ZyncQueMetricsPort, Protocol: v1.ProtocolTCP},
 							},
 							Resources: zync.Options.QueContainerResourceRequirements,
 							Env:       zync.commonZyncEnvVars(),

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -14,6 +14,10 @@ import (
 )
 
 const (
+	ZyncName = "zync"
+)
+
+const (
 	ZyncSecretName                         = "zync"
 	ZyncSecretKeyBaseFieldName             = "SECRET_KEY_BASE"
 	ZyncSecretDatabaseURLFieldName         = "DATABASE_URL"
@@ -168,7 +172,7 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 			APIVersion: "apps.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "zync",
+			Name:   ZyncName,
 			Labels: zync.Options.CommonZyncLabels,
 			Annotations: map[string]string{
 				"prometheus.io/port":   "9393",
@@ -186,7 +190,7 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 						Automatic: true,
 						ContainerNames: []string{
 							"zync-db-svc",
-							"zync",
+							ZyncName,
 						},
 						From: v1.ObjectReference{
 							Kind: "ImageStreamTag",
@@ -196,7 +200,7 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 				},
 			},
 			Replicas: zync.Options.ZyncReplicas,
-			Selector: map[string]string{"deploymentConfig": "zync"},
+			Selector: map[string]string{"deploymentConfig": ZyncName},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: zync.Options.ZyncPodTemplateLabels,
@@ -234,7 +238,7 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 					},
 					Containers: []v1.Container{
 						v1.Container{
-							Name:  "zync",
+							Name:  ZyncName,
 							Image: "amp-zync:latest",
 							Ports: zync.zyncPorts(),
 							Env:   zync.commonZyncEnvVars(),
@@ -519,7 +523,7 @@ func (zync *Zync) Service() *v1.Service {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "zync",
+			Name:   ZyncName,
 			Labels: zync.Options.CommonZyncLabels,
 		},
 		Spec: v1.ServiceSpec{
@@ -531,7 +535,7 @@ func (zync *Zync) Service() *v1.Service {
 					TargetPort: intstr.FromInt(8080),
 				},
 			},
-			Selector: map[string]string{"deploymentConfig": "zync"},
+			Selector: map[string]string{"deploymentConfig": ZyncName},
 		},
 	}
 }
@@ -567,12 +571,12 @@ func (zync *Zync) ZyncPodDisruptionBudget() *v1beta1.PodDisruptionBudget {
 			APIVersion: "policy/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "zync",
+			Name:   ZyncName,
 			Labels: zync.Options.CommonZyncLabels,
 		},
 		Spec: v1beta1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"deploymentConfig": "zync"},
+				MatchLabels: map[string]string{"deploymentConfig": ZyncName},
 			},
 			MaxUnavailable: &intstr.IntOrString{IntVal: PDB_MAX_UNAVAILABLE_POD_NUMBER},
 		},

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -236,13 +236,8 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 						v1.Container{
 							Name:  "zync",
 							Image: "amp-zync:latest",
-							Ports: []v1.ContainerPort{
-								v1.ContainerPort{
-									ContainerPort: 8080,
-									Protocol:      v1.ProtocolTCP},
-								v1.ContainerPort{Name: "metrics", ContainerPort: ZyncMetricsPort, Protocol: v1.ProtocolTCP},
-							},
-							Env: zync.commonZyncEnvVars(),
+							Ports: zync.zyncPorts(),
+							Env:   zync.commonZyncEnvVars(),
 							LivenessProbe: &v1.Probe{
 								Handler: v1.Handler{
 									HTTPGet: &v1.HTTPGetAction{
@@ -601,4 +596,16 @@ func (zync *Zync) QuePodDisruptionBudget() *v1beta1.PodDisruptionBudget {
 			MaxUnavailable: &intstr.IntOrString{IntVal: PDB_MAX_UNAVAILABLE_POD_NUMBER},
 		},
 	}
+}
+
+func (zync *Zync) zyncPorts() []v1.ContainerPort {
+	ports := []v1.ContainerPort{
+		v1.ContainerPort{ContainerPort: 8080, Protocol: v1.ProtocolTCP},
+	}
+
+	if zync.Options.ZyncMetrics {
+		ports = append(ports, v1.ContainerPort{Name: "metrics", ContainerPort: ZyncMetricsPort, Protocol: v1.ProtocolTCP})
+	}
+
+	return ports
 }

--- a/pkg/3scale/amp/component/zync_monitoring.go
+++ b/pkg/3scale/amp/component/zync_monitoring.go
@@ -20,7 +20,7 @@ func (zync *Zync) ZyncMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "zync-metrics",
-			Labels: zync.Options.ZyncMonitoringLabels,
+			Labels: zync.Options.CommonZyncLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -44,7 +44,7 @@ func (zync *Zync) ZyncQueMonitoringService() *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "zync-que-metrics",
-			Labels: zync.Options.ZyncQueMonitoringLabels,
+			Labels: zync.Options.CommonZyncQueLabels,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -64,7 +64,7 @@ func (zync *Zync) ZyncServiceMonitor() *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "zync",
-			Labels: zync.Options.ZyncMonitoringLabels,
+			Labels: zync.Options.CommonZyncLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -73,7 +73,7 @@ func (zync *Zync) ZyncServiceMonitor() *monitoringv1.ServiceMonitor {
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: zync.Options.ZyncMonitoringLabels,
+				MatchLabels: zync.Options.CommonZyncLabels,
 			},
 		},
 	}
@@ -83,7 +83,7 @@ func (zync *Zync) ZyncQueServiceMonitor() *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "zync-que",
-			Labels: zync.Options.ZyncQueMonitoringLabels,
+			Labels: zync.Options.CommonZyncQueLabels,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{{
@@ -92,7 +92,7 @@ func (zync *Zync) ZyncQueServiceMonitor() *monitoringv1.ServiceMonitor {
 				Scheme: "http",
 			}},
 			Selector: metav1.LabelSelector{
-				MatchLabels: zync.Options.ZyncQueMonitoringLabels,
+				MatchLabels: zync.Options.CommonZyncQueLabels,
 			},
 		},
 	}
@@ -123,9 +123,8 @@ func ZyncPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "zync",
 			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-				"prometheus":     "application-monitoring",
-				"role":           "alert-rules",
+				"prometheus": "application-monitoring",
+				"role":       "alert-rules",
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
@@ -157,9 +156,8 @@ func ZyncQuePrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "zync-que",
 			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-				"prometheus":     "application-monitoring",
-				"role":           "alert-rules",
+				"prometheus": "application-monitoring",
+				"role":       "alert-rules",
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/pkg/3scale/amp/component/zync_monitoring.go
+++ b/pkg/3scale/amp/component/zync_monitoring.go
@@ -7,67 +7,18 @@ import (
 	"github.com/3scale/3scale-operator/pkg/common"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (zync *Zync) ZyncMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "zync-metrics",
-			Labels: zync.Options.CommonZyncLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       9393,
-					TargetPort: intstr.FromInt(9393),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "zync"},
-		},
-	}
-}
-
-func (zync *Zync) ZyncQueMonitoringService() *v1.Service {
-	return &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "zync-que-metrics",
-			Labels: zync.Options.CommonZyncQueLabels,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				v1.ServicePort{
-					Name:       "metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       9394,
-					TargetPort: intstr.FromInt(9394),
-				},
-			},
-			Selector: map[string]string{"deploymentConfig": "zync-que"},
-		},
-	}
-}
-
-func (zync *Zync) ZyncServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (zync *Zync) ZyncPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "zync",
 			Labels: zync.Options.CommonZyncLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",
@@ -79,14 +30,14 @@ func (zync *Zync) ZyncServiceMonitor() *monitoringv1.ServiceMonitor {
 	}
 }
 
-func (zync *Zync) ZyncQueServiceMonitor() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
+func (zync *Zync) ZyncQuePodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "zync-que",
 			Labels: zync.Options.CommonZyncQueLabels,
 		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			Endpoints: []monitoringv1.Endpoint{{
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
 				Port:   "metrics",
 				Path:   "/metrics",
 				Scheme: "http",

--- a/pkg/3scale/amp/component/zync_options.go
+++ b/pkg/3scale/amp/component/zync_options.go
@@ -37,6 +37,7 @@ type ZyncOptions struct {
 	ZyncPodTemplateLabels         map[string]string `validate:"required"`
 	ZyncQuePodTemplateLabels      map[string]string `validate:"required"`
 	ZyncDatabasePodTemplateLabels map[string]string `validate:"required"`
+	ZyncMetrics                   bool
 }
 
 func NewZyncOptions() *ZyncOptions {

--- a/pkg/3scale/amp/component/zync_options.go
+++ b/pkg/3scale/amp/component/zync_options.go
@@ -37,9 +37,6 @@ type ZyncOptions struct {
 	ZyncPodTemplateLabels         map[string]string `validate:"required"`
 	ZyncQuePodTemplateLabels      map[string]string `validate:"required"`
 	ZyncDatabasePodTemplateLabels map[string]string `validate:"required"`
-
-	ZyncMonitoringLabels    map[string]string `validate:"required"`
-	ZyncQueMonitoringLabels map[string]string `validate:"required"`
 }
 
 func NewZyncOptions() *ZyncOptions {

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
-	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
@@ -41,8 +40,6 @@ func (a *ApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions,
 	a.apicastOptions.CommonProductionLabels = a.commonProductionLabels()
 	a.apicastOptions.StagingPodTemplateLabels = a.stagingPodTemplateLabels(imageOpts.ApicastImage)
 	a.apicastOptions.ProductionPodTemplateLabels = a.productionPodTemplateLabels(imageOpts.ApicastImage)
-	a.apicastOptions.StagingMonitoringLabels = a.stagingMonitoringLabels()
-	a.apicastOptions.ProductionMonitoringLabels = a.productionMonitoringLabels()
 
 	a.setResourceRequirementsOptions()
 	a.setNodeAffinityAndTolerationsOptions()
@@ -117,17 +114,5 @@ func (a *ApicastOptionsProvider) productionPodTemplateLabels(image string) map[s
 
 	labels["deploymentConfig"] = "apicast-production"
 
-	return labels
-}
-
-func (a *ApicastOptionsProvider) stagingMonitoringLabels() map[string]string {
-	labels := a.commonStagingLabels()
-	labels["monitoring-key"] = common.MonitoringKey
-	return labels
-}
-
-func (a *ApicastOptionsProvider) productionMonitoringLabels() map[string]string {
-	labels := a.commonProductionLabels()
-	labels["monitoring-key"] = common.MonitoringKey
 	return labels
 }

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -89,25 +89,6 @@ func testApicastProductionTolerations() []v1.Toleration {
 	return getTestTolerations("apicast-production")
 }
 
-func testApicastStagingMonitoringLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "apicast",
-		"threescale_component_element": "staging",
-		"monitoring-key":               "middleware",
-	}
-}
-
-func testApicastProductionMonitoringLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "apicast",
-		"threescale_component_element": "production",
-		"monitoring-key":               "middleware",
-	}
-}
-
-
 func basicApimanagerTestApicastOptions() *appsv1alpha1.APIManager {
 	tmpApicastManagementAPI := apicastManagementAPI
 	tmpOpenSSLVerify := openSSLVerify
@@ -146,8 +127,6 @@ func defaultApicastOptions() *component.ApicastOptions {
 		CommonProductionLabels:         testApicastProductionLabels(),
 		StagingPodTemplateLabels:       testApicastStagingPodLabels(),
 		ProductionPodTemplateLabels:    testApicastProductionPodLabels(),
-		StagingMonitoringLabels:        testApicastStagingMonitoringLabels(),
-		ProductionMonitoringLabels:     testApicastProductionMonitoringLabels(),
 	}
 }
 

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -97,16 +97,6 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileMonitoringService(apicast.ApicastStagingMonitoringService(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcileMonitoringService(apicast.ApicastProductionMonitoringService(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	err = r.ReconcileGrafanaDashboard(component.ApicastMainAppGrafanaDashboard(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -122,12 +112,12 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileServiceMonitor(apicast.ApicastProductionServiceMonitor(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(apicast.ApicastProductionPodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileServiceMonitor(apicast.ApicastStagingServiceMonitor(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(apicast.ApicastStagingPodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
-	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 
 	v1 "k8s.io/api/core/v1"
@@ -56,8 +55,6 @@ func (o *OperatorBackendOptionsProvider) GetBackendOptions() (*component.Backend
 	o.backendOptions.ListenerPodTemplateLabels = o.listenerPodTemplateLabels(imageOpts.BackendImage)
 	o.backendOptions.WorkerPodTemplateLabels = o.workerPodTemplateLabels(imageOpts.BackendImage)
 	o.backendOptions.CronPodTemplateLabels = o.cronPodTemplateLabels(imageOpts.BackendImage)
-	o.backendOptions.ListenerMonitoringLabels = o.listenerMonitoringLabels()
-	o.backendOptions.WorkerMonitoringLabels = o.workerMonitoringLabels()
 
 	o.backendOptions.WorkerMetrics = true
 	o.backendOptions.ListenerMetrics = true
@@ -234,17 +231,5 @@ func (o *OperatorBackendOptionsProvider) cronPodTemplateLabels(image string) map
 
 	labels["deploymentConfig"] = "backend-cron"
 
-	return labels
-}
-
-func (o *OperatorBackendOptionsProvider) listenerMonitoringLabels() map[string]string {
-	labels := o.commonListenerLabels()
-	labels["monitoring-key"] = common.MonitoringKey
-	return labels
-}
-
-func (o *OperatorBackendOptionsProvider) workerMonitoringLabels() map[string]string {
-	labels := o.commonWorkerLabels()
-	labels["monitoring-key"] = common.MonitoringKey
 	return labels
 }

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -119,25 +119,6 @@ func testBackendCronTolerations() []v1.Toleration {
 	return getTestTolerations("backend-cron")
 }
 
-func testBackendMonitoringListenerLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "backend",
-		"threescale_component_element": "listener",
-		"monitoring-key":               "middleware",
-	}
-}
-
-func testBackendMonitoringWorkerLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "backend",
-		"threescale_component_element": "worker",
-		"monitoring-key":               "middleware",
-	}
-}
-
-
 func getInternalSecret() *v1.Secret {
 	data := map[string]string{
 		component.BackendSecretInternalApiUsernameFieldName: "someUserName",
@@ -207,8 +188,6 @@ func defaultBackendOptions(opts *component.BackendOptions) *component.BackendOpt
 		ListenerPodTemplateLabels:    testBackendListenerPodLabels(),
 		WorkerPodTemplateLabels:      testBackendWorkerPodLabels(),
 		CronPodTemplateLabels:        testBackendCronPodLabels(),
-		ListenerMonitoringLabels:     testBackendMonitoringListenerLabels(),
-		WorkerMonitoringLabels:       testBackendMonitoringWorkerLabels(),
 		WorkerMetrics:                true,
 		ListenerMetrics:              true,
 	}

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -96,22 +96,12 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileMonitoringService(backend.BackendWorkerMonitoringService(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(backend.BackendWorkerPodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileServiceMonitor(backend.BackendWorkerServiceMonitor(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcileMonitoringService(backend.BackendListenerMonitoringService(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcileServiceMonitor(backend.BackendListenerServiceMonitor(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(backend.BackendListenerPodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -64,6 +64,8 @@ func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, er
 	s.setFileStorageOptions()
 	s.setReplicas()
 
+	s.options.SideKiqMetrics = true
+
 	err = s.options.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("GetSystemOptions validating: %w", err)

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
-	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 
 	v1 "k8s.io/api/core/v1"
@@ -54,7 +53,6 @@ func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, er
 	s.options.SphinxPodTemplateLabels = s.sphinxPodTemplateLabels(imageOpts.SystemImage)
 	s.options.MemcachedLabels = s.memcachedLabels()
 	s.options.SMTPLabels = s.smtpLabels()
-	s.options.SidekiqMonitoringLabels = s.sidekiqMonitoringLabels()
 
 	err = s.setSecretBasedOptions()
 	if err != nil {
@@ -558,11 +556,5 @@ func (s *SystemOptionsProvider) sphinxPodTemplateLabels(image string) map[string
 
 	labels["deploymentConfig"] = "system-sphinx"
 
-	return labels
-}
-
-func (s *SystemOptionsProvider) sidekiqMonitoringLabels() map[string]string {
-	labels := s.commonSidekiqLabels()
-	labels["monitoring-key"] = common.MonitoringKey
 	return labels
 }

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -133,14 +133,6 @@ func testSystemSMTPLabels() map[string]string {
 		"threescale_component_element": "smtp",
 	}
 }
-func testSystemSidekiqMonitoringLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "system",
-		"threescale_component_element": "sidekiq",
-		"monitoring-key":               "middleware",
-	}
-}
 
 func testSystemAppAffinity() *v1.Affinity {
 	return getTestAffinity("system-app")
@@ -327,7 +319,6 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		SphinxPodTemplateLabels:  testSystemSphinxPodTemplateLabels(),
 		MemcachedLabels:          testSystemMemcachedLabels(),
 		SMTPLabels:               testSystemSMTPLabels(),
-		SidekiqMonitoringLabels:  testSystemSidekiqMonitoringLabels(),
 	}
 
 	expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(opts.ApicastAccessToken)

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -319,6 +319,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		SphinxPodTemplateLabels:  testSystemSphinxPodTemplateLabels(),
 		MemcachedLabels:          testSystemMemcachedLabels(),
 		SMTPLabels:               testSystemSMTPLabels(),
+		SideKiqMetrics:           true,
 	}
 
 	expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(opts.ApicastAccessToken)

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -171,12 +171,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileMonitoringService(system.SystemSidekiqMonitoringService(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcileServiceMonitor(system.SystemSidekiqServiceMonitor(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(system.SystemSidekiqPodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -60,6 +60,8 @@ func (z *ZyncOptionsProvider) GetZyncOptions() (*component.ZyncOptions, error) {
 	z.zyncOptions.ZyncQuePodTemplateLabels = z.zyncQuePodTemplateLabels(imageOpts.ZyncImage)
 	z.zyncOptions.ZyncDatabasePodTemplateLabels = z.zyncDatabasePodTemplateLabels(imageOpts.ZyncDatabasePostgreSQLImage)
 
+	z.zyncOptions.ZyncMetrics = true
+
 	err = z.zyncOptions.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("GetZyncOptions validating: %w", err)

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
-	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 
 	v1 "k8s.io/api/core/v1"
@@ -60,8 +59,6 @@ func (z *ZyncOptionsProvider) GetZyncOptions() (*component.ZyncOptions, error) {
 	z.zyncOptions.ZyncPodTemplateLabels = z.zyncPodTemplateLabels(imageOpts.ZyncImage)
 	z.zyncOptions.ZyncQuePodTemplateLabels = z.zyncQuePodTemplateLabels(imageOpts.ZyncImage)
 	z.zyncOptions.ZyncDatabasePodTemplateLabels = z.zyncDatabasePodTemplateLabels(imageOpts.ZyncDatabasePostgreSQLImage)
-	z.zyncOptions.ZyncMonitoringLabels = z.zyncMonitoringLabels()
-	z.zyncOptions.ZyncQueMonitoringLabels = z.zyncQueMonitoringLabels()
 
 	err = z.zyncOptions.Validate()
 	if err != nil {
@@ -192,17 +189,5 @@ func (z *ZyncOptionsProvider) zyncDatabasePodTemplateLabels(image string) map[st
 
 	labels["deploymentConfig"] = "zync-database"
 
-	return labels
-}
-
-func (z *ZyncOptionsProvider) zyncMonitoringLabels() map[string]string {
-	labels := z.commonZyncLabels()
-	labels["monitoring-key"] = common.MonitoringKey
-	return labels
-}
-
-func (z *ZyncOptionsProvider) zyncQueMonitoringLabels() map[string]string {
-	labels := z.commonZyncQueLabels()
-	labels["monitoring-key"] = common.MonitoringKey
 	return labels
 }

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -160,6 +160,7 @@ func defaultZyncOptions(opts *component.ZyncOptions) *component.ZyncOptions {
 		ZyncPodTemplateLabels:                 testZyncPodTemplateLabels(),
 		ZyncQuePodTemplateLabels:              testZyncQuePodTemplateCommonLabels(),
 		ZyncDatabasePodTemplateLabels:         testZyncDatabasePodTemplateCommonLabels(),
+		ZyncMetrics:                           true,
 	}
 
 	expectedOpts.DatabaseURL = component.DefaultZyncDatabaseURL(expectedOpts.DatabasePassword)

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -120,24 +120,6 @@ func testZyncDatabaseTolerations() []v1.Toleration {
 	return getTestTolerations("zync-database")
 }
 
-func testZyncZyncMonitoringLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "zync",
-		"threescale_component_element": "zync",
-		"monitoring-key":               "middleware",
-	}
-}
-
-func testZyncQueMonitoringLabels() map[string]string {
-	return map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "zync",
-		"threescale_component_element": "zync-que",
-		"monitoring-key":               "middleware",
-	}
-}
-
 func getZyncSecret() *v1.Secret {
 	data := map[string]string{
 		component.ZyncSecretKeyBaseFieldName:             zyncSecretKeyBasename,
@@ -178,8 +160,6 @@ func defaultZyncOptions(opts *component.ZyncOptions) *component.ZyncOptions {
 		ZyncPodTemplateLabels:                 testZyncPodTemplateLabels(),
 		ZyncQuePodTemplateLabels:              testZyncQuePodTemplateCommonLabels(),
 		ZyncDatabasePodTemplateLabels:         testZyncDatabasePodTemplateCommonLabels(),
-		ZyncMonitoringLabels:                  testZyncZyncMonitoringLabels(),
-		ZyncQueMonitoringLabels:               testZyncQueMonitoringLabels(),
 	}
 
 	expectedOpts.DatabaseURL = component.DefaultZyncDatabaseURL(expectedOpts.DatabasePassword)

--- a/pkg/3scale/amp/operator/zync_reconciler.go
+++ b/pkg/3scale/amp/operator/zync_reconciler.go
@@ -91,22 +91,12 @@ func (r *ZyncReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileMonitoringService(zync.ZyncMonitoringService(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(zync.ZyncPodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileMonitoringService(zync.ZyncQueMonitoringService(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcileServiceMonitor(zync.ZyncServiceMonitor(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcileServiceMonitor(zync.ZyncQueServiceMonitor(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(zync.ZyncQuePodMonitor(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -110,9 +110,6 @@ func (a *Apicast) options() (*component.ApicastOptions, error) {
 	ao.CommonProductionLabels = a.commonProductionLabels()
 	ao.StagingPodTemplateLabels = a.stagingPodTemplateLabels()
 	ao.ProductionPodTemplateLabels = a.productionPodTemplateLabels()
-	// Not used, can be anything
-	ao.StagingMonitoringLabels = map[string]string{"a": "a"}
-	ao.ProductionMonitoringLabels = map[string]string{"a": "a"}
 
 	err := ao.Validate()
 	return ao, err

--- a/pkg/3scale/amp/template/adapters/backend.go
+++ b/pkg/3scale/amp/template/adapters/backend.go
@@ -100,9 +100,6 @@ func (b *Backend) options() (*component.BackendOptions, error) {
 	bo.ListenerPodTemplateLabels = b.listenerPodTemplateLabels()
 	bo.WorkerPodTemplateLabels = b.workerPodTemplateLabels()
 	bo.CronPodTemplateLabels = b.cronPodTemplateLabels()
-	// Not used, can be anything
-	bo.ListenerMonitoringLabels = map[string]string{"a": "a"}
-	bo.WorkerMonitoringLabels = map[string]string{"a": "a"}
 
 	err := bo.Validate()
 	return bo, err

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -279,8 +279,6 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.SphinxPodTemplateLabels = s.sphinxPodTemplateLabels()
 	o.MemcachedLabels = s.memcachedLabels()
 	o.SMTPLabels = s.smtpLabels()
-	// Not used, can be anything
-	o.SidekiqMonitoringLabels = map[string]string{"a": "a"}
 
 	err := o.Validate()
 	return o, err

--- a/pkg/3scale/amp/template/adapters/zync.go
+++ b/pkg/3scale/amp/template/adapters/zync.go
@@ -100,9 +100,6 @@ func (z *Zync) options() (*component.ZyncOptions, error) {
 	zo.ZyncPodTemplateLabels = z.zyncPodTemplateLabels()
 	zo.ZyncQuePodTemplateLabels = z.zyncQuePodTemplateLabels()
 	zo.ZyncDatabasePodTemplateLabels = z.zyncDatabasePodTemplateLabels()
-	// Not used, can be anything
-	zo.ZyncMonitoringLabels = map[string]string{"a": "a"}
-	zo.ZyncQueMonitoringLabels = map[string]string{"a": "a"}
 
 	zo.AuthenticationToken = "${ZYNC_AUTHENTICATION_TOKEN}"
 	zo.DatabasePassword = "${ZYNC_DATABASE_PASSWORD}"

--- a/pkg/helper/container_port_utils.go
+++ b/pkg/helper/container_port_utils.go
@@ -1,0 +1,13 @@
+package helper
+
+import v1 "k8s.io/api/core/v1"
+
+func FindContainerPortByName(ports []v1.ContainerPort, name string) (v1.ContainerPort, bool) {
+	for idx := range ports {
+		if ports[idx].Name == name {
+			return ports[idx], true
+		}
+	}
+
+	return v1.ContainerPort{}, false
+}


### PR DESCRIPTION
* monitoring-key=middleware only in grafanadashboards
* replace servicemonitors with podmonitors
  * PodMonitors require `metrics` port to be exposed in the DC or in the Service (OCP 4.2)

Added upgrading path

