### PR TITLE
Configurable resource requirements for APIManager components

### DIFF
--- a/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
@@ -670,6 +670,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates
@@ -1347,6 +1367,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates

--- a/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
@@ -10353,6 +10353,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates
@@ -10992,6 +11012,25 @@ spec:
                             - topologyKey
                             type: object
                           type: array
+                      type: object
+                  type: object
+                databaseResources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
                 databaseTolerations:
@@ -11668,6 +11707,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates

--- a/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
@@ -4829,6 +4829,66 @@ spec:
                               type: array
                           type: object
                       type: object
+                    developerContainerResources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    masterContainerResources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    providerContainerResources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     replicas:
                       format: int64
                       type: integer
@@ -5543,6 +5603,26 @@ spec:
                           properties:
                             storageClassName:
                               type: string
+                          type: object
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
                           type: object
                         tolerations:
                           items:
@@ -6994,6 +7074,26 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
                         tolerations:
                           items:
                             description: The pod this Toleration is attached to tolerates
@@ -7687,6 +7787,25 @@ spec:
                   type: object
                 memcachedImage:
                   type: string
+                memcachedResources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
                 memcachedTolerations:
                   items:
                     description: The pod this Toleration is attached to tolerates
@@ -8331,6 +8450,25 @@ spec:
                   properties:
                     storageClassName:
                       type: string
+                  type: object
+                redisResources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
                   type: object
                 redisTolerations:
                   items:
@@ -9002,6 +9140,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates
@@ -9670,6 +9828,26 @@ spec:
                                 - topologyKey
                                 type: object
                               type: array
+                          type: object
+                      type: object
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     tolerations:

--- a/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
@@ -2065,6 +2065,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates
@@ -2740,6 +2760,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates
@@ -3387,6 +3427,25 @@ spec:
                   properties:
                     storageClassName:
                       type: string
+                  type: object
+                redisResources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        type: string
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        type: string
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
                   type: object
                 redisTolerations:
                   items:
@@ -4058,6 +4117,26 @@ spec:
                     replicas:
                       format: int64
                       type: integer
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
                     tolerations:
                       items:
                         description: The pod this Toleration is attached to tolerates

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -25,7 +25,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | AppLabel | `appLabel` | string | No | `3scale-api-management` | The value of the `app` label that will be applied to the API management solution
 | TenantName | `tenantName` | string | No | `3scale` | Tenant name under the root that Admin UI will be available with -admin suffix.
 | ImageStreamTagImportInsecure | `imageStreamTagImportInsecure` | bool | No | `false` | Set to true if the server may bypass certificate verification or connect directly over HTTP during image import |
-| ResourceRequirementsEnabled | `resourceRequirementsEnabled` | bool | No | `true` | When true, 3Scale API management solution is deployed with the optimal resource requirements and limits. Setting this to false removes those resource requirements. ***Warning*** Only set it to false for development and evaluation environments |
+| ResourceRequirementsEnabled | `resourceRequirementsEnabled` | bool | No | `true` | When true, 3Scale API management solution is deployed with the optimal resource requirements and limits. Setting this to false removes those resource requirements. ***Warning*** Only set it to false for development and evaluation environments. When set to `true`, default compute resources are set for the APIManager components. See [Default APIManager components compute resources](#Default-APIManager-components-compute-resources) to see the default assigned values |
 | ApicastSpec | `apicast` | \*ApicastSpec | No | See [ApicastSpec](#ApicastSpec) | Spec of the Apicast part |
 | BackendSpec | `backend` | \*BackendSpec | No | See [BackendSpec](#BackendSpec) reference | Spec of the Backend part |
 | SystemSpec  | `system`  | \*SystemSpec  | No | See [SystemSpec](#SystemSpec) reference | Spec of the System part |
@@ -53,6 +53,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `apicast-production` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### ApicastStagingSpec
 
@@ -61,6 +62,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `apicast-staging` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### BackendSpec
 
@@ -70,6 +72,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | RedisImage | `redisImage` | string | No | nil | Used to overwrite the desired Redis image for the Redis used by backend. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
 | RedisAffinity | `redisAffinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
 | RedisTolerations | `redisTolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
+| RedisResources | `redisResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | RedisResources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 | RedisPersistentVolumeClaimSpec | `redisPersistentVolumeClaim` | \*[BackendRedisPersistentVolumeClaimSpec](#BackendRedisPersistentVolumeClaimSpec) | No | nil | Backend's Redis PersistentVolumeClaim configuration options. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
 | ListenerSpec | `listenerSpec` | \*BackendListenerSpec | No | See [BackendListenerSpec](#BackendListenerSpec) reference | Spec of Backend Listener part |
 | WorkerSpec | `workerSpec` | \*BackendWorkerSpec | No | See [BackendWorkerSpec](#BackendWorkerSpec) reference | Spec of Backend Worker part |
@@ -88,6 +91,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `backend-listener` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### BackendWorkerSpec
 
@@ -96,6 +100,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `backend-worker` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### BackendCronSpec
 
@@ -104,6 +109,7 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `backend-cron` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### SystemSpec
 
@@ -114,9 +120,11 @@ This resource is the resource used to deploy a 3scale API Management solution.
 | RedisPersistentVolumeClaimSpec | `redisPersistentVolumeClaim` | \*[SystemRedisPersistentVolumeClaimSpec](#SystemRedisPersistentVolumeClaimSpec) | No | nil | System's Redis PersistentVolumeClaim configuration options. Only takes effect when `.spec.highAvailability.enabled` is not set to true  |
 | RedisAffinity | `redisAffinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
 | RedisTolerations | `redisTolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
+| RedisResources | `redisResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | RedisResources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 | MemcachedImage | `memcachedImage` | string | No | nil | Used to overwrite the desired Memcached image for the Memcached used by System. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
 | MemcachedAffinity | `memcachedAffinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules. Only takes effect when `.spec.highAvailability.enabled` is not set to true | |
 | MemcachedTolerations | `memcachedTolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
+| MemcachedResources | `memcachedResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | MemcachedResources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 | FileStorageSpec | `fileStorage` | \*SystemFileStorageSpec | No | See [FileStorageSpec](#FileStorageSpec) specification | Spec of the System's File Storage part |
 | DatabaseSpec | `database` | \*SystemDatabaseSpec | No | See [DatabaseSpec](#DatabaseSpec) specification | Spec of the System's Database part |
 | AppSpec | `appSpec` | \*SystemAppSpec | No | See [SystemAppSpec](#SystemAppSpec) reference | Spec of System App part |
@@ -182,6 +190,7 @@ that should be set on it.
 | PersistentVolumeClaimSpec | `persistentVolumeClaim` | \*[SystemMySQLPVCSpec](#SystemMySQLPVCSpec) | No | nil | System's MySQL PersistentVolumeClaim configuration options |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### SystemMySQLPVCSpec
 
@@ -197,6 +206,7 @@ that should be set on it.
 | PersistentVolumeClaimSpec | `persistentVolumeClaim` | \*[SystemPostgreSQLPVCSpec](#SystemPostgreSQLPVCSpec) | No | nil | System's PostgreSQL PersistentVolumeClaim configuration options |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### SystemPostgreSQLPVCSpec
 
@@ -211,6 +221,9 @@ that should be set on it.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `system-app` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| MasterContainerResources | `masterContainerResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
+| ProviderContainerResources | `providerContainerResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
+| DeveloperContainerResources | `developerContainerResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### SystemSidekiqSpec
 
@@ -219,6 +232,7 @@ that should be set on it.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `system-sidekiq` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### SystemSphinxSpec
 
@@ -226,6 +240,7 @@ that should be set on it.
 | --- | --- | --- | --- | --- | --- |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### ZyncSpec
 
@@ -237,6 +252,7 @@ that should be set on it.
 | QueSpec | `queSpec` | \*ZyncQueSpec | No | See [ZyncQueSpec](#ZyncQueSpec) reference | Spec of Zync Que part |
 | DatabaseAffinity | `databaseAffinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
 | DatabaseTolerations | `databaseTolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints. Only takes effect when `.spec.highAvailability.enabled` is not set to true |
+| DatabaseResources | `databaseResources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | DatabaseResources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### ZyncAppSpec
 
@@ -245,6 +261,7 @@ that should be set on it.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `zync` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### ZyncQueSpec
 
@@ -253,6 +270,7 @@ that should be set on it.
 | Replicas | `replicas` | integer | No | 1 | Number of Pod replicas of the `zync-que` deployment |
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
+| Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 
 #### HighAvailabilitySpec
 
@@ -432,3 +450,33 @@ existing secret names.
 | username | In case the mail server requires authentication and the authentication type requires it | `""` |
 | password | In case the mail server requires authentication and the authentication type requires it | `""` |
 | openssl.verify.mode | When using TLS, you can set how OpenSSL checks the certificate. This is really useful if you need to validate a self-signed and/or a wildcard certificate. You can use the name of an OpenSSL verify constant: `none` or `peer` | `""` |
+
+
+### Default APIManager components compute resources
+
+When APIManager's `spec.resourceRequirementsEnabled` attribute is set to
+`true`, default compute resources are set for the APIManager components.
+
+The specific compute resources default values that are set for the
+APIManager components are the following ones:
+
+
+| **Component** | **CPU Requests**| **CPU Limits** | **Memory Requests** | **Memory Limits** |
+| --- | --- | --- | --- | --- |
+| system-app's system-master | 50m | 1000m | 600Mi | 800Mi |
+| system-app's system-provider | 50m | 1000m | 600Mi | 800Mi |
+| system-app's system-developer | 50m | 1000m | 600Mi | 800Mi |
+| system-sidekiq | 100m | 1000m  | 500Mi  | 2Gi |
+| system-sphinx | 80m | 1000m | 250Mi | 512Mi |
+| system-redis | 150m | 500m | 256Mi | 32Gi |
+| system-mysql | 250m | No limit | 512Mi | 2Gi |
+| system-postgresql | 250m | No limit | 512Mi | 2Gi |
+| backend-listener | 500m | 1000m | 550Mi | 700Mi |
+| backend-worker | 150m | 1000m | 50Mi | 300Mi |
+| backend-cron | 50m | 150m | 40Mi | 80Mi |
+| backend-redis | 1000m | 2000m | 1024Mi | 32Gi |
+| apicast-production | 500m | 1000m | 64Mi | 128Mi |
+| apicast-staging | 50m | 100m | 64Mi | 128Mi |
+| zync | 150m | 1 | 250M | 512Mi |
+| zync-que | 250m | 1 | 250M | 512Mi |
+| zync-database | 50m | 250m | 250M | 2G |

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -12,6 +12,7 @@
     * [PostgreSQL Installation](#postgresql-installation)
     * [Enabling Pod Disruption Budgets](#enabling-pod-disruption-budgets)
     * [Setting custom affinity and tolerations](#setting-custom-affinity-and-tolerations)
+    * [Setting custom compute resource requirements at component level](#setting-custom-compute-resource-requirements-at-component-level)
     * [Enabling monitoring resources](operator-monitoring-resources.md)
 * [Reconciliation](#reconciliation)
 * [Upgrading 3scale](#upgrading-3scale)
@@ -441,6 +442,54 @@ spec:
 
 See [APIManager reference](apimanager-reference.md) for a full list of
 attributes related to affinity and tolerations.
+
+#### Setting custom compute resource requirements at component level
+
+Kubernetes [Compute Resource Requirements](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+can be customized in a 3scale API Management solution through APIManager
+CR attributes in order to customize compute resource requirements (this is, CPU
+and Memory) assigned to a specific APIManager's component.
+
+For example, setting custom compute resource requirements for system-master's
+system-provider container, for backend-listener and for zync-database can be
+done in the following way:
+
+```yaml
+apiVersion: apps.3scale.net/v1alpha1
+kind: APIManager
+metadata:
+  name: example-apimanager
+spec:
+  backend:
+    listenerSpec:
+      resources:
+        requests:
+          memory: "150Mi"
+          cpu: "300m"
+        limits:
+          memory: "500Mi"
+          cpu: "1000m"
+  system:
+    appSpec:
+      providerContainerResources:
+        requests:
+          memory: "111Mi"
+          cpu: "222m"
+        limits:
+          memory: "333Mi"
+          cpu: "444m"     
+  zync:
+    databaseResources:
+      requests:
+        memory: "111Mi"
+        cpu: "222m"
+      limits:
+        memory: "333Mi"
+        cpu: "444m"   
+```
+
+See [APIManager reference](apimanager-reference.md) for a full list of
+attributes related to compute resource requirements.
 
 ### Reconciliation
 After 3scale API Management solution has been installed, 3scale Operator enables updating a given set

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -60,6 +60,18 @@ func (a *ApicastOptionsProvider) setResourceRequirementsOptions() {
 		a.apicastOptions.ProductionResourceRequirements = v1.ResourceRequirements{}
 		a.apicastOptions.StagingResourceRequirements = v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if a.apimanager.Spec.Apicast.ProductionSpec.Resources != nil {
+		a.apicastOptions.ProductionResourceRequirements = *a.apimanager.Spec.Apicast.ProductionSpec.Resources
+	}
+
+	if a.apimanager.Spec.Apicast.StagingSpec.Resources != nil {
+		a.apicastOptions.StagingResourceRequirements = *a.apimanager.Spec.Apicast.StagingSpec.Resources
+	}
+
 }
 
 func (a *ApicastOptionsProvider) setNodeAffinityAndTolerationsOptions() {

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -156,6 +156,19 @@ func (o *OperatorBackendOptionsProvider) setResourceRequirementsOptions() {
 		o.backendOptions.WorkerResourceRequirements = v1.ResourceRequirements{}
 		o.backendOptions.CronResourceRequirements = v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if o.apimanager.Spec.Backend.ListenerSpec.Resources != nil {
+		o.backendOptions.ListenerResourceRequirements = *o.apimanager.Spec.Backend.ListenerSpec.Resources
+	}
+	if o.apimanager.Spec.Backend.WorkerSpec.Resources != nil {
+		o.backendOptions.WorkerResourceRequirements = *o.apimanager.Spec.Backend.WorkerSpec.Resources
+	}
+	if o.apimanager.Spec.Backend.CronSpec.Resources != nil {
+		o.backendOptions.CronResourceRequirements = *o.apimanager.Spec.Backend.CronSpec.Resources
+	}
 }
 
 func (o *OperatorBackendOptionsProvider) setNodeAffinityAndTolerationsOptions() {

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -119,6 +119,45 @@ func testBackendCronTolerations() []v1.Toleration {
 	return getTestTolerations("backend-cron")
 }
 
+func testBackendListenerCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("123m"),
+			v1.ResourceMemory: resource.MustParse("456Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("789m"),
+			v1.ResourceMemory: resource.MustParse("111Mi"),
+		},
+	}
+}
+
+func testBackendWorkerCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("222m"),
+			v1.ResourceMemory: resource.MustParse("333Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("444m"),
+			v1.ResourceMemory: resource.MustParse("555Mi"),
+		},
+	}
+}
+
+func testBackendCronCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("666m"),
+			v1.ResourceMemory: resource.MustParse("777Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("888m"),
+			v1.ResourceMemory: resource.MustParse("999Mi"),
+		},
+	}
+}
+
 func getInternalSecret() *v1.Secret {
 	data := map[string]string{
 		component.BackendSecretInternalApiUsernameFieldName: "someUserName",
@@ -281,6 +320,41 @@ func TestGetBackendOptionsProvider(t *testing.T) {
 				opts.ListenerTolerations = testBackendListenerTolerations()
 				opts.WorkerTolerations = testBackendWorkerTolerations()
 				opts.CronTolerations = testBackendCronTolerations()
+				return opts
+			},
+		},
+		{"WithBackendCustomResourceRequirements", nil, nil, nil,
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanagerTestBackendOptions()
+				apimanager.Spec.Backend.ListenerSpec.Resources = testBackendListenerCustomResourceRequirements()
+				apimanager.Spec.Backend.WorkerSpec.Resources = testBackendWorkerCustomResourceRequirements()
+				apimanager.Spec.Backend.CronSpec.Resources = testBackendCronCustomResourceRequirements()
+				return apimanager
+			},
+			func(in *component.BackendOptions) *component.BackendOptions {
+				opts := defaultBackendOptions(in)
+
+				opts.ListenerResourceRequirements = *testBackendListenerCustomResourceRequirements()
+				opts.WorkerResourceRequirements = *testBackendWorkerCustomResourceRequirements()
+				opts.CronResourceRequirements = *testBackendCronCustomResourceRequirements()
+				return opts
+			},
+		},
+		{"WithBackendCustomResourceRequirementsAndGlobalResourceRequirementsDisabled", nil, nil, nil,
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanagerTestBackendOptions()
+				apimanager.Spec.ResourceRequirementsEnabled = &falseValue
+				apimanager.Spec.Backend.ListenerSpec.Resources = testBackendListenerCustomResourceRequirements()
+				apimanager.Spec.Backend.WorkerSpec.Resources = testBackendWorkerCustomResourceRequirements()
+				apimanager.Spec.Backend.CronSpec.Resources = testBackendCronCustomResourceRequirements()
+				return apimanager
+			},
+			func(in *component.BackendOptions) *component.BackendOptions {
+				opts := defaultBackendOptions(in)
+
+				opts.ListenerResourceRequirements = *testBackendListenerCustomResourceRequirements()
+				opts.WorkerResourceRequirements = *testBackendWorkerCustomResourceRequirements()
+				opts.CronResourceRequirements = *testBackendCronCustomResourceRequirements()
 				return opts
 			},
 		},

--- a/pkg/3scale/amp/operator/memcached_options_provider.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider.go
@@ -49,6 +49,13 @@ func (m *MemcachedOptionsProvider) setResourceRequirementsOptions() {
 	} else {
 		m.memcachedOptions.ResourceRequirements = v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if m.apimanager.Spec.System.MemcachedResources != nil {
+		m.memcachedOptions.ResourceRequirements = *m.apimanager.Spec.System.MemcachedResources
+	}
 }
 
 func (m *MemcachedOptionsProvider) setNodeAffinityAndTolerationsOptions() {

--- a/pkg/3scale/amp/operator/memcached_options_provider_test.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider_test.go
@@ -43,6 +43,19 @@ func testMemcachedTolerations() []v1.Toleration {
 	return getTestTolerations("memcached")
 }
 
+func testSystemMemcachedCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("111m"),
+			v1.ResourceMemory: resource.MustParse("222Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("333m"),
+			v1.ResourceMemory: resource.MustParse("444Mi"),
+		},
+	}
+}
+
 func defaultMemcachedOptions() *component.MemcachedOptions {
 	return &component.MemcachedOptions{
 		ImageTag:             product.ThreescaleRelease,
@@ -94,6 +107,31 @@ func TestMemcachedOptionsProvider(t *testing.T) {
 			func() *component.MemcachedOptions {
 				opts := defaultMemcachedOptions()
 				opts.Tolerations = testMemcachedTolerations()
+				return opts
+			},
+		},
+		{"WithSystemMemcachedCustomResourceRequirements",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanager()
+				apimanager.Spec.System.MemcachedResources = testSystemMemcachedCustomResourceRequirements()
+				return apimanager
+			},
+			func() *component.MemcachedOptions {
+				opts := defaultMemcachedOptions()
+				opts.ResourceRequirements = *testSystemMemcachedCustomResourceRequirements()
+				return opts
+			},
+		},
+		{"WithSystemMemcachedCustomResourceRequirementsAndGlobalResourceRequirementsDisabled",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanager()
+				apimanager.Spec.ResourceRequirementsEnabled = &falseValue
+				apimanager.Spec.System.MemcachedResources = testSystemMemcachedCustomResourceRequirements()
+				return apimanager
+			},
+			func() *component.MemcachedOptions {
+				opts := defaultMemcachedOptions()
+				opts.ResourceRequirements = *testSystemMemcachedCustomResourceRequirements()
 				return opts
 			},
 		},

--- a/pkg/3scale/amp/operator/redis_options_provider.go
+++ b/pkg/3scale/amp/operator/redis_options_provider.go
@@ -66,6 +66,13 @@ func (r *RedisOptionsProvider) setResourceRequirementsOptions() {
 		r.options.BackendRedisContainerResourceRequirements = &v1.ResourceRequirements{}
 		r.options.SystemRedisContainerResourceRequirements = &v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if r.apimanager.Spec.Backend.RedisResources != nil {
+		r.options.BackendRedisContainerResourceRequirements = r.apimanager.Spec.Backend.RedisResources
+	}
 }
 
 func (r *RedisOptionsProvider) setPersistentVolumeClaimOptions() {

--- a/pkg/3scale/amp/operator/redis_options_provider.go
+++ b/pkg/3scale/amp/operator/redis_options_provider.go
@@ -73,6 +73,9 @@ func (r *RedisOptionsProvider) setResourceRequirementsOptions() {
 	if r.apimanager.Spec.Backend.RedisResources != nil {
 		r.options.BackendRedisContainerResourceRequirements = r.apimanager.Spec.Backend.RedisResources
 	}
+	if r.apimanager.Spec.System.RedisResources != nil {
+		r.options.SystemRedisContainerResourceRequirements = r.apimanager.Spec.System.RedisResources
+	}
 }
 
 func (r *RedisOptionsProvider) setPersistentVolumeClaimOptions() {

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -100,6 +100,19 @@ func testBackendRedisCustomResourceRequirements() *v1.ResourceRequirements {
 	}
 }
 
+func testSystemRedisCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("222m"),
+			v1.ResourceMemory: resource.MustParse("333Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("444m"),
+			v1.ResourceMemory: resource.MustParse("555Mi"),
+		},
+	}
+}
+
 func defaultRedisOptions() *component.RedisOptions {
 	tmpInsecure := insecureImportPolicy
 	return &component.RedisOptions{
@@ -285,6 +298,32 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				opts := defaultRedisOptions()
 				opts.SystemRedisContainerResourceRequirements = &v1.ResourceRequirements{}
 				opts.BackendRedisContainerResourceRequirements = testBackendRedisCustomResourceRequirements()
+				return opts
+			},
+		},
+		{"WithSystemRedisCustomResourceRequirements",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanager()
+				apimanager.Spec.Backend.RedisResources = testSystemRedisCustomResourceRequirements()
+				return apimanager
+			},
+			func() *component.RedisOptions {
+				opts := defaultRedisOptions()
+				opts.BackendRedisContainerResourceRequirements = testSystemRedisCustomResourceRequirements()
+				return opts
+			},
+		},
+		{"WithSystemRedisCustomResourceRequirementsAndGlobalResourceRequirementsDisabled",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanager()
+				apimanager.Spec.ResourceRequirementsEnabled = &tmpFalseValue
+				apimanager.Spec.System.RedisResources = testSystemRedisCustomResourceRequirements()
+				return apimanager
+			},
+			func() *component.RedisOptions {
+				opts := defaultRedisOptions()
+				opts.BackendRedisContainerResourceRequirements = &v1.ResourceRequirements{}
+				opts.SystemRedisContainerResourceRequirements = testSystemRedisCustomResourceRequirements()
 				return opts
 			},
 		},

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -87,6 +87,19 @@ func testSystemRedisTolerations() []v1.Toleration {
 	return getTestTolerations("system-redis")
 }
 
+func testBackendRedisCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("111m"),
+			v1.ResourceMemory: resource.MustParse("222Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("333m"),
+			v1.ResourceMemory: resource.MustParse("444Mi"),
+		},
+	}
+}
+
 func defaultRedisOptions() *component.RedisOptions {
 	tmpInsecure := insecureImportPolicy
 	return &component.RedisOptions{
@@ -246,6 +259,32 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				opts := defaultRedisOptions()
 				opts.SystemRedisTolerations = testSystemRedisTolerations()
 				opts.BackendRedisTolerations = testBackendRedisTolerations()
+				return opts
+			},
+		},
+		{"WithBackendRedisCustomResourceRequirements",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanager()
+				apimanager.Spec.Backend.RedisResources = testBackendRedisCustomResourceRequirements()
+				return apimanager
+			},
+			func() *component.RedisOptions {
+				opts := defaultRedisOptions()
+				opts.BackendRedisContainerResourceRequirements = testBackendRedisCustomResourceRequirements()
+				return opts
+			},
+		},
+		{"WithBackendRedisCustomResourceRequirementsAndGlobalResourceRequirementsDisabled",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanager()
+				apimanager.Spec.ResourceRequirementsEnabled = &tmpFalseValue
+				apimanager.Spec.Backend.RedisResources = testBackendRedisCustomResourceRequirements()
+				return apimanager
+			},
+			func() *component.RedisOptions {
+				opts := defaultRedisOptions()
+				opts.SystemRedisContainerResourceRequirements = &v1.ResourceRequirements{}
+				opts.BackendRedisContainerResourceRequirements = testBackendRedisCustomResourceRequirements()
 				return opts
 			},
 		},

--- a/pkg/3scale/amp/operator/system_mysql_options_provider.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider.go
@@ -147,6 +147,15 @@ func (s *SystemMysqlOptionsProvider) setResourceRequirementsOptions() {
 	} else {
 		s.mysqlOptions.ContainerResourceRequirements = v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if s.apimanager.Spec.System.DatabaseSpec != nil &&
+		s.apimanager.Spec.System.DatabaseSpec.MySQL != nil &&
+		s.apimanager.Spec.System.DatabaseSpec.MySQL.Resources != nil {
+		s.mysqlOptions.ContainerResourceRequirements = *s.apimanager.Spec.System.DatabaseSpec.MySQL.Resources
+	}
 }
 
 func (s *SystemMysqlOptionsProvider) setPersistentVolumeClaimOptions() {

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -431,6 +431,25 @@ func (s *SystemOptionsProvider) setResourceRequirementsOptions() {
 		s.options.SidekiqContainerResourceRequirements = &v1.ResourceRequirements{}
 		s.options.SphinxContainerResourceRequirements = &v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if s.apimanager.Spec.System.AppSpec.MasterContainerResources != nil {
+		s.options.AppMasterContainerResourceRequirements = s.apimanager.Spec.System.AppSpec.MasterContainerResources
+	}
+	if s.apimanager.Spec.System.AppSpec.ProviderContainerResources != nil {
+		s.options.AppProviderContainerResourceRequirements = s.apimanager.Spec.System.AppSpec.ProviderContainerResources
+	}
+	if s.apimanager.Spec.System.AppSpec.DeveloperContainerResources != nil {
+		s.options.AppDeveloperContainerResourceRequirements = s.apimanager.Spec.System.AppSpec.DeveloperContainerResources
+	}
+	if s.apimanager.Spec.System.SidekiqSpec.Resources != nil {
+		s.options.SidekiqContainerResourceRequirements = s.apimanager.Spec.System.SidekiqSpec.Resources
+	}
+	if s.apimanager.Spec.System.SphinxSpec.Resources != nil {
+		s.options.SphinxContainerResourceRequirements = s.apimanager.Spec.System.SphinxSpec.Resources
+	}
 }
 
 func (s *SystemOptionsProvider) setNodeAffinityAndTolerationsOptions() {

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -158,6 +158,71 @@ func testSystemSphinxTolerations() []v1.Toleration {
 	return getTestTolerations("system-sphinx")
 }
 
+func testSystemMasterContainerCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("111m"),
+			v1.ResourceMemory: resource.MustParse("222Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("333m"),
+			v1.ResourceMemory: resource.MustParse("444Mi"),
+		},
+	}
+}
+
+func testSystemProviderContainerCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("222m"),
+			v1.ResourceMemory: resource.MustParse("333Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("444m"),
+			v1.ResourceMemory: resource.MustParse("555Mi"),
+		},
+	}
+}
+
+func testSystemDeveloperContainerCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("666m"),
+			v1.ResourceMemory: resource.MustParse("777Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("888m"),
+			v1.ResourceMemory: resource.MustParse("999Mi"),
+		},
+	}
+}
+
+func testSystemSidekiqCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("842m"),
+			v1.ResourceMemory: resource.MustParse("253Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("294m"),
+			v1.ResourceMemory: resource.MustParse("195Mi"),
+		},
+	}
+}
+
+func testSystemSphinxCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("123m"),
+			v1.ResourceMemory: resource.MustParse("456Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("789m"),
+			v1.ResourceMemory: resource.MustParse("346Mi"),
+		},
+	}
+}
+
 func basicApimanagerSpecTestSystemOptions() *appsv1alpha1.APIManager {
 	tmpSystemAppReplicas := systemAppReplicas
 	tmpSystemSideKiqReplicas := systemSidekiqReplicas
@@ -510,6 +575,47 @@ func TestGetSystemOptionsProvider(t *testing.T) {
 				expectedOpts.AppTolerations = testSystemAppTolerations()
 				expectedOpts.SidekiqTolerations = testSystemSidekiqTolerations()
 				expectedOpts.SphinxTolerations = testSystemSphinxTolerations()
+				return expectedOpts
+			},
+		},
+		{"WithSystemCustomResourceRequirements",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanagerSpecTestSystemOptions()
+				apimanager.Spec.System.AppSpec.MasterContainerResources = testSystemMasterContainerCustomResourceRequirements()
+				apimanager.Spec.System.AppSpec.ProviderContainerResources = testSystemProviderContainerCustomResourceRequirements()
+				apimanager.Spec.System.AppSpec.DeveloperContainerResources = testSystemDeveloperContainerCustomResourceRequirements()
+				apimanager.Spec.System.SidekiqSpec.Resources = testSystemSidekiqCustomResourceRequirements()
+				apimanager.Spec.System.SphinxSpec.Resources = testSystemSphinxCustomResourceRequirements()
+				return apimanager
+			}, nil, nil, nil, nil, nil, nil, nil,
+			func(opts *component.SystemOptions) *component.SystemOptions {
+				expectedOpts := defaultSystemOptions(opts)
+				expectedOpts.AppMasterContainerResourceRequirements = testSystemMasterContainerCustomResourceRequirements()
+				expectedOpts.AppProviderContainerResourceRequirements = testSystemProviderContainerCustomResourceRequirements()
+				expectedOpts.AppDeveloperContainerResourceRequirements = testSystemDeveloperContainerCustomResourceRequirements()
+				expectedOpts.SidekiqContainerResourceRequirements = testSystemSidekiqCustomResourceRequirements()
+				expectedOpts.SphinxContainerResourceRequirements = testSystemSphinxCustomResourceRequirements()
+				return expectedOpts
+			},
+		},
+		{"WithSystemCustomResourceRequirementsAndGlobalResourceRequirementsDisabled",
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanagerSpecTestSystemOptions()
+				apimanager.Spec.ResourceRequirementsEnabled = &falseValue
+				apimanager.Spec.System.AppSpec.MasterContainerResources = testSystemMasterContainerCustomResourceRequirements()
+				apimanager.Spec.System.AppSpec.ProviderContainerResources = testSystemProviderContainerCustomResourceRequirements()
+				apimanager.Spec.System.AppSpec.DeveloperContainerResources = testSystemDeveloperContainerCustomResourceRequirements()
+				apimanager.Spec.System.SidekiqSpec.Resources = testSystemSidekiqCustomResourceRequirements()
+				apimanager.Spec.System.SphinxSpec.Resources = testSystemSphinxCustomResourceRequirements()
+				return apimanager
+			}, nil, nil, nil, nil, nil, nil, nil,
+			func(opts *component.SystemOptions) *component.SystemOptions {
+				expectedOpts := defaultSystemOptions(opts)
+				expectedOpts.AppMasterContainerResourceRequirements = testSystemMasterContainerCustomResourceRequirements()
+				expectedOpts.AppProviderContainerResourceRequirements = testSystemProviderContainerCustomResourceRequirements()
+				expectedOpts.AppDeveloperContainerResourceRequirements = testSystemDeveloperContainerCustomResourceRequirements()
+				expectedOpts.SidekiqContainerResourceRequirements = testSystemSidekiqCustomResourceRequirements()
+				expectedOpts.SphinxContainerResourceRequirements = testSystemSphinxCustomResourceRequirements()
 				return expectedOpts
 			},
 		},

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider.go
@@ -133,6 +133,15 @@ func (s *SystemPostgresqlOptionsProvider) setResourceRequirementsOptions() {
 	} else {
 		s.options.ContainerResourceRequirements = v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if s.apimanager.Spec.System.DatabaseSpec != nil &&
+		s.apimanager.Spec.System.DatabaseSpec.PostgreSQL != nil &&
+		s.apimanager.Spec.System.DatabaseSpec.PostgreSQL.Resources != nil {
+		s.options.ContainerResourceRequirements = *s.apimanager.Spec.System.DatabaseSpec.PostgreSQL.Resources
+	}
 }
 
 func (s *SystemPostgresqlOptionsProvider) setPersistentVolumeClaimOptions() {

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -117,6 +117,19 @@ func (z *ZyncOptionsProvider) setResourceRequirementsOptions() {
 		z.zyncOptions.QueContainerResourceRequirements = v1.ResourceRequirements{}
 		z.zyncOptions.DatabaseContainerResourceRequirements = v1.ResourceRequirements{}
 	}
+
+	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// spec.resourceRequirementsEnabled, overwriting that setting when they are
+	// defined
+	if z.apimanager.Spec.Zync.AppSpec.Resources != nil {
+		z.zyncOptions.ContainerResourceRequirements = *z.apimanager.Spec.Zync.AppSpec.Resources
+	}
+	if z.apimanager.Spec.Zync.QueSpec.Resources != nil {
+		z.zyncOptions.QueContainerResourceRequirements = *z.apimanager.Spec.Zync.QueSpec.Resources
+	}
+	if z.apimanager.Spec.Zync.DatabaseResources != nil {
+		z.zyncOptions.DatabaseContainerResourceRequirements = *z.apimanager.Spec.Zync.DatabaseResources
+	}
 }
 
 func (z *ZyncOptionsProvider) setNodeAffinityAndTolerationsOptions() {

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -120,6 +120,45 @@ func testZyncDatabaseTolerations() []v1.Toleration {
 	return getTestTolerations("zync-database")
 }
 
+func testZyncCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("123m"),
+			v1.ResourceMemory: resource.MustParse("456Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("789m"),
+			v1.ResourceMemory: resource.MustParse("111Mi"),
+		},
+	}
+}
+
+func testQueZyncCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("222m"),
+			v1.ResourceMemory: resource.MustParse("333Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("444m"),
+			v1.ResourceMemory: resource.MustParse("555Mi"),
+		},
+	}
+}
+
+func testZyncDatabaseCustomResourceRequirements() *v1.ResourceRequirements {
+	return &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("666m"),
+			v1.ResourceMemory: resource.MustParse("777Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("888m"),
+			v1.ResourceMemory: resource.MustParse("999Mi"),
+		},
+	}
+}
+
 func getZyncSecret() *v1.Secret {
 	data := map[string]string{
 		component.ZyncSecretKeyBaseFieldName:             zyncSecretKeyBasename,
@@ -235,6 +274,39 @@ func TestGetZyncOptionsProvider(t *testing.T) {
 				expectedOpts.ZyncTolerations = testZyncTolerations()
 				expectedOpts.ZyncQueTolerations = testZyncQueTolerations()
 				expectedOpts.ZyncDatabaseTolerations = testZyncDatabaseTolerations()
+				return expectedOpts
+			},
+		},
+		{"WithZyncCustomResourceRequirements", nil,
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanagerSpecTestZyncOptions()
+				apimanager.Spec.Zync.AppSpec.Resources = testZyncCustomResourceRequirements()
+				apimanager.Spec.Zync.QueSpec.Resources = testQueZyncCustomResourceRequirements()
+				apimanager.Spec.Zync.DatabaseResources = testZyncDatabaseCustomResourceRequirements()
+				return apimanager
+			},
+			func(opts *component.ZyncOptions) *component.ZyncOptions {
+				expectedOpts := defaultZyncOptions(opts)
+				expectedOpts.ContainerResourceRequirements = *testZyncCustomResourceRequirements()
+				expectedOpts.QueContainerResourceRequirements = *testQueZyncCustomResourceRequirements()
+				expectedOpts.DatabaseContainerResourceRequirements = *testZyncDatabaseCustomResourceRequirements()
+				return expectedOpts
+			},
+		},
+		{"WithZyncCustomResourceRequirementsAndGlobalResourceRequirementsDisabled", nil,
+			func() *appsv1alpha1.APIManager {
+				apimanager := basicApimanagerSpecTestZyncOptions()
+				apimanager.Spec.ResourceRequirementsEnabled = &falseValue
+				apimanager.Spec.Zync.AppSpec.Resources = testZyncCustomResourceRequirements()
+				apimanager.Spec.Zync.QueSpec.Resources = testQueZyncCustomResourceRequirements()
+				apimanager.Spec.Zync.DatabaseResources = testZyncDatabaseCustomResourceRequirements()
+				return apimanager
+			},
+			func(opts *component.ZyncOptions) *component.ZyncOptions {
+				expectedOpts := defaultZyncOptions(opts)
+				expectedOpts.ContainerResourceRequirements = *testZyncCustomResourceRequirements()
+				expectedOpts.QueContainerResourceRequirements = *testQueZyncCustomResourceRequirements()
+				expectedOpts.DatabaseContainerResourceRequirements = *testZyncDatabaseCustomResourceRequirements()
 				return expectedOpts
 			},
 		},

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -250,6 +250,8 @@ type SystemSpec struct {
 	MemcachedAffinity *v1.Affinity `json:"memcachedAffinity,omitempty"`
 	// +optional
 	MemcachedTolerations []v1.Toleration `json:"memcachedTolerations,omitempty"`
+	// +optional
+	MemcachedResources *v1.ResourceRequirements `json:"memcachedResources,omitempty"`
 
 	// +optional
 	RedisImage *string `json:"redisImage,omitempty"`
@@ -260,6 +262,8 @@ type SystemSpec struct {
 	RedisAffinity *v1.Affinity `json:"redisAffinity,omitempty"`
 	// +optional
 	RedisTolerations []v1.Toleration `json:"redisTolerations,omitempty"`
+	// +optional
+	RedisResources *v1.ResourceRequirements `json:"redisResources,omitempty"`
 
 	// TODO should this field be optional? We have different approaches in Kubernetes.
 	// For example, in v1.Volume it is optional and there's an implied behaviour
@@ -291,6 +295,12 @@ type SystemAppSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	MasterContainerResources *v1.ResourceRequirements `json:"masterContainerResources,omitempty"`
+	// +optional
+	ProviderContainerResources *v1.ResourceRequirements `json:"providerContainerResources,omitempty"`
+	// +optional
+	DeveloperContainerResources *v1.ResourceRequirements `json:"developerContainerResources,omitempty"`
 }
 
 type SystemSidekiqSpec struct {
@@ -300,6 +310,8 @@ type SystemSidekiqSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type SystemSphinxSpec struct {
@@ -307,6 +319,8 @@ type SystemSphinxSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type SystemFileStorageSpec struct {
@@ -361,6 +375,8 @@ type SystemMySQLSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type SystemPostgreSQLSpec struct {
@@ -373,6 +389,8 @@ type SystemPostgreSQLSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type SystemMySQLPVCSpec struct {

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -192,6 +192,8 @@ type BackendSpec struct {
 	// +optional
 	RedisTolerations []v1.Toleration `json:"redisTolerations,omitempty"`
 	// +optional
+	RedisResources *v1.ResourceRequirements `json:"redisResources,omitempty"`
+	// +optional
 	ListenerSpec *BackendListenerSpec `json:"listenerSpec,omitempty"`
 	// +optional
 	WorkerSpec *BackendWorkerSpec `json:"workerSpec,omitempty"`
@@ -211,6 +213,8 @@ type BackendListenerSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type BackendWorkerSpec struct {
@@ -220,6 +224,8 @@ type BackendWorkerSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type BackendCronSpec struct {
@@ -229,6 +235,8 @@ type BackendCronSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type SystemSpec struct {

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -399,6 +399,8 @@ type ZyncSpec struct {
 	DatabaseAffinity *v1.Affinity `json:"databaseAffinity,omitempty"`
 	// +optional
 	DatabaseTolerations []v1.Toleration `json:"databaseTolerations,omitempty"`
+	// +optional
+	DatabaseResources *v1.ResourceRequirements `json:"databaseResources,omitempty"`
 
 	// +optional
 	AppSpec *ZyncAppSpec `json:"appSpec,omitempty"`
@@ -414,6 +416,8 @@ type ZyncAppSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type ZyncQueSpec struct {
@@ -423,6 +427,8 @@ type ZyncQueSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type HighAvailabilitySpec struct {

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -165,6 +165,8 @@ type ApicastProductionSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type ApicastStagingSpec struct {
@@ -174,6 +176,8 @@ type ApicastStagingSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// +optional
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type BackendSpec struct {

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -497,6 +497,11 @@ func (in *ApicastProductionSpec) DeepCopyInto(out *ApicastProductionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -580,6 +585,11 @@ func (in *ApicastStagingSpec) DeepCopyInto(out *ApicastStagingSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -1377,6 +1377,11 @@ func (in *ZyncAppSpec) DeepCopyInto(out *ZyncAppSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -1409,6 +1414,11 @@ func (in *ZyncQueSpec) DeepCopyInto(out *ZyncQueSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1447,6 +1457,11 @@ func (in *ZyncSpec) DeepCopyInto(out *ZyncSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.DatabaseResources != nil {
+		in, out := &in.DatabaseResources, &out.DatabaseResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AppSpec != nil {
 		in, out := &in.AppSpec, &out.AppSpec

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -952,6 +952,21 @@ func (in *SystemAppSpec) DeepCopyInto(out *SystemAppSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.MasterContainerResources != nil {
+		in, out := &in.MasterContainerResources, &out.MasterContainerResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ProviderContainerResources != nil {
+		in, out := &in.ProviderContainerResources, &out.ProviderContainerResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DeveloperContainerResources != nil {
+		in, out := &in.DeveloperContainerResources, &out.DeveloperContainerResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -1068,6 +1083,11 @@ func (in *SystemMySQLSpec) DeepCopyInto(out *SystemMySQLSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -1160,6 +1180,11 @@ func (in *SystemPostgreSQLSpec) DeepCopyInto(out *SystemPostgreSQLSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -1231,6 +1256,11 @@ func (in *SystemSidekiqSpec) DeepCopyInto(out *SystemSidekiqSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -1269,6 +1299,11 @@ func (in *SystemSpec) DeepCopyInto(out *SystemSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.MemcachedResources != nil {
+		in, out := &in.MemcachedResources, &out.MemcachedResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RedisImage != nil {
 		in, out := &in.RedisImage, &out.RedisImage
 		*out = new(string)
@@ -1290,6 +1325,11 @@ func (in *SystemSpec) DeepCopyInto(out *SystemSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.RedisResources != nil {
+		in, out := &in.RedisResources, &out.RedisResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FileStorageSpec != nil {
 		in, out := &in.FileStorageSpec, &out.FileStorageSpec
@@ -1343,6 +1383,11 @@ func (in *SystemSphinxSpec) DeepCopyInto(out *SystemSphinxSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -624,6 +624,11 @@ func (in *BackendCronSpec) DeepCopyInto(out *BackendCronSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -656,6 +661,11 @@ func (in *BackendListenerSpec) DeepCopyInto(out *BackendListenerSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -721,6 +731,11 @@ func (in *BackendSpec) DeepCopyInto(out *BackendSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RedisResources != nil {
+		in, out := &in.RedisResources, &out.RedisResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ListenerSpec != nil {
 		in, out := &in.ListenerSpec, &out.ListenerSpec
 		*out = new(BackendListenerSpec)
@@ -768,6 +783,11 @@ func (in *BackendWorkerSpec) DeepCopyInto(out *BackendWorkerSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }


### PR DESCRIPTION
This PR adds configurable resource requirements for APIManager components.

### Summary of the implemented behaviour

* Configurable resource requirements per component has been added
* When resource requirements are not specified at component level the global defaults for the component are used for it (if enabled)
* When resource requirements are specified at component level, they take over preference over the global default and they follow a REPLACE behaviour (instead of merge behaviour) with the defaults.

### Detailed implemented behaviour

* global-level defaults for resource limits and requests for the components of 3scale are provided. This global-level defaults can be enabled or disabled through a CR attribute that already existed before this PR, named 'resourceRequirementsEnabled'.
* component-level *resources* attribute is provided at component level (for example spec.backend.listenerSpec.resources attribute):
 * If it is not set by the user or set to nil and the global-level CR attribute is not set to true then no resource limits and/or requests are enforced
 * If it is not set by the user or set to nil and the global-level CR attribute is set to true then the defaults for that given component are set
 * If it is set by the user to a non-nil value then the resources requests and limits set are the ones specified by the user with a REPLACE behaviour, not a merge behavior. Global defaults are not used for that component then, independently of the value of the global-level CR attribute. In this case, omitting a limit, request or cpu,memory inside a limit o request is equivalent to not enforcing it for that component. This is the same behavior that ResourceLimits have in Kubernetes.

#### Possible use case scenarios
1. The user wants to have default limits and requests for all components enabled and wants to modify them for a specific DeploymentConfig
  - The user is able to do that by setting the global resourceRequirementsEnabled attribute to true (default behavior) and then specifying the desired
    values on the corresponding *resources* attribute provided at component level in the APIManager CR
2. The user wants to have default limits and requests for all components disabled and wants to set them with custom values for a specific DeploymentConfig
  - The user is able to do that by setting the global resourceRequirementsEnabled attribute to false and then specifying the desired values on the
    corresponding *resources* attribute provided at component level in the APIManager CR
  - Limitation: The user has no way to specify not having a default limit and having a custom request for that same component or viceversa
3. The user wants to have default limits and requests for all components enabled and wants to disable them for a specific DeploymentConfig
  - The user is able to do that by setting the global resourceRequirementsEnabled attribute to true (default behavior) and then setting the corresponding
    *resources* attribute provided at component level in the APIManager CR as the empty map value `{}`

#### Unsupported scenarios

Basically the ones that involve a potentially desired merge behavior between global defaults and custom values:
1. On a given component, having a global default resource request and a custom resource limit for that same component or viceversa
2. On a given component, not having a global default resource request and having a custom resource limit for the same component or viceversa
3. On a given component, having a global default CPU and having custom Memory, or having global default Memory and having custom CPU for resource requirements
4. On a given component, having a global default CPU and having custom Memory, or having global default Memory and using custom CPU  for resource limits

Allowing those unsupported scenarios would require us to stop using the v1.ResourceRequirements type provided by Kubernetes in our CR and provide our own type where we can differentiate between setting resource requests to nil or empty, as the Kubernetes implementation treats those values with the same behavior, which is not enforcing them in that case.
The alternative implementation:
* Increases complexity
* May not be intuitive for users as it differs from how v1.ResourceRequirements field works (nil, vs empty, ...)
* Removes flexibility. Right now by reusing v1.ResourceRequirements other possible additional resources can be specified potentially, we would not be limited to CPU and requests. We would not be able to take advantage on changes/improvements on that type
* Allows more configuration combinations between defaults and custom resources at both requests/limits level and cpu/memory inside requests/limits
* Opens up new additional questions about how to specify cpus and memory and other potential resources (provide a map as kubernetes does, attribute fields? use Quantity attribute? etc...)

- [x] Documentation