### PR TITLE
Add system-app prometheus monitoring

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -97,14 +97,12 @@ const (
 )
 
 const (
-	SystemSidekiqMetricsPort = 9394
-)
-
-const (
-	SystemAppPrometheusExporterPortEnvVarName = "PROMETHEUS_EXPORTER_PORT"
-	SystemAppMasterContainerPrometheusPort    = 9395
-	SystemAppProviderContainerPrometheusPort  = 9396
-	SystemAppDeveloperContainerPrometheusPort = 9394
+	SystemAppPrometheusExporterPortEnvVarName     = "PROMETHEUS_EXPORTER_PORT"
+	SystemSidekiqPrometheusExporterPortEnvVarName = "PROMETHEUS_EXPORTER_PORT"
+	SystemSidekiqMetricsPort                      = 9394
+	SystemAppMasterContainerPrometheusPort        = 9395
+	SystemAppProviderContainerPrometheusPort      = 9396
+	SystemAppDeveloperContainerPrometheusPort     = 9394
 )
 
 type System struct {
@@ -270,6 +268,15 @@ func (system *System) buildAppDeveloperContainerEnv() []v1.EnvVar {
 	result := system.buildSystemBaseEnv()
 	if system.Options.AppMetrics {
 		result = append(result, helper.EnvVarFromValue(SystemAppPrometheusExporterPortEnvVarName, strconv.Itoa(SystemAppDeveloperContainerPrometheusPort)))
+	}
+
+	return result
+}
+
+func (system *System) buildSystemSidekiqContainerEnv() []v1.EnvVar {
+	result := system.buildSystemBaseEnv()
+	if system.Options.SideKiqMetrics {
+		result = append(result, helper.EnvVarFromValue(SystemSidekiqPrometheusExporterPortEnvVarName, strconv.Itoa(SystemSidekiqMetricsPort)))
 	}
 
 	return result
@@ -583,16 +590,10 @@ func (system *System) AppDeploymentConfig() *appsv1.DeploymentConfig {
 					Volumes:     system.appPodVolumes(),
 					Containers: []v1.Container{
 						v1.Container{
-							Name:  "system-master",
-							Image: "amp-system:latest",
-							Args:  []string{"env", "TENANT_MODE=master", "PORT=3002", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
-							Ports: []v1.ContainerPort{
-								v1.ContainerPort{
-									Name:          "master",
-									HostPort:      0,
-									ContainerPort: 3002,
-									Protocol:      v1.ProtocolTCP},
-							},
+							Name:         "system-master",
+							Image:        "amp-system:latest",
+							Args:         []string{"env", "TENANT_MODE=master", "PORT=3002", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
+							Ports:        system.appMasterPorts(),
 							Env:          system.buildAppMasterContainerEnv(),
 							Resources:    *system.Options.AppMasterContainerResourceRequirements,
 							VolumeMounts: system.appMasterContainerVolumeMounts(),
@@ -632,16 +633,10 @@ func (system *System) AppDeploymentConfig() *appsv1.DeploymentConfig {
 							StdinOnce:       false,
 							TTY:             false,
 						}, v1.Container{
-							Name:  "system-provider",
-							Image: "amp-system:latest",
-							Args:  []string{"env", "TENANT_MODE=provider", "PORT=3000", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
-							Ports: []v1.ContainerPort{
-								v1.ContainerPort{
-									Name:          "provider",
-									HostPort:      0,
-									ContainerPort: 3000,
-									Protocol:      v1.ProtocolTCP},
-							},
+							Name:         "system-provider",
+							Image:        "amp-system:latest",
+							Args:         []string{"env", "TENANT_MODE=provider", "PORT=3000", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
+							Ports:        system.appProviderPorts(),
 							Env:          system.buildAppProviderContainerEnv(),
 							Resources:    *system.Options.AppProviderContainerResourceRequirements,
 							VolumeMounts: system.appProviderContainerVolumeMounts(),
@@ -681,16 +676,10 @@ func (system *System) AppDeploymentConfig() *appsv1.DeploymentConfig {
 							StdinOnce:       false,
 							TTY:             false,
 						}, v1.Container{
-							Name:  "system-developer",
-							Image: "amp-system:latest",
-							Args:  []string{"env", "PORT=3001", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
-							Ports: []v1.ContainerPort{
-								v1.ContainerPort{
-									Name:          "developer",
-									HostPort:      0,
-									ContainerPort: 3001,
-									Protocol:      v1.ProtocolTCP},
-							},
+							Name:         "system-developer",
+							Image:        "amp-system:latest",
+							Args:         []string{"env", "PORT=3001", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
+							Ports:        system.appDeveloperPorts(),
 							Env:          system.buildAppDeveloperContainerEnv(),
 							Resources:    *system.Options.AppDeveloperContainerResourceRequirements,
 							VolumeMounts: system.appDeveloperContainerVolumeMounts(),
@@ -851,7 +840,7 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 							Name:            SystemSidekiqName,
 							Image:           "amp-system:latest",
 							Args:            []string{"rake", "sidekiq:worker", "RAILS_MAX_THREADS=25"},
-							Env:             system.buildSystemBaseEnv(),
+							Env:             system.buildSystemSidekiqContainerEnv(),
 							Resources:       *system.Options.SidekiqContainerResourceRequirements,
 							VolumeMounts:    system.sidekiqContainerVolumeMounts(),
 							ImagePullPolicy: v1.PullIfNotPresent,
@@ -1288,6 +1277,42 @@ func (system *System) sideKiqPorts() []v1.ContainerPort {
 
 	if system.Options.SideKiqMetrics {
 		ports = append(ports, v1.ContainerPort{Name: "metrics", ContainerPort: SystemSidekiqMetricsPort, Protocol: v1.ProtocolTCP})
+	}
+
+	return ports
+}
+
+func (system *System) appMasterPorts() []v1.ContainerPort {
+	var ports []v1.ContainerPort
+
+	ports = append(ports, v1.ContainerPort{Name: "master", HostPort: 0, ContainerPort: 3002, Protocol: v1.ProtocolTCP})
+
+	if system.Options.AppMetrics {
+		ports = append(ports, v1.ContainerPort{Name: "master-metrics", ContainerPort: SystemAppMasterContainerPrometheusPort, Protocol: v1.ProtocolTCP})
+	}
+
+	return ports
+}
+
+func (system *System) appProviderPorts() []v1.ContainerPort {
+	var ports []v1.ContainerPort
+
+	ports = append(ports, v1.ContainerPort{Name: "provider", HostPort: 0, ContainerPort: 3000, Protocol: v1.ProtocolTCP})
+
+	if system.Options.AppMetrics {
+		ports = append(ports, v1.ContainerPort{Name: "prov-metrics", ContainerPort: SystemAppProviderContainerPrometheusPort, Protocol: v1.ProtocolTCP})
+	}
+
+	return ports
+}
+
+func (system *System) appDeveloperPorts() []v1.ContainerPort {
+	var ports []v1.ContainerPort
+
+	ports = append(ports, v1.ContainerPort{Name: "developer", HostPort: 0, ContainerPort: 3001, Protocol: v1.ProtocolTCP})
+
+	if system.Options.AppMetrics {
+		ports = append(ports, v1.ContainerPort{Name: "dev-metrics", ContainerPort: SystemAppDeveloperContainerPrometheusPort, Protocol: v1.ProtocolTCP})
 	}
 
 	return ports

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -30,6 +30,37 @@ func (system *System) SystemSidekiqPodMonitor() *monitoringv1.PodMonitor {
 	}
 }
 
+func (system *System) SystemAppPodMonitor() *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "system-app",
+			Labels: system.Options.CommonAppLabels,
+		},
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+				{
+					Port:   SystemAppMasterContainerMetricsPortName,
+					Path:   "/metrics",
+					Scheme: "http",
+				},
+				{
+					Port:   SystemAppProviderContainerMetricsPortName,
+					Path:   "/metrics",
+					Scheme: "http",
+				},
+				{
+					Port:   SystemAppDeveloperContainerMetricsPortName,
+					Path:   "/metrics",
+					Scheme: "http",
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: system.Options.CommonAppLabels,
+			},
+		},
+	}
+}
+
 func SystemGrafanaDashboard(ns string) *grafanav1alpha1.GrafanaDashboard {
 	data := &struct {
 		Namespace string

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -93,6 +93,7 @@ type SystemOptions struct {
 	MemcachedLabels          map[string]string `validate:"required"`
 	SMTPLabels               map[string]string `validate:"required"`
 	SideKiqMetrics           bool
+	AppMetrics               bool
 
 	IncludeOracleOptionalSettings bool
 }

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -65,6 +65,7 @@ func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, er
 	s.setReplicas()
 
 	s.options.SideKiqMetrics = true
+	s.options.AppMetrics = true
 	s.options.IncludeOracleOptionalSettings = true
 
 	err = s.options.Validate()

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -385,6 +385,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		MemcachedLabels:               testSystemMemcachedLabels(),
 		SMTPLabels:                    testSystemSMTPLabels(),
 		SideKiqMetrics:                true,
+		AppMetrics:                    true,
 		IncludeOracleOptionalSettings: true,
 	}
 

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -176,6 +176,11 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
+	err = r.ReconcilePodMonitor(system.SystemAppPodMonitor(), reconcilers.CreateOnlyMutator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	err = r.ReconcileGrafanaDashboard(component.SystemGrafanaDashboard(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -33,6 +37,14 @@ func (u *UpgradeApiManager) Upgrade() (reconcile.Result, error) {
 	res, err := u.upgradeImages()
 	if err != nil {
 		return res, fmt.Errorf("Upgrading images: %w", err)
+	}
+	if res.Requeue {
+		return res, nil
+	}
+
+	res, err = u.upgradeMonitoringSettings()
+	if err != nil {
+		return res, fmt.Errorf("Upgrading monitoring settings: %w", err)
 	}
 	if res.Requeue {
 		return res, nil
@@ -392,6 +404,114 @@ func (u *UpgradeApiManager) findDeploymentTriggerOnImageChange(triggerPolicies [
 	}
 
 	return result, nil
+}
+
+func (u *UpgradeApiManager) upgradeMonitoringSettings() (reconcile.Result, error) {
+	updated := false
+
+	// Port and environment variable are exposed in DC for monitoring
+	updatedTmp, err := u.ensureSystemAppMonitoringSettings()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	updated = updated || updatedTmp
+
+	// We explicitely set the metrics environment variable in system-sidekiq
+	// for clarity
+	updatedTmp, err = u.ensureSystemSidekiqMonitoringSettings()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	updated = updated || updatedTmp
+
+	return reconcile.Result{Requeue: updated}, nil
+}
+
+func (u *UpgradeApiManager) ensureSystemSidekiqMonitoringSettings() (bool, error) {
+	existing := &appsv1.DeploymentConfig{}
+	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: component.SystemSidekiqName, Namespace: u.apiManager.Namespace}, existing)
+	if err != nil {
+		return false, err
+	}
+
+	if len(existing.Spec.Template.Spec.Containers) != 1 {
+		return false, fmt.Errorf("DeploymentConfig %s spec.template.spec.containers length is %d, should be 1",
+			component.SystemSidekiqName, len(existing.Spec.Template.Spec.Containers))
+	}
+
+	update := false
+	if _, ok := helper.FindEnvVar(existing.Spec.Template.Spec.Containers[0].Env, component.SystemSidekiqPrometheusExporterPortEnvVarName); !ok {
+		existing.Spec.Template.Spec.Containers[0].Env = append(
+			existing.Spec.Template.Spec.Containers[0].Env,
+			helper.EnvVarFromValue(component.SystemSidekiqPrometheusExporterPortEnvVarName, strconv.Itoa(component.SystemSidekiqMetricsPort)),
+		)
+		update = true
+	}
+
+	if update {
+		u.Logger().Info(fmt.Sprintf("Adding prometheus metrics environment variable to DC %s", component.SystemSidekiqName))
+		err = u.UpdateResource(existing)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return update, nil
+}
+
+func (u *UpgradeApiManager) ensureSystemAppMonitoringSettings() (bool, error) {
+	existing := &appsv1.DeploymentConfig{}
+	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: component.SystemAppDeploymentName, Namespace: u.apiManager.Namespace}, existing)
+	if err != nil {
+		return false, err
+	}
+
+	if len(existing.Spec.Template.Spec.Containers) != 3 {
+		return false, fmt.Errorf("DeploymentConfig %s spec.template.spec.containers length is %d, should be 3",
+			existing.Name, len(existing.Spec.Template.Spec.Containers))
+	}
+
+	update := false
+	for idx := range existing.Spec.Template.Spec.Containers {
+		container := &existing.Spec.Template.Spec.Containers[idx]
+		var containerPrometheusMetricsPort int
+		var containerPrometheusMetricsPortName string
+		switch containerName := container.Name; {
+		case containerName == component.SystemAppMasterContainerName:
+			containerPrometheusMetricsPort = component.SystemAppMasterContainerPrometheusPort
+			containerPrometheusMetricsPortName = component.SystemAppMasterContainerMetricsPortName
+		case containerName == component.SystemAppProviderContainerName:
+			containerPrometheusMetricsPort = component.SystemAppProviderContainerPrometheusPort
+			containerPrometheusMetricsPortName = component.SystemAppProviderContainerMetricsPortName
+		case containerName == component.SystemAppDeveloperContainerName:
+			containerPrometheusMetricsPort = component.SystemAppDeveloperContainerPrometheusPort
+			containerPrometheusMetricsPortName = component.SystemAppDeveloperContainerMetricsPortName
+		default:
+			return false, fmt.Errorf("DeploymentConfig '%s' has unrecognized container name '%s'", existing.Name, containerName)
+		}
+
+		if _, ok := helper.FindEnvVar(container.Env, component.SystemAppPrometheusExporterPortEnvVarName); !ok {
+			container.Env = append(
+				container.Env,
+				helper.EnvVarFromValue(component.SystemAppPrometheusExporterPortEnvVarName, strconv.Itoa(containerPrometheusMetricsPort)),
+			)
+			update = true
+		}
+		if _, ok := helper.FindContainerPortByName(container.Ports, containerPrometheusMetricsPortName); !ok {
+			container.Ports = append(container.Ports, v1.ContainerPort{Name: containerPrometheusMetricsPortName, ContainerPort: int32(containerPrometheusMetricsPort), Protocol: v1.ProtocolTCP})
+			update = true
+		}
+	}
+
+	if update {
+		u.Logger().Info(fmt.Sprintf("Adding prometheus metrics environment variable and ports to DC %s", existing.Name))
+		err = u.UpdateResource(existing)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return update, nil
 }
 
 func (u *UpgradeApiManager) Logger() logr.Logger {


### PR DESCRIPTION
This PR adds Prometheus Monitoring for system-app containers.

The expected environment variables and port numberings for system-app containers Prometheus functionality has been defined in https://github.com/3scale/3scale-operator/issues/453. This PR uses thoses values.

- [x] Upgrade
- [x] Testing upgrade
