### PR TITLE
Update severity of some 3scale prometheus alerts

### DIFF
--- a/pkg/3scale/amp/component/apicast_monitoring.go
+++ b/pkg/3scale/amp/component/apicast_monitoring.go
@@ -136,7 +136,7 @@ func ApicastPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 							Expr: intstr.FromString(fmt.Sprintf(`sum(rate(apicast_status{namespace='%s', status=~"^4.."}[1m])) / sum(rate(apicast_status{namespace='%s'}[1m])) * 100 > 5`, ns, ns)),
 							For:  "5m",
 							Labels: map[string]string{
-								"severity": "critical",
+								"severity": "warning",
 							},
 						},
 						{

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -104,7 +104,7 @@ func SystemSidekiqPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 							Expr: intstr.FromString(fmt.Sprintf(`avg(sidekiq_job_runtime_seconds_sum{queue="zync",worker="ZyncWorker",namespace="%s"}) > 300`, ns)),
 							For:  "10m",
 							Labels: map[string]string{
-								"severity": "critical",
+								"severity": "warning",
 							},
 						},
 					},


### PR DESCRIPTION
Solves part of https://github.com/3scale/platform/issues/355

Severity `critical` must be configured on very important alerts with customer impact, they are the ones paging oncall SRE, so there is needed a very good reason to be treated as `critical` (at least on the default values).

For that reason, it has been updated severity on some alerts (from `critical` to `warning`):
- **ThreescaleApicastHttp4xxErrorRate**: after agreed with @eloycoto, having a high number of 4XX http requests can occur by many reasons (auth is not valid, service is not being found, mapping rule does not exists, upstream is sending a 4XX status code, used policy is configured to send 4XX status code), most of them should never be treated as a `critical` alert
- **SystemSidekiqZyncRuntime**: this is just an example of a possible system alert (not a real one), in fact system monitoring is being completely redefined right now (using new libraries, renaming all metrics, updating scrapping format without auth_basic, updating scrapping container port...). Actually, this alert will eventually disappear, so at least by the moment let's just update severity  to `warning` to not cause possible unnecessary oncall alerts