### PR TITLE
Fix regex validation in Product type for fields that specify USD

### DIFF
--- a/deploy/crds/capabilities.3scale.net_products_crd.yaml
+++ b/deploy/crds/capabilities.3scale.net_products_crd.yaml
@@ -42,7 +42,7 @@ spec:
                     type: boolean
                   costMonth:
                     description: Cost per Month (USD)
-                    pattern: ^\d+.?\d{2}$
+                    pattern: ^\d+(\.\d{2})?$
                     type: string
                   limits:
                     description: Limits
@@ -115,7 +115,7 @@ spec:
                           type: object
                         pricePerUnit:
                           description: Price per unit (USD)
-                          pattern: ^\d+.?\d{2}$
+                          pattern: ^\d+(\.\d{2})?$
                           type: string
                         to:
                           description: Range To
@@ -129,7 +129,7 @@ spec:
                     type: array
                   setupFee:
                     description: Setup fee (USD)
-                    pattern: ^\d+.?\d{2}$
+                    pattern: ^\d+(\.\d{2})?$
                     type: string
                   trialPeriod:
                     description: Trial Period (days)

--- a/pkg/apis/capabilities/v1beta1/product_types.go
+++ b/pkg/apis/capabilities/v1beta1/product_types.go
@@ -96,7 +96,7 @@ type PricingRuleSpec struct {
 	MetricMethodRef MetricMethodRefSpec `json:"metricMethodRef"`
 
 	// Price per unit (USD)
-	// +kubebuilder:validation:Pattern=`^\d+.?\d{2}$`
+	// +kubebuilder:validation:Pattern=`^\d+(\.\d{2})?$`
 	PricePerUnit string `json:"pricePerUnit"`
 }
 
@@ -116,12 +116,12 @@ type ApplicationPlanSpec struct {
 	TrialPeriod *int `json:"trialPeriod,omitempty"`
 
 	// Setup fee (USD)
-	// +kubebuilder:validation:Pattern=`^\d+.?\d{2}$`
+	// +kubebuilder:validation:Pattern=`^\d+(\.\d{2})?$`
 	// +optional
 	SetupFee *string `json:"setupFee,omitempty"`
 
 	// Cost per Month (USD)
-	// +kubebuilder:validation:Pattern=`^\d+.?\d{2}$`
+	// +kubebuilder:validation:Pattern=`^\d+(\.\d{2})?$`
 	// +optional
 	CostMonth *string `json:"costMonth,omitempty"`
 


### PR DESCRIPTION
The original regular expression, that I understand was intended to validate a floating point number with optionally two decimal numbers exactly was not validating that specification.

This PR fixes the regular expression to validate it.

This applies to pricePerUnit, setupFee and costMonth fields