### PR TITLE
 fix nil pointer when provider account not found

### DIFF
--- a/pkg/controller/backend/backend_controller.go
+++ b/pkg/controller/backend/backend_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcileBackend) reconcile(backendResource *capabilitiesv1beta1.Backen
 
 	providerAccount, err := controllerhelper.LookupProviderAccount(r.Client(), backendResource.Namespace, backendResource.Spec.ProviderAccountRef, logger)
 	if err != nil {
-		statusReconciler := NewStatusReconciler(r.BaseReconciler, backendResource, nil, providerAccount.AdminURLStr, err)
+		statusReconciler := NewStatusReconciler(r.BaseReconciler, backendResource, nil, "", err)
 		return statusReconciler, err
 	}
 

--- a/pkg/controller/product/product_controller.go
+++ b/pkg/controller/product/product_controller.go
@@ -186,7 +186,7 @@ func (r *ReconcileProduct) reconcile(productResource *capabilitiesv1beta1.Produc
 
 	providerAccount, err := controllerhelper.LookupProviderAccount(r.Client(), productResource.Namespace, productResource.Spec.ProviderAccountRef, logger)
 	if err != nil {
-		statusReconciler := NewStatusReconciler(r.BaseReconciler, productResource, nil, providerAccount.AdminURLStr, err)
+		statusReconciler := NewStatusReconciler(r.BaseReconciler, productResource, nil, "", err)
 		return statusReconciler, err
 	}
 


### PR DESCRIPTION
product, backend controllers: fix nil pointer when provider account not found
