### PR TITLE
Update APIManagerBackup PVC requirements documentation

### DIFF
--- a/doc/apimanagerbackup-reference.md
+++ b/doc/apimanagerbackup-reference.md
@@ -60,7 +60,7 @@ Backups of the external databases used by 3scale is not part of the
 | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
 | --- | --- | --- | --- | --- | --- |
 | `apiManagerName` | string | No | Name of the APIManager deployed in the same namespace as the deployed APIManagerBackup | Name of the APIManager to backup |
-| `backupSource` | [APIManagerBackupDestinationSpec](#APIManagerBackupDestinationSpec) | Yes | See [APIManagerBackupDestinationSpec](#APIManagerBackupDestinationSpec) | Configuration related to where the backup is performed |
+| `backupDestination` | [APIManagerBackupDestinationSpec](#APIManagerBackupDestinationSpec) | Yes | See [APIManagerBackupDestinationSpec](#APIManagerBackupDestinationSpec) | Configuration related to where the backup is performed |
 
 ### APIManagerBackupDestinationSpec
 
@@ -77,7 +77,9 @@ There are two main ways to provide a PersistentVolumeClaim for the backup:
 * Providing the volume name of an already existing Kubernetes PersistentVolume
   through the usage of the `volumeName` field. The already existing Kubernetes
   PersistentVolume has to be appropriately sized to contain
-  all [data that is backed up](#data-that-is-backed-up)
+  all [data that is backed up](#data-that-is-backed-up). In this case storage
+  size on the `resources` field has to be also specified, although it will be
+  ignored as per K8s PersistentVolumeClaim requirements behavior
 * Providing the desired size of the PersistentVolumeClaim through the
   `resources` field. In this case the `storageClass` field
   can be also set to specify what StorageClass will be used for the
@@ -86,7 +88,7 @@ There are two main ways to provide a PersistentVolumeClaim for the backup:
 
 | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
 | --- | --- | --- | --- | --- |
-| `resources` | [PersistentVolumeClaimResourcesSpec](#PersistentVolumeClaimResourcesSpec) | No | See [PersistentVolumeClaimResourcesSpec](#PersistentVolumeClaimResourcesSpec) | 
+| `resources` | [PersistentVolumeClaimResourcesSpec](#PersistentVolumeClaimResourcesSpec) | No | See [PersistentVolumeClaimResourcesSpec](#PersistentVolumeClaimResourcesSpec) | |
 | `volumeName` | string | No | N/A | A binding reference to the PersistentVolume backing this claim. This is not the persistentVolumeClaim name. See the field `volumeName` in the [Kubernetes PersistentVolumeClaim API reference](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#persistentvolumeclaimspec-v1-core) for more information |
 | `storageClass` | string | No | N/A | Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1 |
 

--- a/doc/operator-backup-and-restore.md
+++ b/doc/operator-backup-and-restore.md
@@ -67,6 +67,20 @@ workflow is the following one:
            resources:
              requests: "10Gi"
    ```
+   Another example, providing a pre-existing PersistentVolume name instead:
+   ```
+     apiVersion: apps.3scale.net/v1alpha1
+     kind: APIManagerBackup
+     metadata:
+      name: example-apimanagerbackup-pvc
+     spec:
+       backupDestination:
+         persistentVolumeClaim:
+           # resources specification is required but ignored when providing a volumeName as per K8s PVCs requirements behavior
+           resources:
+             requests: "10Gi"
+           volumeName: "my-preexisting-persistent-volume"
+   ```
 1. Wait until APIManagerBackup finishes. You can check this by obtaining
    the content of APIManagerBackup and waiting until the `.status.completed` field
    is set to true.

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -15,6 +15,7 @@
     * [Enabling monitoring resources](operator-monitoring-resources.md)
 * [Reconciliation](#reconciliation)
 * [Upgrading 3scale](#upgrading-3scale)
+* [3scale installation Backup and Restore using the operator (in *TechPreview*)](operator-backup-and-restore.md)
 * [Feature Operator (in *TechPreview*)](operator-capabilities.md)
 * [APIManager CRD reference](apimanager-reference.md)
 


### PR DESCRIPTION
This PR updates APIManagerBackup documentation to clarify PV pre-binding usage.
    
When providing a pre-existing PersistentVolume to APIManagerBackup
resources still have to be defined as per K8s PVCs behavior.
This commit updates the APIManagerBackup reference documentation
and deployment examples to specify and clarify this behavior which
might be surprising but that is how PVCs specification in K8s
requires and behaves.

Details about this behavior in: https://issues.redhat.com/browse/THREESCALE-5677