### PR TITLE
capabilities: reconciliate product on backend metric deletion

### DIFF
--- a/pkg/apis/capabilities/v1beta1/product_types.go
+++ b/pkg/apis/capabilities/v1beta1/product_types.go
@@ -1015,6 +1015,10 @@ func (product *Product) Validate() field.ErrorList {
 	return errors
 }
 
+func (product *Product) IsSynced() bool {
+	return product.Status.Conditions.IsTrueFor(ProductSyncedConditionType)
+}
+
 func (product *Product) FindMetricOrMethod(ref string) bool {
 	if len(product.Spec.Metrics) > 0 {
 		if _, ok := product.Spec.Metrics[ref]; ok {

--- a/pkg/controller/backend/backend_controller.go
+++ b/pkg/controller/backend/backend_controller.go
@@ -196,7 +196,7 @@ func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backen
 		return statusReconciler, err
 	}
 
-	reconciler := NewThreescaleReconciler(r.BaseReconciler, backendResource, threescaleAPIClient, backendRemoteIndex)
+	reconciler := NewThreescaleReconciler(r.BaseReconciler, backendResource, threescaleAPIClient, backendRemoteIndex, providerAccount)
 	backendAPIEntity, err := reconciler.Reconcile()
 	statusReconciler := NewStatusReconciler(r.BaseReconciler, backendResource, backendAPIEntity, providerAccount.AdminURLStr, err)
 	return statusReconciler, err

--- a/pkg/controller/helper/backend_list.go
+++ b/pkg/controller/helper/backend_list.go
@@ -1,0 +1,50 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/pkg/apis/capabilities/v1beta1"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BackendList returns a list of backend custom resources where all elements:
+// - Sync state (ensure remote backend exist and in sync)
+// - Same 3scale provider Account
+func BackendList(ns string, cl client.Client, providerAccount *ProviderAccount, logger logr.Logger) ([]capabilitiesv1beta1.Backend, error) {
+	backendList := &capabilitiesv1beta1.BackendList{}
+	opts := []controllerclient.ListOption{
+		controllerclient.InNamespace(ns),
+	}
+	err := cl.List(context.TODO(), backendList, opts...)
+	logger.V(1).Info("Get list of Backend resources.", "Err", err)
+	if err != nil {
+		return nil, fmt.Errorf("BackendList: %w", err)
+	}
+	logger.V(1).Info("Backend resources", "total", len(backendList.Items))
+
+	validBackends := make([]capabilitiesv1beta1.Backend, 0)
+	for idx := range backendList.Items {
+		// Filter by synchronized
+		if !backendList.Items[idx].IsSynced() {
+			continue
+		}
+
+		backendProviderAccount, err := LookupProviderAccount(cl, ns, backendList.Items[idx].Spec.ProviderAccountRef, logger)
+		if err != nil {
+			return nil, fmt.Errorf("BackendList: %w", err)
+		}
+
+		// Filter by provider account
+		if providerAccount.AdminURLStr != backendProviderAccount.AdminURLStr {
+			continue
+		}
+		validBackends = append(validBackends, backendList.Items[idx])
+	}
+
+	logger.V(1).Info("Backend valid resources", "total", len(validBackends))
+	return validBackends, nil
+}

--- a/pkg/controller/helper/product_list.go
+++ b/pkg/controller/helper/product_list.go
@@ -1,0 +1,50 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/pkg/apis/capabilities/v1beta1"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ProductList returns a list of product custom resources where all elements:
+// - Sync state (ensure remote product exist and in sync)
+// - Same 3scale provider Account
+func ProductList(ns string, cl client.Client, providerAccount *ProviderAccount, logger logr.Logger) ([]capabilitiesv1beta1.Product, error) {
+	productList := &capabilitiesv1beta1.ProductList{}
+	opts := []controllerclient.ListOption{
+		controllerclient.InNamespace(ns),
+	}
+	err := cl.List(context.TODO(), productList, opts...)
+	logger.V(1).Info("Get list of Product resources.", "Err", err)
+	if err != nil {
+		return nil, fmt.Errorf("ProductList: %w", err)
+	}
+	logger.V(1).Info("Product resources", "total", len(productList.Items))
+
+	validProducts := make([]capabilitiesv1beta1.Product, 0)
+	for idx := range productList.Items {
+		// Filter by synchronized
+		if !productList.Items[idx].IsSynced() {
+			continue
+		}
+
+		productProviderAccount, err := LookupProviderAccount(cl, ns, productList.Items[idx].Spec.ProviderAccountRef, logger)
+		if err != nil {
+			return nil, fmt.Errorf("BackendList: %w", err)
+		}
+
+		// Filter by provider account
+		if providerAccount.AdminURLStr != productProviderAccount.AdminURLStr {
+			continue
+		}
+		validProducts = append(validProducts, productList.Items[idx])
+	}
+
+	logger.V(1).Info("Product valid resources", "total", len(validProducts))
+	return validProducts, nil
+}

--- a/pkg/controller/helper/product_list.go
+++ b/pkg/controller/helper/product_list.go
@@ -35,7 +35,7 @@ func ProductList(ns string, cl client.Client, providerAccount *ProviderAccount, 
 
 		productProviderAccount, err := LookupProviderAccount(cl, ns, productList.Items[idx].Spec.ProviderAccountRef, logger)
 		if err != nil {
-			return nil, fmt.Errorf("BackendList: %w", err)
+			return nil, fmt.Errorf("ProductList: %w", err)
 		}
 
 		// Filter by provider account

--- a/pkg/helper/slice_string_utils.go
+++ b/pkg/helper/slice_string_utils.go
@@ -31,3 +31,24 @@ func ArrayStringIntersection(a, b []string) []string {
 
 	return result
 }
+
+// ArrayFind returns the smallest index i at which x == a[i],
+// or len(a) if there is no such index.
+func ArrayFind(a []string, x string) int {
+	for i, n := range a {
+		if x == n {
+			return i
+		}
+	}
+	return len(a)
+}
+
+// ArrayContains tells whether a contains x.
+func ArrayContains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
When backend metric or method is deleted, Application plan limits and pricing rules with references to it have to be deleted also, as it happens automatically in the System UI.

Fixes [issue](https://issues.redhat.com/browse/THREESCALE-5534) about product and backend consistency when there are references between them.