### PR TITLE
Update documentation to remove apicast redis reference

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -322,7 +322,7 @@ that should be set on it.
 
 | **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
 | --- | --- | --- | --- | --- | --- |
-| Enabled | `enabled` | bool | No | `false` | Enable to use external system database, backend redis, system redis and apicast redis databases|
+| Enabled | `enabled` | bool | No | `false` | Enable to use external system database, backend redis, and system redis databases|
 
 When HighAvailability is enabled the following secrets have to be pre-created by the user:
 


### PR DESCRIPTION
apicast does not make use of redis anymore. That part of
the documentation was outdated in that regard.