### PR TITLE
product CRD: system name to lower case

### DIFF
--- a/pkg/apis/capabilities/v1beta1/product_types_test.go
+++ b/pkg/apis/capabilities/v1beta1/product_types_test.go
@@ -3,7 +3,14 @@ package v1beta1
 import (
 	"strings"
 	"testing"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+func getv1beta1TestLogger() logr.Logger {
+	return logf.Log.WithName("v1beta1")
+}
 
 func defaultTestingProduct() Product {
 	product := Product{
@@ -12,7 +19,7 @@ func defaultTestingProduct() Product {
 		},
 	}
 
-	product.SetDefaults()
+	product.SetDefaults(getv1beta1TestLogger())
 	return product
 }
 

--- a/pkg/controller/backend/backend_controller.go
+++ b/pkg/controller/backend/backend_controller.go
@@ -138,7 +138,7 @@ func (r *ReconcileBackend) Reconcile(request reconcile.Request) (reconcile.Resul
 }
 
 func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backend) (reconcile.Result, error) {
-	logger := r.Logger().WithValues("reconcile", backendResource.Name)
+	logger := r.Logger().WithValues("backend", backendResource.Name)
 
 	if backendResource.SetDefaults() {
 		err := r.Client().Update(r.Context(), backendResource)

--- a/pkg/controller/product/product_controller.go
+++ b/pkg/controller/product/product_controller.go
@@ -139,9 +139,9 @@ func (r *ReconcileProduct) Reconcile(request reconcile.Request) (reconcile.Resul
 }
 
 func (r *ReconcileProduct) reconcile(productResource *capabilitiesv1beta1.Product) (reconcile.Result, error) {
-	logger := r.Logger().WithValues("reconcile", productResource.Name)
+	logger := r.Logger().WithValues("product", productResource.Name)
 
-	if productResource.SetDefaults() {
+	if productResource.SetDefaults(logger) {
 		err := r.Client().Update(r.Context(), productResource)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("Failed setting product defaults: %w", err)


### PR DESCRIPTION
3scale API ignores case of the `system_name` field.

The operator will transform to lower case to avoid confusion and conflict with other existing product with the same system_name when all chars are lowercase.