### PR TITLE
doc monitoring stack

### DIFF
--- a/doc/monitoring-stack-deployment/3scale-scrape-configs.yaml
+++ b/doc/monitoring-stack-deployment/3scale-scrape-configs.yaml
@@ -1,0 +1,27 @@
+- job_name: openshift-monitoring-federation
+  honor_labels: true
+  static_configs:
+    - targets:
+      - 'prometheus-k8s.openshift-monitoring.svc:9091'
+  scrape_interval: 30s
+  metrics_path: /federate
+  params:
+    match[]:
+    - '{endpoint="https-metrics"}'
+    - '{service="kube-state-metrics"}'
+    - '{service="node-exporter"}'
+    - '{__name__=~"namespace_pod_name_container_name:.*"}'
+    - '{__name__=~"node_namespace_pod_container:.*"}'
+    - '{__name__=~"node:.*"}'
+    - '{__name__=~"instance:.*"}'
+    - '{__name__=~"container_memory_.*"}'
+    - '{__name__=~":node_memory_.*"}'
+  scheme: https
+  tls_config:
+    insecure_skip_verify: true
+  basic_auth:
+    username: "internal"
+    password: "<BASIC_AUTH_PASSWD>"
+  metric_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica

--- a/doc/monitoring-stack-deployment/README.md
+++ b/doc/monitoring-stack-deployment/README.md
@@ -1,4 +1,4 @@
-1. Install Prometheus opeator v0.32.0 from catalog
+1. Install Prometheus operator v0.32.0 from catalog
 
 1. Install Grafana operator (v3.4.0). At the time of writing, not available from catalog, so manual installation from git repo.
 

--- a/doc/monitoring-stack-deployment/README.md
+++ b/doc/monitoring-stack-deployment/README.md
@@ -1,0 +1,31 @@
+1. Install Prometheus opeator v0.32.0 from catalog
+
+1. Install Grafana operator (v3.4.0). At the time of writing, not available from catalog, so manual installation from git repo.
+
+1. Create additional-scrape-configs secret with 3scale scrape config
+
+Get basic auth password `basicAuthPassword` from `ns/openshift-monitoring/secrets/grafana-datasources/prometheus.yaml` and update `3scale-scrape-configs.yaml` basic auth field.
+
+Then create secret:
+
+```
+kubectl create secret generic additional-scrape-configs --from-file=3scale-scrape-configs.yaml=./3scale-scrape-configs.yaml
+```
+
+1. Deploy prometheus
+
+```
+k apply -f prometheus.yaml
+```
+
+1. Create Prometheus route
+
+```
+oc expose service prometheus-operated --hostname prometheus.namespace_name.apps.DOMAIN
+```
+
+1. Deploy grafana
+
+```
+k apply -f grafana.yaml
+```

--- a/doc/monitoring-stack-deployment/datasource.yaml
+++ b/doc/monitoring-stack-deployment/datasource.yaml
@@ -1,0 +1,16 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: prometheus
+spec:
+  name: middleware
+  datasources:
+    - name: Prometheus
+      type: prometheus
+      access: proxy
+      url: http://prometheus-operated:9090
+      isDefault: true
+      version: 1
+      editable: true
+      jsonData:
+        timeInterval: "5s"

--- a/doc/monitoring-stack-deployment/grafana.yaml
+++ b/doc/monitoring-stack-deployment/grafana.yaml
@@ -1,0 +1,27 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: example-grafana
+spec:
+  config:
+    log:
+      mode: "console"
+      level: "debug"
+    security:
+      admin_password: "1234"
+      admin_user: "admin"
+    auth:
+      disable_login_form: False
+      disable_signout_menu: True
+    auth.basic:
+      enabled: true
+    auth.anonymous:
+      enabled: True
+  dashboardLabelSelector:
+  - matchExpressions:
+    - key: monitoring-key
+      operator: In
+      values:
+      - middleware
+  ingress:
+    enabled: true

--- a/doc/monitoring-stack-deployment/prometheus.yaml
+++ b/doc/monitoring-stack-deployment/prometheus.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    prometheus: k8s
+  name: example
+spec:
+  baseImage: quay.io/openshift/origin-prometheus
+  tag: "4.2"
+  externalUrl: https://prometheus.namespace_name.apps.DOMAIN
+  podMonitorSelector: {}
+  replicas: 1
+  ruleSelector: {}
+  securityContext: {}
+  serviceAccountName: prometheus-k8s
+  serviceMonitorSelector: {}
+  additionalScrapeConfigs:
+    key: 3scale-scrape-configs.yaml
+    name: additional-scrape-configs

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -29,7 +29,7 @@ NOTE: All monitoring resources will be created by the operator using *Create onl
 
 ## Monitored components
 
-* Kubernetes resources at namespace level where 3scale is installed
+* Kubernetes resources at pod and namespace level where 3scale is installed
 * Apicast Staging
 * Apicast Production
 * 3scale Backend worker

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -2,15 +2,13 @@
 
 The 3scale monitoring resources are (optionally) installed when 3scale is installed on Openshift using the 3scale Operator.
 
-## Prerequirements
+## TOC
 
-* [prometheus-operator](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus#quickstart) needs to be deployed in the cluster.
-
-The prometheus operator is an operator that creates, configures, and manages Prometheus clusters atop Kubernetes. It provides `ServiceMonitor`, `PodMonitor` and `PrometheusRule` custom resources required by 3scale monitoring.
-
-* [grafana-operator](https://github.com/integr8ly/grafana-operator) needs to be deployed in the cluster.
-
-The grafana operator is an operator for creating and managing Grafana instances. It provides `GrafanaDashboard` custom resources required by 3scale monitoring.
+* [Enabling 3scale monitoring](#enabling-3scale-monitoring)
+* [Monitored components](#monitored-components)
+* [Monitoring stack](#monitoring-stack)
+   * [Prometheus](#prometheus)
+   * [Grafana](#grafana)
 
 ## Enabling 3scale monitoring
 
@@ -34,18 +32,105 @@ spec:
 * Apicast Production
 * 3scale Backend worker
 * 3scale Backend listener
-* System sidekiq
+* System
 * Zync
 * Zync-que
 
-## Exposing monitoring resources
+## Monitoring stack
 
-`GrafanaDashboard` resources will all be labeled with
+3scale monitoring is leveraged by [prometheus](https://prometheus.io/) and [grafana](https://grafana.com/) monitoring solutions. They need to be up and running in the cluster and configured to watch for monitoring resources.
+
+Monitoring stack setup and running is beyond 3scale operator reponsabilities.
+There are many ways to provide the required monitoring stack. Few examples are given:
+
+* Openshift new proposal [User Workload Monitoring](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/user-workload-monitoring.md)
+
+* [kube-prometheus](https://github.com/coreos/kube-prometheus): This repository collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
+
+* For devtesting purposes only, *quickstart steps* to deploy minimum required monitoring stack in [monitoring-stack-deployment](monitoring-stack-deployment/README.md)
+
+### Prometheus
+
+3scale monitoring requires [Prometheus Operator](https://github.com/coreos/prometheus-operator) to be deployed in the cluster.
+The prometheus operator is an operator that creates, configures, and manages Prometheus clusters atop Kubernetes. It provides `PodMonitor`, `ServiceMonitor` and `PrometheusRule` custom resources definitions required by 3scale monitoring.
+
+Tested releases:
+* Prometheus operator `v0.32.0`
+* Prometheus image: `quay.io/openshift/origin-prometheus: 4.2`
+
+Make sure prometheus services are configured to monitor 3scale monitoring resources.
+The simplest configuration is catch-all config in `Prometheus` custom resource spec :
 
 ```
+podMonitorSelector: {}
+ruleSelector: {}
+```
+
+Optionally, you can filter by labels. 3scale operator created `PodMonitors` and `PrometheusRules` will all be labeled with
+
+```
+app: 3scale-api-management
+```
+
+`Prometheus` custom resource spec to filter podmonitors and rules:
+
+```
+podMonitorSelector:
+  matchExpressions:
+  - key: monitoring-key
+      operator: In
+      values:
+      - middleware
+ruleSelector:
+  matchExpressions:
+  - key: monitoring-key
+    operator: In
+    values:
+    - middleware
+```
+
+Note: If the prometheus operator is installed in a different namespace than 3scale, then configure it accordingly to watch for resources outside the namespace. Check operator [doc](https://github.com/coreos/prometheus-operator/blob/v0.32.0/Documentation/api.md#prometheusspec) regarding this issue.
+
+**Kubernetes metrics: kube-state-metrics**
+
+3scale monitoring requires [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) for dashboards and alerts. There are several options available:
+
+* Federate the prometheus instance with cluster default prometheus instance to gather required metrics.
+* Configure your own scraping jobs to get metrics from kubelet, etcd...
+
+### Grafana
+
+3scale monitoring requires [Grafana Operator](https://github.com/integr8ly/grafana-operator) to be deployed in the cluster.
+The grafana operator is an operator for creating and managing Grafana instances. It provides `GrafanaDashboard` custom resource definition required by 3scale monitoring.
+
+Tested releases:
+* Grafana operator `v3.4.0`
+* Grafana image: `quay.io/openshift/origin-grafana:4.2`
+
+Make sure grafana services are configured to monitor 3scale monitoring resources:
+* `GrafanaDashboards`
+
+3scale operator created `GrafanaDashboards` will all be labeled with
+
+```
+app: 3scale-api-management
 monitoring-key: middleware
 ```
 
-Make sure the prometheus services and grafana services created by respective operators are configured to monitor resources with that label.
+This `dashboardLabelSelector` configuration in the `Grafana` cusrom resource spec should do that:
 
-Depending on the prometheus and grafana service configuration, the namespace where 3scale is installed might require labels too. Check your monitoring provider configuration like grafana and prometheus servers.
+```
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana
+spec:
+  dashboardLabelSelector:
+  - matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - 3scale-api-management
+```
+
+Note: If the grafana operator is installed in a different namespace than 3scale, then configure accordingly it to watch for resources outside the namespace. Check operator [doc](https://github.com/integr8ly/grafana-operator/blob/v2.0.0/documentation/deploy_grafana.md#operator-flags) regarding this issue.

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -25,6 +25,8 @@ spec:
     enabled: true
 ```
 
+NOTE: All monitoring resources will be created by the operator using *Create only* reconcilliation policy. That means that PrometheusRules and GrafanaDashboards objects can be updated preventing the operator to revert the changes back. This policy allows to tune, for instance, the alert thresholds, to your needs.
+
 ## Monitored components
 
 * Kubernetes resources at namespace level where 3scale is installed

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -119,7 +119,7 @@ app: 3scale-api-management
 monitoring-key: middleware
 ```
 
-This `dashboardLabelSelector` configuration in the `Grafana` cusrom resource spec should do that:
+This `dashboardLabelSelector` configuration in the `Grafana` custom resource spec should do that:
 
 ```
 apiVersion: integreatly.org/v1alpha1

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -33,7 +33,7 @@ NOTE: All monitoring resources will be created by the operator using *Create onl
 * Apicast Staging
 * Apicast Production
 * Backend worker
-* 3scale Backend listener
+* Backend listener
 * System
 * Zync
 * Zync-que

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -50,7 +50,7 @@ There are many ways to provide the required monitoring stack. Few examples are g
 * [kube-prometheus](https://github.com/coreos/kube-prometheus): This repository collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 
 * For devtesting purposes only, *quickstart steps* to deploy minimum required monitoring stack in [monitoring-stack-deployment](monitoring-stack-deployment/README.md).
-*Warning*: no *authentication* setup included. Prototect the prometheus and grafana services when you want to expose them in internet.
+*Warning*: no *authentication* setup included. Protect the prometheus and grafana services when you want to expose them in internet.
 In our dev clusters we configure authentication to be managed by Openshift (so htpassword or github)
 
 ### Prometheus

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -32,7 +32,7 @@ NOTE: All monitoring resources will be created by the operator using *Create onl
 * Kubernetes resources at pod and namespace level where 3scale is installed
 * Apicast Staging
 * Apicast Production
-* 3scale Backend worker
+* Backend worker
 * 3scale Backend listener
 * System
 * Zync

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -42,7 +42,7 @@ NOTE: All monitoring resources will be created by the operator using *Create onl
 
 3scale monitoring is leveraged by [prometheus](https://prometheus.io/) and [grafana](https://grafana.com/) monitoring solutions. They need to be up and running in the cluster and configured to watch for monitoring resources.
 
-Monitoring stack setup and running is beyond 3scale operator reponsabilities.
+**Monitoring stack setup and running is beyond 3scale operator reponsabilities, cluster administrator must provide it.**
 There are many ways to provide the required monitoring stack. Few examples are given:
 
 * Openshift new proposal [User Workload Monitoring](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/user-workload-monitoring.md)


### PR DESCRIPTION
Monitoring stack setup is beyond 3scale operator responsibility. 

* Document 3scale operator monitoring requirements from the monitoring stack.
* Monitoring stack deployment steps and templates for devtesting purposes
