### PR TITLE
set operator courier version for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,7 +491,7 @@ jobs:
       - image: circleci/python:3.6.4
     steps:
       - checkout
-      - run: sudo pip3 install operator-courier
+      - run: sudo pip3 install -v operator-courier==2.1.7
       - run: make verify-manifest
 
   unit-tests-coverage:


### PR DESCRIPTION
Latest release is 2.1.8 which has a bug being fixed https://github.com/operator-framework/operator-courier/pull/189

Set specific version