### PR TITLE
Update deprecated CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
 
   tag-operator-image-master:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -405,7 +405,7 @@ jobs:
 
   tag-operator-image-release:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -425,7 +425,7 @@ jobs:
 
   deploy_templates:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     resource_class: large
     steps:
@@ -439,7 +439,7 @@ jobs:
       components_imagestream_tag_name:
         type: string
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     resource_class: large
     steps:
@@ -463,7 +463,7 @@ jobs:
 
   run-operator-e2e-test:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:202007-01
       docker_layer_caching: true
     resource_class: large
     steps:


### PR DESCRIPTION
As per https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572, some linux machine images have been deprecated in CircleCI

This PR updates the deprecated `circleci/classic:latest` images by `ubuntu-1604:202007-01` as suggested in the provided link. There's also an ubuntu 20 based image but is still in beta so we are not using it yet.

The update of image implies an update of operating system from Ubuntu 14.04 to Ubuntu 16.04.