### PR TITLE
Fix backend sync

### DIFF
--- a/pkg/controller/backend/3scale_reconciler.go
+++ b/pkg/controller/backend/3scale_reconciler.go
@@ -87,6 +87,9 @@ func (t *ThreescaleReconciler) syncBackend(_ interface{}) error {
 			"private_endpoint": t.backendResource.Spec.PrivateBaseURL,
 		}
 		backendAPIEntity, err = t.backendRemoteIndex.CreateBackendAPI(params)
+		if err != nil {
+			return fmt.Errorf("Error sync backend [%s]: %w", t.backendResource.Spec.SystemName, err)
+		}
 	}
 
 	// Will be used by coming steps

--- a/pkg/controller/backend/backend_controller.go
+++ b/pkg/controller/backend/backend_controller.go
@@ -140,7 +140,7 @@ func (r *ReconcileBackend) Reconcile(request reconcile.Request) (reconcile.Resul
 func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backend) (reconcile.Result, error) {
 	logger := r.Logger().WithValues("backend", backendResource.Name)
 
-	if backendResource.SetDefaults() {
+	if backendResource.SetDefaults(logger) {
 		err := r.Client().Update(r.Context(), backendResource)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("Failed setting backend defaults: %w", err)


### PR DESCRIPTION
* backend controller: fix handle err
* backend controller: system name to lower case: 3scale API ignores case of the system_name field. The operator will transform to lower case to avoid confusion and conflict with other existing product with the same system_name when all chars are lowercase.