### PR TITLE
Add configurable 'last' attribute in mapping rules

### DIFF
--- a/deploy/crds/capabilities.3scale.net_backends_crd.yaml
+++ b/deploy/crds/capabilities.3scale.net_backends_crd.yaml
@@ -53,6 +53,8 @@ spec:
                     type: string
                   increment:
                     type: integer
+                  last:
+                    type: boolean
                   metricMethodRef:
                     type: string
                   pattern:

--- a/deploy/crds/capabilities.3scale.net_products_crd.yaml
+++ b/deploy/crds/capabilities.3scale.net_products_crd.yaml
@@ -362,6 +362,8 @@ spec:
                     type: string
                   increment:
                     type: integer
+                  last:
+                    type: boolean
                   metricMethodRef:
                     type: string
                   pattern:

--- a/doc/backend-reference.md
+++ b/doc/backend-reference.md
@@ -29,6 +29,7 @@ Specifies backend mapping rule
 | Metric Method Reference | `metricMethodRef` | string | Existing method or metric **system name** | Yes |
 | Increment | `increment` | int | Increase the metric by this delta | Yes |
 | Position | `position` | int | Mapping Rule position | No |
+| Last | `last` | \*bool | Last matched Mapping Rule to process | No |
 
 ### MetricSpec
 

--- a/doc/product-reference.md
+++ b/doc/product-reference.md
@@ -97,6 +97,7 @@ Specifies product mapping rules
 | Metric Method Reference | `metricMethodRef` | string | Existing method or metric **system name** | Yes |
 | Increment | `increment` | int | Increase the metric by this delta | Yes |
 | Position | `position` | int | Mapping Rule position | No |
+| Last | `last` | \*bool | Last matched Mapping Rule to process | No |
 
 ### MetricSpec
 

--- a/pkg/apis/capabilities/v1beta1/product_types.go
+++ b/pkg/apis/capabilities/v1beta1/product_types.go
@@ -160,6 +160,8 @@ type MappingRuleSpec struct {
 	Increment       int    `json:"increment"`
 	// +optional
 	Position *int `json:"position,omitempty"`
+	// +optional
+	Last *bool `json:"last,omitempty"`
 }
 
 // BackendUsageSpec defines the desired state of Product's Backend Usages

--- a/pkg/apis/capabilities/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/capabilities/v1beta1/zz_generated.deepcopy.go
@@ -351,6 +351,11 @@ func (in *MappingRuleSpec) DeepCopyInto(out *MappingRuleSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.Last != nil {
+		in, out := &in.Last, &out.Last
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/backend/3scale_reconciler.go
+++ b/pkg/controller/backend/3scale_reconciler.go
@@ -476,6 +476,18 @@ func (t *ThreescaleReconciler) reconcileMatchedMappingRules(matchedList []mappin
 			params["delta"] = strconv.Itoa(data.spec.Increment)
 		}
 
+		//
+		// Reconcile last
+		//
+		desiredLastAttribute := false
+		if data.spec.Last != nil {
+			desiredLastAttribute = *data.spec.Last
+		}
+
+		if desiredLastAttribute != data.item.Last {
+			params["last"] = strconv.FormatBool(desiredLastAttribute)
+		}
+
 		if len(params) > 0 {
 			err := t.backendAPIEntity.UpdateMappingRule(data.item.ID, params)
 			if err != nil {
@@ -504,6 +516,10 @@ func (t *ThreescaleReconciler) createNewMappingRules(desiredList []capabilitiesv
 			"http_method": spec.HTTPMethod,
 			"metric_id":   strconv.FormatInt(metricID, 10),
 			"delta":       strconv.Itoa(spec.Increment),
+		}
+
+		if spec.Last != nil {
+			params["last"] = strconv.FormatBool(*spec.Last)
 		}
 
 		err = t.backendAPIEntity.CreateMappingRule(params)

--- a/pkg/controller/product/mapping_rules.go
+++ b/pkg/controller/product/mapping_rules.go
@@ -131,6 +131,18 @@ func (t *ThreescaleReconciler) reconcileMatchedMappingRules(matchedList []mappin
 			params["delta"] = strconv.Itoa(data.spec.Increment)
 		}
 
+		//
+		// Reconcile last
+		//
+		desiredLastAttribute := false
+		if data.spec.Last != nil {
+			desiredLastAttribute = *data.spec.Last
+		}
+
+		if desiredLastAttribute != data.item.Last {
+			params["last"] = strconv.FormatBool(desiredLastAttribute)
+		}
+
 		if len(params) > 0 {
 			err := t.productEntity.UpdateMappingRule(data.item.ID, params)
 			if err != nil {
@@ -159,6 +171,10 @@ func (t *ThreescaleReconciler) createNewMappingRules(desiredList []capabilitiesv
 			"http_method": spec.HTTPMethod,
 			"metric_id":   strconv.FormatInt(metricID, 10),
 			"delta":       strconv.Itoa(spec.Increment),
+		}
+
+		if spec.Last != nil {
+			params["last"] = strconv.FormatBool(*spec.Last)
 		}
 
 		err = t.productEntity.CreateMappingRule(params)


### PR DESCRIPTION
Add the optional 'last' attribute in MappingRules for Products and Backends