### PR TITLE
Create and Reconcile the 'position' attribute in Product and Backend MappingRules

### DIFF
--- a/pkg/controller/backend/3scale_reconciler.go
+++ b/pkg/controller/backend/3scale_reconciler.go
@@ -475,6 +475,16 @@ func (t *ThreescaleReconciler) reconcileMatchedMappingRules(matchedList []mappin
 			params["delta"] = strconv.Itoa(data.spec.Increment)
 		}
 
+		//
+		// Reconcile position. Only reconcile position when it has been set
+		// in the CR spec. If it has not been set on the spec we assume the desired
+		// position is the one set by the 3scale API and we do not modify
+		// the spec with the value from the API either.
+		//
+		if data.spec.Position != nil && *data.spec.Position != data.item.Position {
+			params["position"] = strconv.FormatInt(int64(*data.spec.Position), 10)
+		}
+
 		if len(params) > 0 {
 			err := t.backendAPIEntity.UpdateMappingRule(data.item.ID, params)
 			if err != nil {
@@ -503,6 +513,11 @@ func (t *ThreescaleReconciler) createNewMappingRules(desiredList []capabilitiesv
 			"http_method": spec.HTTPMethod,
 			"metric_id":   strconv.FormatInt(metricID, 10),
 			"delta":       strconv.Itoa(spec.Increment),
+		}
+
+		// Only set params position when position is set in CR's spec
+		if spec.Position != nil {
+			params["position"] = strconv.FormatInt(int64(*spec.Position), 10)
 		}
 
 		err = t.backendAPIEntity.CreateMappingRule(params)

--- a/pkg/controller/product/mapping_rules.go
+++ b/pkg/controller/product/mapping_rules.go
@@ -131,6 +131,16 @@ func (t *ThreescaleReconciler) reconcileMatchedMappingRules(matchedList []mappin
 			params["delta"] = strconv.Itoa(data.spec.Increment)
 		}
 
+		//
+		// Reconcile position. Only reconcile position when it has been set
+		// in the CR spec. If it has not been set on the spec we assume the desired
+		// position is the one set by the 3scale API and we do not modify
+		// the spec with the value from the API either.
+		//
+		if data.spec.Position != nil && *data.spec.Position != data.item.Position {
+			params["position"] = strconv.FormatInt(int64(*data.spec.Position), 10)
+		}
+
 		if len(params) > 0 {
 			err := t.productEntity.UpdateMappingRule(data.item.ID, params)
 			if err != nil {
@@ -159,6 +169,11 @@ func (t *ThreescaleReconciler) createNewMappingRules(desiredList []capabilitiesv
 			"http_method": spec.HTTPMethod,
 			"metric_id":   strconv.FormatInt(metricID, 10),
 			"delta":       strconv.Itoa(spec.Increment),
+		}
+
+		// Only set params position when position is set in CR's spec
+		if spec.Position != nil {
+			params["position"] = strconv.FormatInt(int64(*spec.Position), 10)
 		}
 
 		err = t.productEntity.CreateMappingRule(params)


### PR DESCRIPTION
This PRs makes the 'position' attribute configurable in Product and Backend MappingRules.

The 'position' attribute allows a user to define the processing priority order for a set of MappingRules.

This implementation approach has added this attribute as a field in the CR for the MappingRules.

The implementation has some advantages and drawbacks:
* Advantage: The user can define the desired position number arbitrarily. Position numbers between mappingrules do not necessarily have to be confitguous. For example, you could have 3 mappingRules with the positions 3,6,9 defined respectively
* Disadvantage: When a MappingRule is added or removed all the existing MappingRule positions in System are reordered. For example, if there are 3 MappingRules with positions 1,2,7 respectively and a new MappingRule is added with position set to 6, the original MappingRule with position 7 is changed by system to position 8. This causes an inconsistency between what's defined in the CR and what's effective in System, and when reconciliation happens in that case it would always detect differences. The implication of this is that if we take this approach we are moving the responsibility of reordering the existing MappingRules position to the user when a MappingRule is added or removed.

An alternative implementation is  provided in the pull request #452 to evaluate which one we prefer/is more desirable