### PR TITLE
Capabilities provider account status

### DIFF
--- a/deploy/crds/capabilities.3scale.net_backends_crd.yaml
+++ b/deploy/crds/capabilities.3scale.net_backends_crd.yaml
@@ -174,6 +174,9 @@ spec:
                 recently observed Backend Spec.
               format: int64
               type: integer
+            providerAccountHost:
+              description: 3scale control plane host
+              type: string
           type: object
       type: object
   version: v1beta1

--- a/deploy/crds/capabilities.3scale.net_products_crd.yaml
+++ b/deploy/crds/capabilities.3scale.net_products_crd.yaml
@@ -478,6 +478,9 @@ spec:
             productId:
               format: int64
               type: integer
+            providerAccountHost:
+              description: 3scale control plane host
+              type: string
             state:
               type: string
           type: object

--- a/pkg/apis/capabilities/v1beta1/backend_types.go
+++ b/pkg/apis/capabilities/v1beta1/backend_types.go
@@ -91,6 +91,10 @@ type BackendStatus struct {
 	// +optional
 	ID *int64 `json:"backendId,omitempty"`
 
+	// 3scale control plane host
+	// +optional
+	ProviderAccountHost string `json:"providerAccountHost,omitempty"`
+
 	// ObservedGeneration reflects the generation of the most recently observed Backend Spec.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -107,6 +111,12 @@ func (b *BackendStatus) Equals(other *BackendStatus, logger logr.Logger) bool {
 	if !reflect.DeepEqual(b.ID, other.ID) {
 		diff := cmp.Diff(b.ID, other.ID)
 		logger.V(1).Info("ID not equal", "difference", diff)
+		return false
+	}
+
+	if b.ProviderAccountHost != other.ProviderAccountHost {
+		diff := cmp.Diff(b.ProviderAccountHost, other.ProviderAccountHost)
+		logger.V(1).Info("ProviderAccountHost not equal", "difference", diff)
 		return false
 	}
 

--- a/pkg/apis/capabilities/v1beta1/product_types.go
+++ b/pkg/apis/capabilities/v1beta1/product_types.go
@@ -766,6 +766,10 @@ type ProductStatus struct {
 	// +optional
 	State *string `json:"state,omitempty"`
 
+	// 3scale control plane host
+	// +optional
+	ProviderAccountHost string `json:"providerAccountHost,omitempty"`
+
 	// ObservedGeneration reflects the generation of the most recently observed Product Spec.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -788,6 +792,12 @@ func (p *ProductStatus) Equals(other *ProductStatus, logger logr.Logger) bool {
 	if !reflect.DeepEqual(p.State, other.State) {
 		diff := cmp.Diff(p.State, other.State)
 		logger.V(1).Info("State not equal", "difference", diff)
+		return false
+	}
+
+	if p.ProviderAccountHost != other.ProviderAccountHost {
+		diff := cmp.Diff(p.ProviderAccountHost, other.ProviderAccountHost)
+		logger.V(1).Info("ProviderAccountHost not equal", "difference", diff)
 		return false
 	}
 

--- a/pkg/controller/backend/backend_controller.go
+++ b/pkg/controller/backend/backend_controller.go
@@ -201,37 +201,6 @@ func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backen
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileBackend) reconcileSpec(backendResource *capabilitiesv1beta1.Backend) (*helper.BackendAPIEntity, error) {
-	err := r.validateSpec(backendResource)
-	if err != nil {
-		// Do not wrap error
-		return nil, err
-	}
-
-	providerAccount, err := helper.LookupProviderAccount(r.Client(), backendResource.Namespace, backendResource.Spec.ProviderAccountRef, r.Logger())
-	if err != nil {
-		return nil, fmt.Errorf("reconcile backend spec: %w", err)
-	}
-
-	threescaleAPIClient, err := helper.PortaClient(providerAccount)
-	if err != nil {
-		return nil, fmt.Errorf("reconcile backend spec: %w", err)
-	}
-
-	backendRemoteIndex, err := helper.NewBackendAPIRemoteIndex(threescaleAPIClient, r.Logger())
-	if err != nil {
-		return nil, fmt.Errorf("reconcile backend spec: %w", err)
-	}
-
-	reconciler := NewThreescaleReconciler(r.BaseReconciler, backendResource, threescaleAPIClient, backendRemoteIndex)
-	backendAPIEntity, err := reconciler.Reconcile()
-	if err != nil {
-		return nil, fmt.Errorf("Error 3scale sync: %w", err)
-	}
-
-	return backendAPIEntity, nil
-}
-
 func (r *ReconcileBackend) validateSpec(backendResource *capabilitiesv1beta1.Backend) error {
 	errors := field.ErrorList{}
 	// internal validation

--- a/pkg/controller/backend/backend_controller.go
+++ b/pkg/controller/backend/backend_controller.go
@@ -150,13 +150,41 @@ func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backen
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	backendAPI, specErr := r.reconcileSpec(backendResource)
+	err := r.validateSpec(backendResource)
+	if err != nil {
+		if helper.IsInvalidSpecError(err) {
+			// On Validation error, no need to retry as spec is not valid and needs to be changed
+			logger.Info("ERROR", "spec validation error", err)
+			r.EventRecorder().Eventf(backendResource, corev1.EventTypeWarning, "Invalid Backend Spec", "%v", err)
+			return reconcile.Result{}, nil
+		}
 
-	statusReconciler := NewStatusReconciler(r.BaseReconciler, backendResource, backendAPI, specErr)
+		return reconcile.Result{}, err
+	}
+
+	providerAccount, err := helper.LookupProviderAccount(r.Client(), backendResource.Namespace, backendResource.Spec.ProviderAccountRef, r.Logger())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("reconcile backend spec: %w", err)
+	}
+
+	threescaleAPIClient, err := helper.PortaClient(providerAccount)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("reconcile backend spec: %w", err)
+	}
+
+	backendRemoteIndex, err := helper.NewBackendAPIRemoteIndex(threescaleAPIClient, r.Logger())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("reconcile backend spec: %w", err)
+	}
+
+	reconciler := NewThreescaleReconciler(r.BaseReconciler, backendResource, threescaleAPIClient, backendRemoteIndex)
+	backendAPIEntity, syncErr := reconciler.Reconcile()
+
+	statusReconciler := NewStatusReconciler(r.BaseReconciler, backendResource, backendAPIEntity, providerAccount.AdminURLStr, syncErr)
 	statusResult, statusErr := statusReconciler.Reconcile()
 	if statusErr != nil {
-		if specErr != nil {
-			return reconcile.Result{}, fmt.Errorf("Failed to sync backend: %v. Failed to update backend status: %w", specErr, statusErr)
+		if syncErr != nil {
+			return reconcile.Result{}, fmt.Errorf("Failed to sync backend: %v. Failed to update backend status: %w", syncErr, statusErr)
 		}
 
 		return reconcile.Result{}, fmt.Errorf("Failed to update backend status: %w", statusErr)
@@ -166,15 +194,8 @@ func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backen
 		return statusResult, nil
 	}
 
-	if helper.IsInvalidSpecError(specErr) {
-		// On Validation error, no need to retry as spec is not valid and needs to be changed
-		logger.Info("ERROR", "spec validation error", specErr)
-		r.EventRecorder().Eventf(backendResource, corev1.EventTypeWarning, "Invalid Backend Spec", "%v", specErr)
-		return reconcile.Result{}, nil
-	}
-
-	if specErr != nil {
-		return reconcile.Result{}, fmt.Errorf("Failed to sync backend: %w", specErr)
+	if syncErr != nil {
+		return reconcile.Result{}, fmt.Errorf("Failed to sync backend: %w", syncErr)
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/backend/status_reconciler.go
+++ b/pkg/controller/backend/status_reconciler.go
@@ -16,19 +16,21 @@ import (
 
 type StatusReconciler struct {
 	*reconcilers.BaseReconciler
-	backendResource  *capabilitiesv1beta1.Backend
-	backendAPIEntity *helper.BackendAPIEntity
-	syncError        error
-	logger           logr.Logger
+	backendResource     *capabilitiesv1beta1.Backend
+	backendAPIEntity    *helper.BackendAPIEntity
+	providerAccountHost string
+	syncError           error
+	logger              logr.Logger
 }
 
-func NewStatusReconciler(b *reconcilers.BaseReconciler, backendResource *capabilitiesv1beta1.Backend, backendAPIEntity *helper.BackendAPIEntity, syncError error) *StatusReconciler {
+func NewStatusReconciler(b *reconcilers.BaseReconciler, backendResource *capabilitiesv1beta1.Backend, backendAPIEntity *helper.BackendAPIEntity, providerAccountHost string, syncError error) *StatusReconciler {
 	return &StatusReconciler{
-		BaseReconciler:   b,
-		backendResource:  backendResource,
-		backendAPIEntity: backendAPIEntity,
-		syncError:        syncError,
-		logger:           b.Logger().WithValues("Status Reconciler", backendResource.Name),
+		BaseReconciler:      b,
+		backendResource:     backendResource,
+		backendAPIEntity:    backendAPIEntity,
+		providerAccountHost: providerAccountHost,
+		syncError:           syncError,
+		logger:              b.Logger().WithValues("Status Reconciler", backendResource.Name),
 	}
 }
 
@@ -74,6 +76,8 @@ func (s *StatusReconciler) calculateStatus() *capabilitiesv1beta1.BackendStatus 
 		tmp := s.backendAPIEntity.ID()
 		newStatus.ID = &tmp
 	}
+
+	newStatus.ProviderAccountHost = s.providerAccountHost
 
 	newStatus.ObservedGeneration = s.backendResource.Status.ObservedGeneration
 

--- a/pkg/controller/product/product_controller.go
+++ b/pkg/controller/product/product_controller.go
@@ -202,7 +202,7 @@ func (r *ReconcileProduct) reconcile(productResource *capabilitiesv1beta1.Produc
 		return reconcile.Result{}, fmt.Errorf("Failed to update product status: %w", statusErr)
 	}
 
-        if statusResult.Requeue {
+	if statusResult.Requeue {
 		return statusResult, nil
 	}
 

--- a/pkg/controller/product/status_reconciler.go
+++ b/pkg/controller/product/status_reconciler.go
@@ -16,19 +16,21 @@ import (
 
 type StatusReconciler struct {
 	*reconcilers.BaseReconciler
-	resource  *capabilitiesv1beta1.Product
-	entity    *helper.ProductEntity
-	syncError error
-	logger    logr.Logger
+	resource            *capabilitiesv1beta1.Product
+	entity              *helper.ProductEntity
+	providerAccountHost string
+	syncError           error
+	logger              logr.Logger
 }
 
-func NewStatusReconciler(b *reconcilers.BaseReconciler, resource *capabilitiesv1beta1.Product, entity *helper.ProductEntity, syncError error) *StatusReconciler {
+func NewStatusReconciler(b *reconcilers.BaseReconciler, resource *capabilitiesv1beta1.Product, entity *helper.ProductEntity, providerAccountHost string, syncError error) *StatusReconciler {
 	return &StatusReconciler{
-		BaseReconciler: b,
-		resource:       resource,
-		entity:         entity,
-		syncError:      syncError,
-		logger:         b.Logger().WithValues("Status Reconciler", resource.Name),
+		BaseReconciler:      b,
+		resource:            resource,
+		entity:              entity,
+		providerAccountHost: providerAccountHost,
+		syncError:           syncError,
+		logger:              b.Logger().WithValues("Status Reconciler", resource.Name),
 	}
 }
 
@@ -76,6 +78,8 @@ func (s *StatusReconciler) calculateStatus() *capabilitiesv1beta1.ProductStatus 
 		tmpState := s.entity.State()
 		newStatus.State = &tmpState
 	}
+
+	newStatus.ProviderAccountHost = s.providerAccountHost
 
 	newStatus.ObservedGeneration = s.resource.Status.ObservedGeneration
 


### PR DESCRIPTION
Add provider account host url in status for `Backend` and `Product` CRD's.

As example, check `providerAccountHost` field in status object
```
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend-a
  namespace: eguz
spec:
  ...
status:
  backendId: 61535
  providerAccountHost: https://3scale-supertest-admin.3scale.net
```