### PR TITLE
[system] Use the only unique Dockerfile for nightly build

### DIFF
--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -64,7 +64,7 @@ objects:
       dockerStrategy:
         pullSecret:
           name: "${PULLSECRET_NAME}"
-        dockerfilePath: openshift/system/Dockerfile.on_prem
+        dockerfilePath: openshift/system/Dockerfile
         forcePull: true
 
 - apiVersion: v1


### PR DESCRIPTION
We are moving the Dockerfile.on_prem to Dockerfile

Requires: https://github.com/3scale/porta/pull/2132