### PR TITLE
reconcile system database secret when external databases enabled

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -410,6 +410,40 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  stringData:
+    REDIS_QUEUES_SENTINEL_HOSTS: ""
+    REDIS_QUEUES_SENTINEL_ROLE: ""
+    REDIS_QUEUES_URL: redis://backend-redis:6379/1
+    REDIS_STORAGE_SENTINEL_HOSTS: ""
+    REDIS_STORAGE_SENTINEL_ROLE: ""
+    REDIS_STORAGE_URL: redis://backend-redis:6379/0
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_SENTINEL_HOSTS: ""
+    MESSAGE_BUS_SENTINEL_ROLE: ""
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    SENTINEL_HOSTS: ""
+    SENTINEL_ROLE: ""
+    URL: ${SYSTEM_REDIS_URL}
+  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -1040,22 +1074,6 @@ objects:
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
     username: ${SYSTEM_BACKEND_USERNAME}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: backend
-    name: backend-redis
-  stringData:
-    REDIS_QUEUES_SENTINEL_HOSTS: ""
-    REDIS_QUEUES_SENTINEL_ROLE: ""
-    REDIS_QUEUES_URL: redis://backend-redis:6379/1
-    REDIS_STORAGE_SENTINEL_HOSTS: ""
-    REDIS_STORAGE_SENTINEL_ROLE: ""
-    REDIS_STORAGE_URL: redis://backend-redis:6379/0
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3450,24 +3468,6 @@ objects:
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
     URL: http://system-master:3000/master/events/import
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-    name: system-redis
-  stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
-    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
-    SENTINEL_HOSTS: ""
-    SENTINEL_ROLE: ""
-    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -409,6 +409,40 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  stringData:
+    REDIS_QUEUES_SENTINEL_HOSTS: ""
+    REDIS_QUEUES_SENTINEL_ROLE: ""
+    REDIS_QUEUES_URL: redis://backend-redis:6379/1
+    REDIS_STORAGE_SENTINEL_HOSTS: ""
+    REDIS_STORAGE_SENTINEL_ROLE: ""
+    REDIS_STORAGE_URL: redis://backend-redis:6379/0
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_SENTINEL_HOSTS: ""
+    MESSAGE_BUS_SENTINEL_ROLE: ""
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    SENTINEL_HOSTS: ""
+    SENTINEL_ROLE: ""
+    URL: ${SYSTEM_REDIS_URL}
+  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -1039,22 +1073,6 @@ objects:
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
     username: ${SYSTEM_BACKEND_USERNAME}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: backend
-    name: backend-redis
-  stringData:
-    REDIS_QUEUES_SENTINEL_HOSTS: ""
-    REDIS_QUEUES_SENTINEL_ROLE: ""
-    REDIS_QUEUES_URL: redis://backend-redis:6379/1
-    REDIS_STORAGE_SENTINEL_HOSTS: ""
-    REDIS_STORAGE_SENTINEL_ROLE: ""
-    REDIS_STORAGE_URL: redis://backend-redis:6379/0
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3267,24 +3285,6 @@ objects:
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
     URL: http://system-master:3000/master/events/import
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-    name: system-redis
-  stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
-    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
-    SENTINEL_HOSTS: ""
-    SENTINEL_ROLE: ""
-    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -180,6 +180,40 @@ objects:
   metadata:
     creationTimestamp: null
     name: amp
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  stringData:
+    REDIS_QUEUES_SENTINEL_HOSTS: ${BACKEND_REDIS_QUEUE_SENTINEL_HOSTS}
+    REDIS_QUEUES_SENTINEL_ROLE: ${BACKEND_REDIS_QUEUE_SENTINEL_ROLE}
+    REDIS_QUEUES_URL: ${BACKEND_REDIS_QUEUES_ENDPOINT}
+    REDIS_STORAGE_SENTINEL_HOSTS: ${BACKEND_REDIS_STORAGE_SENTINEL_HOSTS}
+    REDIS_STORAGE_SENTINEL_ROLE: ${BACKEND_REDIS_STORAGE_SENTINEL_ROLE}
+    REDIS_STORAGE_URL: ${BACKEND_REDIS_STORAGE_ENDPOINT}
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_SENTINEL_HOSTS: ${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS}
+    MESSAGE_BUS_SENTINEL_ROLE: ${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE}
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    SENTINEL_HOSTS: ${SYSTEM_REDIS_SENTINEL_HOSTS}
+    SENTINEL_ROLE: ${SYSTEM_REDIS_SENTINEL_ROLE}
+    URL: ${SYSTEM_REDIS_URL}
+  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -680,22 +714,6 @@ objects:
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
     username: ${SYSTEM_BACKEND_USERNAME}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: backend
-    name: backend-redis
-  stringData:
-    REDIS_QUEUES_SENTINEL_HOSTS: ${BACKEND_REDIS_QUEUE_SENTINEL_HOSTS}
-    REDIS_QUEUES_SENTINEL_ROLE: ${BACKEND_REDIS_QUEUE_SENTINEL_ROLE}
-    REDIS_QUEUES_URL: ${BACKEND_REDIS_QUEUES_ENDPOINT}
-    REDIS_STORAGE_SENTINEL_HOSTS: ${BACKEND_REDIS_STORAGE_SENTINEL_HOSTS}
-    REDIS_STORAGE_SENTINEL_ROLE: ${BACKEND_REDIS_STORAGE_SENTINEL_ROLE}
-    REDIS_STORAGE_URL: ${BACKEND_REDIS_STORAGE_ENDPOINT}
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -2816,24 +2834,6 @@ objects:
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
     URL: http://system-master:3000/master/events/import
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-    name: system-redis
-  stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS}
-    MESSAGE_BUS_SENTINEL_ROLE: ${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE}
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
-    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
-    SENTINEL_HOSTS: ${SYSTEM_REDIS_SENTINEL_HOSTS}
-    SENTINEL_ROLE: ${SYSTEM_REDIS_SENTINEL_ROLE}
-    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -415,6 +415,40 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  stringData:
+    REDIS_QUEUES_SENTINEL_HOSTS: ""
+    REDIS_QUEUES_SENTINEL_ROLE: ""
+    REDIS_QUEUES_URL: redis://backend-redis:6379/1
+    REDIS_STORAGE_SENTINEL_HOSTS: ""
+    REDIS_STORAGE_SENTINEL_ROLE: ""
+    REDIS_STORAGE_URL: redis://backend-redis:6379/0
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_SENTINEL_HOSTS: ""
+    MESSAGE_BUS_SENTINEL_ROLE: ""
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    SENTINEL_HOSTS: ""
+    SENTINEL_ROLE: ""
+    URL: ${SYSTEM_REDIS_URL}
+  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -1069,22 +1103,6 @@ objects:
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
     username: ${SYSTEM_BACKEND_USERNAME}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: backend
-    name: backend-redis
-  stringData:
-    REDIS_QUEUES_SENTINEL_HOSTS: ""
-    REDIS_QUEUES_SENTINEL_ROLE: ""
-    REDIS_QUEUES_URL: redis://backend-redis:6379/1
-    REDIS_STORAGE_SENTINEL_HOSTS: ""
-    REDIS_STORAGE_SENTINEL_ROLE: ""
-    REDIS_STORAGE_URL: redis://backend-redis:6379/0
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3289,24 +3307,6 @@ objects:
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
     URL: http://system-master:3000/master/events/import
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-    name: system-redis
-  stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
-    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
-    SENTINEL_HOSTS: ""
-    SENTINEL_ROLE: ""
-    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -416,6 +416,40 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  stringData:
+    REDIS_QUEUES_SENTINEL_HOSTS: ""
+    REDIS_QUEUES_SENTINEL_ROLE: ""
+    REDIS_QUEUES_URL: redis://backend-redis:6379/1
+    REDIS_STORAGE_SENTINEL_HOSTS: ""
+    REDIS_STORAGE_SENTINEL_ROLE: ""
+    REDIS_STORAGE_URL: redis://backend-redis:6379/0
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_SENTINEL_HOSTS: ""
+    MESSAGE_BUS_SENTINEL_ROLE: ""
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    SENTINEL_HOSTS: ""
+    SENTINEL_ROLE: ""
+    URL: ${SYSTEM_REDIS_URL}
+  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -1070,22 +1104,6 @@ objects:
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
     username: ${SYSTEM_BACKEND_USERNAME}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: backend
-    name: backend-redis
-  stringData:
-    REDIS_QUEUES_SENTINEL_HOSTS: ""
-    REDIS_QUEUES_SENTINEL_ROLE: ""
-    REDIS_QUEUES_URL: redis://backend-redis:6379/1
-    REDIS_STORAGE_SENTINEL_HOSTS: ""
-    REDIS_STORAGE_SENTINEL_ROLE: ""
-    REDIS_STORAGE_URL: redis://backend-redis:6379/0
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3521,24 +3539,6 @@ objects:
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
     URL: http://system-master:3000/master/events/import
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-    name: system-redis
-  stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
-    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
-    SENTINEL_HOSTS: ""
-    SENTINEL_ROLE: ""
-    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -415,6 +415,40 @@ objects:
         type: ""
   status:
     dockerImageRepository: ""
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: backend
+    name: backend-redis
+  stringData:
+    REDIS_QUEUES_SENTINEL_HOSTS: ""
+    REDIS_QUEUES_SENTINEL_ROLE: ""
+    REDIS_QUEUES_URL: redis://backend-redis:6379/1
+    REDIS_STORAGE_SENTINEL_HOSTS: ""
+    REDIS_STORAGE_SENTINEL_ROLE: ""
+    REDIS_STORAGE_URL: redis://backend-redis:6379/0
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ${APP_LABEL}
+      threescale_component: system
+    name: system-redis
+  stringData:
+    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
+    MESSAGE_BUS_SENTINEL_HOSTS: ""
+    MESSAGE_BUS_SENTINEL_ROLE: ""
+    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
+    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
+    SENTINEL_HOSTS: ""
+    SENTINEL_ROLE: ""
+    URL: ${SYSTEM_REDIS_URL}
+  type: Opaque
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -1069,22 +1103,6 @@ objects:
   stringData:
     password: ${SYSTEM_BACKEND_PASSWORD}
     username: ${SYSTEM_BACKEND_USERNAME}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: backend
-    name: backend-redis
-  stringData:
-    REDIS_QUEUES_SENTINEL_HOSTS: ""
-    REDIS_QUEUES_SENTINEL_ROLE: ""
-    REDIS_QUEUES_URL: redis://backend-redis:6379/1
-    REDIS_STORAGE_SENTINEL_HOSTS: ""
-    REDIS_STORAGE_SENTINEL_ROLE: ""
-    REDIS_STORAGE_URL: redis://backend-redis:6379/0
   type: Opaque
 - apiVersion: v1
   kind: Secret
@@ -3338,24 +3356,6 @@ objects:
   stringData:
     PASSWORD: ${SYSTEM_BACKEND_SHARED_SECRET}
     URL: http://system-master:3000/master/events/import
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: ${APP_LABEL}
-      threescale_component: system
-    name: system-redis
-  stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
-    NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
-    SENTINEL_HOSTS: ""
-    SENTINEL_ROLE: ""
-    URL: ${SYSTEM_REDIS_URL}
   type: Opaque
 - apiVersion: v1
   kind: Secret

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -367,28 +367,6 @@ func (backend *Backend) EnvironmentConfigMap() *v1.ConfigMap {
 	}
 }
 
-func (backend *Backend) RedisSecret() *v1.Secret {
-	return &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   BackendSecretBackendRedisSecretName,
-			Labels: backend.Options.CommonLabels,
-		},
-		StringData: map[string]string{
-			BackendSecretBackendRedisStorageURLFieldName:           backend.Options.StorageURL,
-			BackendSecretBackendRedisQueuesURLFieldName:            backend.Options.QueuesURL,
-			BackendSecretBackendRedisStorageSentinelHostsFieldName: backend.Options.StorageSentinelHosts,
-			BackendSecretBackendRedisStorageSentinelRoleFieldName:  backend.Options.StorageSentinelRole,
-			BackendSecretBackendRedisQueuesSentinelHostsFieldName:  backend.Options.QueuesSentinelHosts,
-			BackendSecretBackendRedisQueuesSentinelRoleFieldName:   backend.Options.QueuesSentinelRole,
-		},
-		Type: v1.SecretTypeOpaque,
-	}
-}
-
 func (backend *Backend) buildBackendCommonEnv() []v1.EnvVar {
 	return []v1.EnvVar{
 		helper.EnvVarFromSecret("CONFIG_REDIS_PROXY", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageURLFieldName),

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -8,14 +8,8 @@ import (
 )
 
 type BackendOptions struct {
-	ServiceEndpoint              string `validate:"required"`
-	RouteEndpoint                string `validate:"required"`
-	StorageURL                   string `validate:"required"`
-	QueuesURL                    string `validate:"required"`
-	StorageSentinelHosts         string
-	StorageSentinelRole          string
-	QueuesSentinelHosts          string
-	QueuesSentinelRole           string
+	ServiceEndpoint              string                  `validate:"required"`
+	RouteEndpoint                string                  `validate:"required"`
 	ImageTag                     string                  `validate:"required"`
 	ListenerResourceRequirements v1.ResourceRequirements `validate:"-"`
 	WorkerResourceRequirements   v1.ResourceRequirements `validate:"-"`
@@ -55,14 +49,6 @@ func (b *BackendOptions) Validate() error {
 
 func DefaultBackendServiceEndpoint() string {
 	return "http://backend-listener:3000"
-}
-
-func DefaultBackendRedisStorageURL() string {
-	return "redis://backend-redis:6379/0"
-}
-
-func DefaultBackendRedisQueuesURL() string {
-	return "redis://backend-redis:6379/1"
 }
 
 func DefaultBackendListenerResourceRequirements() v1.ResourceRequirements {
@@ -110,20 +96,4 @@ func DefaultSystemBackendUsername() string {
 
 func DefaultSystemBackendPassword() string {
 	return oprand.String(8)
-}
-
-func DefaultBackendStorageSentinelHosts() string {
-	return ""
-}
-
-func DefaultBackendStorageSentinelRole() string {
-	return ""
-}
-
-func DefaultBackendQueuesSentinelHosts() string {
-	return ""
-}
-
-func DefaultBackendQueuesSentinelRole() string {
-	return ""
 }

--- a/pkg/3scale/amp/component/highavailability.go
+++ b/pkg/3scale/amp/component/highavailability.go
@@ -26,14 +26,57 @@ func (ha *HighAvailability) SystemDatabaseSecret() *v1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: SystemSecretSystemDatabaseSecretName,
-			Labels: map[string]string{
-				"app":                  ha.Options.AppLabel,
-				"threescale_component": "system",
-			},
+			Name:   SystemSecretSystemDatabaseSecretName,
+			Labels: ha.Options.SystemDatabaseLabels,
 		},
 		StringData: map[string]string{
 			SystemSecretSystemDatabaseURLFieldName: ha.Options.SystemDatabaseURL,
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+}
+
+func (ha *HighAvailability) BackendRedisSecret() *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   BackendSecretBackendRedisSecretName,
+			Labels: ha.Options.BackendRedisLabels,
+		},
+		StringData: map[string]string{
+			BackendSecretBackendRedisStorageURLFieldName:           ha.Options.BackendRedisStorageEndpoint,
+			BackendSecretBackendRedisQueuesURLFieldName:            ha.Options.BackendRedisQueuesEndpoint,
+			BackendSecretBackendRedisStorageSentinelHostsFieldName: ha.Options.BackendRedisStorageSentinelHosts,
+			BackendSecretBackendRedisStorageSentinelRoleFieldName:  ha.Options.BackendRedisStorageSentinelRole,
+			BackendSecretBackendRedisQueuesSentinelHostsFieldName:  ha.Options.BackendRedisQueuesSentinelHosts,
+			BackendSecretBackendRedisQueuesSentinelRoleFieldName:   ha.Options.BackendRedisQueuesSentinelRole,
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+}
+
+func (ha *HighAvailability) SystemRedisSecret() *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   SystemSecretSystemRedisSecretName,
+			Labels: ha.Options.SystemRedisLabels,
+		},
+		StringData: map[string]string{
+			SystemSecretSystemRedisURLFieldName:                ha.Options.SystemRedisURL,
+			SystemSecretSystemRedisSentinelHosts:               ha.Options.SystemRedisSentinelsHosts,
+			SystemSecretSystemRedisSentinelRole:                ha.Options.SystemRedisSentinelsRole,
+			SystemSecretSystemRedisMessageBusRedisURLFieldName: ha.Options.SystemMessageBusRedisURL,
+			SystemSecretSystemRedisMessageBusSentinelHosts:     ha.Options.SystemMessageBusRedisSentinelsHosts,
+			SystemSecretSystemRedisMessageBusSentinelRole:      ha.Options.SystemMessageBusRedisSentinelsRole,
+			SystemSecretSystemRedisNamespace:                   ha.Options.SystemRedisNamespace,
+			SystemSecretSystemRedisMessageBusRedisNamespace:    ha.Options.SystemMessageBusRedisNamespace,
 		},
 		Type: v1.SecretTypeOpaque,
 	}

--- a/pkg/3scale/amp/component/highavailability_options.go
+++ b/pkg/3scale/amp/component/highavailability_options.go
@@ -6,7 +6,7 @@ type HighAvailabilityOptions struct {
 	BackendRedisQueuesEndpoint          string `validate:"required"`
 	BackendRedisQueuesSentinelHosts     string
 	BackendRedisQueuesSentinelRole      string
-	BackendRedisStorageEndpoint         string
+	BackendRedisStorageEndpoint         string `validate:"required"`
 	BackendRedisStorageSentinelHosts    string
 	BackendRedisStorageSentinelRole     string
 	SystemDatabaseURL                   string `validate:"required"`

--- a/pkg/3scale/amp/component/highavailability_options.go
+++ b/pkg/3scale/amp/component/highavailability_options.go
@@ -3,20 +3,25 @@ package component
 import "github.com/go-playground/validator/v10"
 
 type HighAvailabilityOptions struct {
-	AppLabel                            string `validate:"required"`
 	BackendRedisQueuesEndpoint          string `validate:"required"`
-	BackendRedisQueuesSentinelHosts     string `validate:"required"`
-	BackendRedisQueuesSentinelRole      string `validate:"required"`
-	BackendRedisStorageEndpoint         string `validate:"required"`
-	BackendRedisStorageSentinelHosts    string `validate:"required"`
-	BackendRedisStorageSentinelRole     string `validate:"required"`
+	BackendRedisQueuesSentinelHosts     string
+	BackendRedisQueuesSentinelRole      string
+	BackendRedisStorageEndpoint         string
+	BackendRedisStorageSentinelHosts    string
+	BackendRedisStorageSentinelRole     string
 	SystemDatabaseURL                   string `validate:"required"`
 	SystemRedisURL                      string `validate:"required"`
-	SystemRedisSentinelsHosts           string `validate:"required"`
-	SystemRedisSentinelsRole            string `validate:"required"`
+	SystemRedisSentinelsHosts           string
+	SystemRedisSentinelsRole            string
+	SystemRedisNamespace                string
 	SystemMessageBusRedisURL            string `validate:"required"`
-	SystemMessageBusRedisSentinelsHosts string `validate:"required"`
-	SystemMessageBusRedisSentinelsRole  string `validate:"required"`
+	SystemMessageBusRedisSentinelsHosts string
+	SystemMessageBusRedisSentinelsRole  string
+	SystemMessageBusRedisNamespace      string
+
+	BackendRedisLabels   map[string]string `validate:"required"`
+	SystemRedisLabels    map[string]string `validate:"required"`
+	SystemDatabaseLabels map[string]string `validate:"required"`
 }
 
 func NewHighAvailabilityOptions() *HighAvailabilityOptions {

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -408,6 +408,28 @@ func (redis *Redis) BackendImageStream() *imagev1.ImageStream {
 	}
 }
 
+func (redis *Redis) BackendRedisSecret() *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   BackendSecretBackendRedisSecretName,
+			Labels: redis.Options.BackendCommonLabels,
+		},
+		StringData: map[string]string{
+			BackendSecretBackendRedisStorageURLFieldName:           redis.Options.BackendStorageURL,
+			BackendSecretBackendRedisQueuesURLFieldName:            redis.Options.BackendQueuesURL,
+			BackendSecretBackendRedisStorageSentinelHostsFieldName: redis.Options.BackendRedisStorageSentinelHosts,
+			BackendSecretBackendRedisStorageSentinelRoleFieldName:  redis.Options.BackendRedisStorageSentinelRole,
+			BackendSecretBackendRedisQueuesSentinelHostsFieldName:  redis.Options.BackendRedisQueuesSentinelHosts,
+			BackendSecretBackendRedisQueuesSentinelRoleFieldName:   redis.Options.BackendRedisQueuesSentinelRole,
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+}
+
 ////// Begin System Redis
 
 func (redis *Redis) SystemDeploymentConfig() *appsv1.DeploymentConfig {
@@ -591,6 +613,30 @@ func (redis *Redis) SystemImageStream() *imagev1.ImageStream {
 				},
 			},
 		},
+	}
+}
+
+func (redis *Redis) SystemRedisSecret() *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   SystemSecretSystemRedisSecretName,
+			Labels: redis.Options.SystemCommonLabels,
+		},
+		StringData: map[string]string{
+			SystemSecretSystemRedisURLFieldName:                redis.Options.SystemRedisURL,
+			SystemSecretSystemRedisSentinelHosts:               redis.Options.SystemRedisSentinelsHosts,
+			SystemSecretSystemRedisSentinelRole:                redis.Options.SystemRedisSentinelsRole,
+			SystemSecretSystemRedisMessageBusRedisURLFieldName: redis.Options.SystemRedisMessageBusURL,
+			SystemSecretSystemRedisMessageBusSentinelHosts:     redis.Options.SystemMessageBusRedisSentinelsHosts,
+			SystemSecretSystemRedisMessageBusSentinelRole:      redis.Options.SystemMessageBusRedisSentinelsRole,
+			SystemSecretSystemRedisNamespace:                   redis.Options.SystemRedisNamespace,
+			SystemSecretSystemRedisMessageBusRedisNamespace:    redis.Options.SystemMessageBusRedisNamespace,
+		},
+		Type: v1.SecretTypeOpaque,
 	}
 }
 

--- a/pkg/3scale/amp/component/redis_options.go
+++ b/pkg/3scale/amp/component/redis_options.go
@@ -29,6 +29,22 @@ type RedisOptions struct {
 	BackendCommonLabels           map[string]string `validate:"required"`
 	BackendRedisLabels            map[string]string `validate:"required"`
 	BackendRedisPodTemplateLabels map[string]string `validate:"required"`
+
+	// secrets
+	BackendStorageURL                   string `validate:"required"`
+	BackendQueuesURL                    string `validate:"required"`
+	BackendRedisQueuesSentinelHosts     string
+	BackendRedisQueuesSentinelRole      string
+	BackendRedisStorageSentinelHosts    string
+	BackendRedisStorageSentinelRole     string
+	SystemRedisURL                      string `validate:"required"`
+	SystemRedisMessageBusURL            string
+	SystemRedisSentinelsHosts           string
+	SystemRedisSentinelsRole            string
+	SystemRedisNamespace                string
+	SystemMessageBusRedisSentinelsHosts string
+	SystemMessageBusRedisSentinelsRole  string
+	SystemMessageBusRedisNamespace      string
 }
 
 func NewRedisOptions() *RedisOptions {
@@ -64,4 +80,60 @@ func DefaultSystemRedisContainerResourceRequirements() *v1.ResourceRequirements 
 			v1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
+}
+
+func DefaultBackendRedisStorageURL() string {
+	return "redis://backend-redis:6379/0"
+}
+
+func DefaultBackendRedisQueuesURL() string {
+	return "redis://backend-redis:6379/1"
+}
+
+func DefaultSystemRedisURL() string {
+	return "redis://system-redis:6379/1"
+}
+
+func DefaultSystemRedisMessageBusURL() string {
+	return ""
+}
+
+func DefaultSystemRedisSentinelHosts() string {
+	return ""
+}
+
+func DefaultSystemRedisSentinelRole() string {
+	return ""
+}
+
+func DefaultSystemMessageBusRedisSentinelHosts() string {
+	return ""
+}
+
+func DefaultSystemMessageBusRedisSentinelRole() string {
+	return ""
+}
+
+func DefaultSystemRedisNamespace() string {
+	return ""
+}
+
+func DefaultSystemMessageBusRedisNamespace() string {
+	return ""
+}
+
+func DefaultBackendStorageSentinelHosts() string {
+	return ""
+}
+
+func DefaultBackendStorageSentinelRole() string {
+	return ""
+}
+
+func DefaultBackendQueuesSentinelHosts() string {
+	return ""
+}
+
+func DefaultBackendQueuesSentinelRole() string {
+	return ""
 }

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -403,30 +403,6 @@ func (system *System) EventsHookSecret() *v1.Secret {
 	}
 }
 
-func (system *System) RedisSecret() *v1.Secret {
-	return &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   SystemSecretSystemRedisSecretName,
-			Labels: system.Options.CommonLabels,
-		},
-		StringData: map[string]string{
-			SystemSecretSystemRedisURLFieldName:                system.Options.RedisURL,
-			SystemSecretSystemRedisSentinelHosts:               *system.Options.RedisSentinelHosts,
-			SystemSecretSystemRedisSentinelRole:                *system.Options.RedisSentinelRole,
-			SystemSecretSystemRedisMessageBusRedisURLFieldName: *system.Options.MessageBusRedisURL,
-			SystemSecretSystemRedisMessageBusSentinelHosts:     *system.Options.MessageBusRedisSentinelHosts,
-			SystemSecretSystemRedisMessageBusSentinelRole:      *system.Options.MessageBusRedisSentinelRole,
-			SystemSecretSystemRedisNamespace:                   *system.Options.RedisNamespace,
-			SystemSecretSystemRedisMessageBusRedisNamespace:    *system.Options.MessageBusRedisNamespace,
-		},
-		Type: v1.SecretTypeOpaque,
-	}
-}
-
 func (system *System) AppSecret() *v1.Secret {
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -32,14 +32,6 @@ type PVCFileStorageOptions struct {
 type SystemOptions struct {
 	MemcachedServers                       string  `validate:"required"`
 	EventHooksURL                          string  `validate:"required"`
-	RedisURL                               string  `validate:"required"`
-	RedisSentinelHosts                     *string `validate:"required"`
-	RedisSentinelRole                      *string `validate:"required"`
-	RedisNamespace                         *string `validate:"required"`
-	MessageBusRedisURL                     *string `validate:"required"`
-	MessageBusRedisSentinelHosts           *string `validate:"required"`
-	MessageBusRedisSentinelRole            *string `validate:"required"`
-	MessageBusRedisNamespace               *string `validate:"required"`
 	ApicastSystemMasterProxyConfigEndpoint string  `validate:"required"`
 	AdminEmail                             *string `validate:"required"`
 
@@ -131,38 +123,6 @@ func DefaultBackendSharedSecret() string {
 
 func DefaultEventHooksURL() string {
 	return "http://system-master:3000/master/events/import"
-}
-
-func DefaultSystemRedisURL() string {
-	return "redis://system-redis:6379/1"
-}
-
-func DefaultSystemRedisSentinelHosts() string {
-	return ""
-}
-
-func DefaultSystemRedisSentinelRole() string {
-	return ""
-}
-
-func DefaultSystemMessageBusRedisURL() string {
-	return ""
-}
-
-func DefaultSystemMessageBusRedisSentinelHosts() string {
-	return ""
-}
-
-func DefaultSystemMessageBusRedisSentinelRole() string {
-	return ""
-}
-
-func DefaultSystemRedisNamespace() string {
-	return ""
-}
-
-func DefaultSystemMessageBusRedisNamespace() string {
-	return ""
 }
 
 func DefaultSystemAppSecretKeyBase() string {

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -97,42 +97,6 @@ func (o *OperatorBackendOptionsProvider) setSecretBasedOptions() error {
 			component.BackendSecretBackendListenerRouteEndpointFieldName,
 			fmt.Sprintf("https://backend-%s.%s", *o.apimanager.Spec.TenantName, o.apimanager.Spec.WildcardDomain),
 		},
-		{
-			&o.backendOptions.StorageURL,
-			component.BackendSecretBackendRedisSecretName,
-			component.BackendSecretBackendRedisStorageURLFieldName,
-			component.DefaultBackendRedisStorageURL(),
-		},
-		{
-			&o.backendOptions.QueuesURL,
-			component.BackendSecretBackendRedisSecretName,
-			component.BackendSecretBackendRedisQueuesURLFieldName,
-			component.DefaultBackendRedisQueuesURL(),
-		},
-		{
-			&o.backendOptions.StorageSentinelHosts,
-			component.BackendSecretBackendRedisSecretName,
-			component.BackendSecretBackendRedisStorageSentinelHostsFieldName,
-			component.DefaultBackendStorageSentinelHosts(),
-		},
-		{
-			&o.backendOptions.StorageSentinelRole,
-			component.BackendSecretBackendRedisSecretName,
-			component.BackendSecretBackendRedisStorageSentinelRoleFieldName,
-			component.DefaultBackendStorageSentinelRole(),
-		},
-		{
-			&o.backendOptions.QueuesSentinelHosts,
-			component.BackendSecretBackendRedisSecretName,
-			component.BackendSecretBackendRedisQueuesSentinelHostsFieldName,
-			component.DefaultBackendQueuesSentinelHosts(),
-		},
-		{
-			&o.backendOptions.QueuesSentinelRole,
-			component.BackendSecretBackendRedisSecretName,
-			component.BackendSecretBackendRedisQueuesSentinelRoleFieldName,
-			component.DefaultBackendQueuesSentinelRole(),
-		},
 	}
 
 	for _, option := range cases {

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -62,12 +63,6 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Internal API Secret
 	err = r.ReconcileSecret(backend.InternalAPISecretForSystem(), reconcilers.DefaultsOnlySecretMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Redis Secret
-	err = r.ReconcileSecret(backend.RedisSecret(), reconcilers.DefaultsOnlySecretMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/backend_reconciler_test.go
+++ b/pkg/3scale/amp/operator/backend_reconciler_test.go
@@ -103,7 +103,6 @@ func TestNewBackendReconciler(t *testing.T) {
 		{"environmentCM", "backend-environment", &v1.ConfigMap{}},
 		{"internalAPISecret", component.BackendSecretInternalApiSecretName, &v1.Secret{}},
 		{"listenerSecret", component.BackendSecretBackendListenerSecretName, &v1.Secret{}},
-		{"redisSecret", component.BackendSecretBackendRedisSecretName, &v1.Secret{}},
 		{"workerPDB", "backend-worker", &v1beta1.PodDisruptionBudget{}},
 		{"cronPDB", "backend-cron", &v1beta1.PodDisruptionBudget{}},
 		{"listenerPDB", "backend-listener", &v1beta1.PodDisruptionBudget{}},

--- a/pkg/3scale/amp/operator/highavailability_options_provider.go
+++ b/pkg/3scale/amp/operator/highavailability_options_provider.go
@@ -190,7 +190,7 @@ func (h *HighAvailabilityOptionsProvider) setSystemRedisOptions() error {
 	}
 
 	for _, option := range casesWithDefault {
-		val, err := h.secretSource.FieldValue(option.secretName, option.secretField, option.defValue)
+		val, err := h.secretSource.FieldValueFromRequiredSecret(option.secretName, option.secretField, option.defValue)
 		if err != nil {
 			return err
 		}

--- a/pkg/3scale/amp/operator/highavailability_options_provider.go
+++ b/pkg/3scale/amp/operator/highavailability_options_provider.go
@@ -108,7 +108,7 @@ func (h *HighAvailabilityOptionsProvider) setBackendRedisOptions() error {
 	}
 
 	for _, option := range casesWithDefault {
-		val, err := h.secretSource.FieldValue(option.secretName, option.secretField, option.defValue)
+		val, err := h.secretSource.FieldValueFromRequiredSecret(option.secretName, option.secretField, option.defValue)
 		if err != nil {
 			return err
 		}

--- a/pkg/3scale/amp/operator/highavailability_options_provider.go
+++ b/pkg/3scale/amp/operator/highavailability_options_provider.go
@@ -2,19 +2,23 @@ package operator
 
 import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/helper"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type HighAvailabilityOptionsProvider struct {
+	apimanager   *appsv1alpha1.APIManager
 	namespace    string
 	client       client.Client
 	options      *component.HighAvailabilityOptions
 	secretSource *helper.SecretSource
 }
 
-func NewHighAvailabilityOptionsProvider(namespace string, client client.Client) *HighAvailabilityOptionsProvider {
+func NewHighAvailabilityOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace string, client client.Client) *HighAvailabilityOptionsProvider {
 	return &HighAvailabilityOptionsProvider{
+		apimanager:   apimanager,
 		namespace:    namespace,
 		client:       client,
 		options:      component.NewHighAvailabilityOptions(),
@@ -36,16 +40,9 @@ func (h *HighAvailabilityOptionsProvider) GetHighAvailabilityOptions() (*compone
 		return nil, err
 	}
 
-	// not required for operator, but required for templates
-	h.options.AppLabel = "-"
-	h.options.BackendRedisQueuesSentinelHosts = "-"
-	h.options.BackendRedisQueuesSentinelRole = "-"
-	h.options.BackendRedisStorageSentinelHosts = "-"
-	h.options.BackendRedisStorageSentinelRole = "-"
-	h.options.SystemRedisSentinelsHosts = "-"
-	h.options.SystemRedisSentinelsRole = "-"
-	h.options.SystemMessageBusRedisSentinelsHosts = "-"
-	h.options.SystemMessageBusRedisSentinelsRole = "-"
+	h.options.BackendRedisLabels = h.backendRedisLabels()
+	h.options.SystemRedisLabels = h.SystemDatabaseLabels()
+	h.options.SystemDatabaseLabels = h.SystemDatabaseLabels()
 
 	err = h.options.Validate()
 	return h.options, err
@@ -71,6 +68,47 @@ func (h *HighAvailabilityOptionsProvider) setBackendRedisOptions() error {
 
 	for _, option := range cases {
 		val, err := h.secretSource.RequiredFieldValueFromRequiredSecret(option.secretName, option.secretField)
+		if err != nil {
+			return err
+		}
+		*option.field = val
+	}
+
+	// Optional fields
+	casesWithDefault := []struct {
+		field       *string
+		secretName  string
+		secretField string
+		defValue    string
+	}{
+		{
+			&h.options.BackendRedisStorageSentinelHosts,
+			component.BackendSecretBackendRedisSecretName,
+			component.BackendSecretBackendRedisStorageSentinelHostsFieldName,
+			component.DefaultBackendStorageSentinelHosts(),
+		},
+		{
+			&h.options.BackendRedisStorageSentinelRole,
+			component.BackendSecretBackendRedisSecretName,
+			component.BackendSecretBackendRedisStorageSentinelRoleFieldName,
+			component.DefaultBackendStorageSentinelRole(),
+		},
+		{
+			&h.options.BackendRedisQueuesSentinelHosts,
+			component.BackendSecretBackendRedisSecretName,
+			component.BackendSecretBackendRedisQueuesSentinelHostsFieldName,
+			component.DefaultBackendQueuesSentinelHosts(),
+		},
+		{
+			&h.options.BackendRedisQueuesSentinelRole,
+			component.BackendSecretBackendRedisSecretName,
+			component.BackendSecretBackendRedisQueuesSentinelRoleFieldName,
+			component.DefaultBackendQueuesSentinelRole(),
+		},
+	}
+
+	for _, option := range casesWithDefault {
+		val, err := h.secretSource.FieldValue(option.secretName, option.secretField, option.defValue)
 		if err != nil {
 			return err
 		}
@@ -106,6 +144,61 @@ func (h *HighAvailabilityOptionsProvider) setSystemRedisOptions() error {
 		*option.field = val
 	}
 
+	// Optional fields
+	casesWithDefault := []struct {
+		field       *string
+		secretName  string
+		secretField string
+		defValue    string
+	}{
+		{
+			&h.options.SystemRedisSentinelsHosts,
+			component.SystemSecretSystemRedisSecretName,
+			component.SystemSecretSystemRedisSentinelHosts,
+			component.DefaultSystemRedisSentinelHosts(),
+		},
+		{
+			&h.options.SystemRedisSentinelsRole,
+			component.SystemSecretSystemRedisSecretName,
+			component.SystemSecretSystemRedisSentinelRole,
+			component.DefaultSystemRedisSentinelRole(),
+		},
+		{
+			&h.options.SystemMessageBusRedisSentinelsHosts,
+			component.SystemSecretSystemRedisSecretName,
+			component.SystemSecretSystemRedisMessageBusSentinelHosts,
+			component.DefaultSystemMessageBusRedisSentinelHosts(),
+		},
+		{
+			&h.options.SystemMessageBusRedisSentinelsRole,
+			component.SystemSecretSystemRedisSecretName,
+			component.SystemSecretSystemRedisMessageBusSentinelRole,
+			component.DefaultSystemMessageBusRedisSentinelRole(),
+		},
+		{
+			&h.options.SystemRedisNamespace,
+			component.SystemSecretSystemRedisSecretName,
+			component.SystemSecretSystemRedisNamespace,
+			component.DefaultSystemRedisNamespace(),
+		},
+		{
+			&h.options.SystemMessageBusRedisNamespace,
+			component.SystemSecretSystemRedisSecretName,
+			component.SystemSecretSystemRedisMessageBusRedisNamespace,
+			component.DefaultSystemMessageBusRedisNamespace(),
+		},
+	}
+
+	for _, option := range casesWithDefault {
+		val, err := h.secretSource.FieldValue(option.secretName, option.secretField, option.defValue)
+		if err != nil {
+			return err
+		}
+		*option.field = val
+	}
+
+	return nil
+
 	return nil
 }
 
@@ -117,4 +210,18 @@ func (h *HighAvailabilityOptionsProvider) setSystemDatabaseOptions() error {
 	}
 	h.options.SystemDatabaseURL = val
 	return nil
+}
+
+func (h *HighAvailabilityOptionsProvider) backendRedisLabels() map[string]string {
+	return map[string]string{
+		"app":                  *h.apimanager.Spec.AppLabel,
+		"threescale_component": "backend",
+	}
+}
+
+func (h *HighAvailabilityOptionsProvider) SystemDatabaseLabels() map[string]string {
+	return map[string]string{
+		"app":                  *h.apimanager.Spec.AppLabel,
+		"threescale_component": "system",
+	}
 }

--- a/pkg/3scale/amp/operator/highavailability_reconciler.go
+++ b/pkg/3scale/amp/operator/highavailability_reconciler.go
@@ -1,0 +1,56 @@
+package operator
+
+import (
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type HighAvailabilityReconciler struct {
+	*BaseAPIManagerLogicReconciler
+}
+
+func NewHighAvailabilityReconciler(baseAPIManagerLogicReconciler *BaseAPIManagerLogicReconciler) *HighAvailabilityReconciler {
+	return &HighAvailabilityReconciler{
+		BaseAPIManagerLogicReconciler: baseAPIManagerLogicReconciler,
+	}
+}
+
+func (r *HighAvailabilityReconciler) Reconcile() (reconcile.Result, error) {
+	ha, err := HighAvailability(r.apiManager, r.Client())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Backend Redis Secret
+	err = r.ReconcileSecret(ha.BackendRedisSecret(), reconcilers.DefaultsOnlySecretMutator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// System Redis Secret
+	err = r.ReconcileSecret(ha.SystemRedisSecret(), reconcilers.DefaultsOnlySecretMutator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// System database Secret
+	err = r.ReconcileSecret(ha.SystemDatabaseSecret(), reconcilers.DefaultsOnlySecretMutator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func HighAvailability(apimanager *appsv1alpha1.APIManager, client client.Client) (*component.HighAvailability, error) {
+	optsProvider := NewHighAvailabilityOptionsProvider(apimanager, apimanager.Namespace, client)
+	opts, err := optsProvider.GetHighAvailabilityOptions()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewHighAvailability(opts), nil
+}

--- a/pkg/3scale/amp/operator/highavailability_reconciler_test.go
+++ b/pkg/3scale/amp/operator/highavailability_reconciler_test.go
@@ -1,0 +1,97 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestHighAvailabilityReconciler(t *testing.T) {
+	var (
+		log                     = logf.Log.WithName("operator_test")
+		systemMysqlRootPassword = "rootPassw1"
+		systemMysqlDatabaseName = "myDatabaseName"
+		databaseURL             = fmt.Sprintf("mysql2://root:%s@system-mysql/%s", systemMysqlRootPassword, systemMysqlDatabaseName)
+	)
+
+	ctx := context.TODO()
+
+	apimanager := basicApimanagerTestHA()
+	backendRedisSecret := testBackendRedisSecret()
+	systemRedisSecret := testSystemRedisSecret()
+	systemDBSecret := getSystemDBSecret(databaseURL, systemMysqlUsername, systemMysqlPassword)
+	// Objects to track in the fake client.
+	objs := []runtime.Object{apimanager, backendRedisSecret, systemRedisSecret, systemDBSecret}
+	s := scheme.Scheme
+	s.AddKnownTypes(appsv1alpha1.SchemeGroupVersion, apimanager)
+	err := appsv1.AddToScheme(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+
+	baseReconciler := reconcilers.NewBaseReconciler(cl, s, clientAPIReader, ctx, log, clientset.Discovery(), recorder)
+	BaseAPIManagerLogicReconciler := NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+
+	reconciler := NewHighAvailabilityReconciler(BaseAPIManagerLogicReconciler)
+	_, err = reconciler.Reconcile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		testName   string
+		secretName string
+	}{
+		{"backendRedisTest", component.BackendSecretBackendRedisSecretName},
+	}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			secret := &v1.Secret{}
+			namespacedName := types.NamespacedName{
+				Name:      tc.secretName,
+				Namespace: namespace,
+			}
+			err = cl.Get(context.TODO(), namespacedName, secret)
+			// object must exist, that is all required to be tested
+			if err != nil {
+				subT.Errorf("error fetching object %s: %v", tc.secretName, err)
+			}
+
+			// Assert owner ref
+			if len(secret.GetOwnerReferences()) == 0 {
+				subT.Errorf("secret %s: owner ref not set", tc.secretName)
+			}
+
+			ownerRef := secret.GetOwnerReferences()[0]
+
+			// apimanager.Kind is empty
+			if ownerRef.Kind != "APIManager" {
+				subT.Errorf("secret %s: owner ref kind not matched. Expected: %s, found: %s", tc.secretName, "APIManager", ownerRef.Kind)
+			}
+
+			if ownerRef.Name != apimanager.Name {
+				subT.Errorf("secret %s: owner ref name not matched. Expected: %s, found: %s", tc.secretName, apimanager.Name, ownerRef.Name)
+			}
+		})
+	}
+}

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	appsv1alpha1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func testRedisSystemCommonLabels() map[string]string {
@@ -130,6 +133,20 @@ func defaultRedisOptions() *component.RedisOptions {
 		BackendCommonLabels:                       testRedisBackendCommonLabels(),
 		BackendRedisLabels:                        testRedisBackendRedisLabels(),
 		BackendRedisPodTemplateLabels:             testRedisBackendRedisPodTemplateLabels(),
+		BackendStorageURL:                         component.DefaultBackendRedisStorageURL(),
+		BackendQueuesURL:                          component.DefaultBackendRedisQueuesURL(),
+		BackendRedisStorageSentinelHosts:          component.DefaultBackendStorageSentinelHosts(),
+		BackendRedisStorageSentinelRole:           component.DefaultBackendStorageSentinelRole(),
+		BackendRedisQueuesSentinelHosts:           component.DefaultBackendQueuesSentinelHosts(),
+		BackendRedisQueuesSentinelRole:            component.DefaultBackendQueuesSentinelRole(),
+		SystemRedisURL:                            component.DefaultSystemRedisURL(),
+		SystemRedisMessageBusURL:                  component.DefaultSystemRedisMessageBusURL(),
+		SystemRedisSentinelsHosts:                 component.DefaultSystemRedisSentinelHosts(),
+		SystemRedisSentinelsRole:                  component.DefaultSystemRedisSentinelRole(),
+		SystemMessageBusRedisSentinelsHosts:       component.DefaultSystemMessageBusRedisSentinelHosts(),
+		SystemMessageBusRedisSentinelsRole:        component.DefaultSystemMessageBusRedisSentinelRole(),
+		SystemMessageBusRedisNamespace:            component.DefaultSystemMessageBusRedisNamespace(),
+		SystemRedisNamespace:                      component.DefaultSystemRedisNamespace(),
 	}
 }
 
@@ -331,7 +348,9 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(subT *testing.T) {
-			optsProvider := NewRedisOptionsProvider(tc.apimanagerFactory())
+			objs := []runtime.Object{}
+			cl := fake.NewFakeClient(objs...)
+			optsProvider := NewRedisOptionsProvider(tc.apimanagerFactory(), namespace, cl)
 			opts, err := optsProvider.GetRedisOptions()
 			if err != nil {
 				subT.Error(err)

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -116,6 +116,32 @@ func testSystemRedisCustomResourceRequirements() *v1.ResourceRequirements {
 	}
 }
 
+func testBackendRedisSecret() *v1.Secret {
+	data := map[string]string{
+		component.BackendSecretBackendRedisStorageURLFieldName:           "storageURLValue",
+		component.BackendSecretBackendRedisQueuesURLFieldName:            "queueURLValue",
+		component.BackendSecretBackendRedisStorageSentinelHostsFieldName: "storageSentinelHostsValue",
+		component.BackendSecretBackendRedisStorageSentinelRoleFieldName:  "storageSentinelRoleValue",
+		component.BackendSecretBackendRedisQueuesSentinelHostsFieldName:  "queueSentinelHostsValue",
+		component.BackendSecretBackendRedisQueuesSentinelRoleFieldName:   "queueSentinelRoleValue",
+	}
+	return GetTestSecret(namespace, component.BackendSecretBackendRedisSecretName, data)
+}
+
+func testSystemRedisSecret() *v1.Secret {
+	data := map[string]string{
+		component.SystemSecretSystemRedisNamespace:                   "systemRedis",
+		component.SystemSecretSystemRedisURLFieldName:                "redis://system1:6379",
+		component.SystemSecretSystemRedisSentinelHosts:               "someHosts1",
+		component.SystemSecretSystemRedisSentinelRole:                "someRole1",
+		component.SystemSecretSystemRedisMessageBusRedisNamespace:    "mbus",
+		component.SystemSecretSystemRedisMessageBusSentinelHosts:     "someHosts2",
+		component.SystemSecretSystemRedisMessageBusSentinelRole:      "someRole2",
+		component.SystemSecretSystemRedisMessageBusRedisURLFieldName: "redis://system2:6379",
+	}
+	return GetTestSecret(namespace, component.SystemSecretSystemRedisSecretName, data)
+}
+
 func defaultRedisOptions() *component.RedisOptions {
 	tmpInsecure := insecureImportPolicy
 	return &component.RedisOptions{
@@ -159,11 +185,13 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 
 	cases := []struct {
 		testName               string
+		backendRedisSecret     *v1.Secret
+		systemRedisSecret      *v1.Secret
 		apimanagerFactory      func() *appsv1alpha1.APIManager
 		expectedOptionsFactory func() *component.RedisOptions
 	}{
-		{"Default", basicApimanager, defaultRedisOptions},
-		{"WithoutResourceRequirements",
+		{"Default", nil, nil, basicApimanager, defaultRedisOptions},
+		{"WithoutResourceRequirements", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.ResourceRequirementsEnabled = &tmpFalseValue
@@ -176,7 +204,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"BackendRedisImageSet",
+		{"BackendRedisImageSet", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.Backend = &appsv1alpha1.BackendSpec{
@@ -191,7 +219,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"SystemRedisImageSet",
+		{"SystemRedisImageSet", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.System = &appsv1alpha1.SystemSpec{
@@ -206,7 +234,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"SystemRedisOnlyPVCSpecSet",
+		{"SystemRedisOnlyPVCSpecSet", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.System = &appsv1alpha1.SystemSpec{
@@ -219,7 +247,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"BackendRedisOnlyPVCSpecSet",
+		{"BackendRedisOnlyPVCSpecSet", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.Backend = &appsv1alpha1.BackendSpec{
@@ -232,7 +260,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"BackendRedisStoragePVCStorageClassSet",
+		{"BackendRedisStoragePVCStorageClassSet", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.Backend = &appsv1alpha1.BackendSpec{
@@ -248,7 +276,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"SystemRedisStoragePVCStorageClassSet",
+		{"SystemRedisStoragePVCStorageClassSet", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.System = &appsv1alpha1.SystemSpec{
@@ -264,7 +292,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"WithAffinity",
+		{"WithAffinity", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.System.RedisAffinity = testSystemRedisAffinity()
@@ -278,7 +306,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"WithTolerations",
+		{"WithTolerations", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.System.RedisTolerations = testSystemRedisTolerations()
@@ -292,7 +320,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"WithBackendRedisCustomResourceRequirements",
+		{"WithBackendRedisCustomResourceRequirements", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.Backend.RedisResources = testBackendRedisCustomResourceRequirements()
@@ -304,7 +332,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"WithBackendRedisCustomResourceRequirementsAndGlobalResourceRequirementsDisabled",
+		{"WithBackendRedisCustomResourceRequirementsAndGlobalResourceRequirementsDisabled", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.ResourceRequirementsEnabled = &tmpFalseValue
@@ -318,7 +346,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"WithSystemRedisCustomResourceRequirements",
+		{"WithSystemRedisCustomResourceRequirements", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.Backend.RedisResources = testSystemRedisCustomResourceRequirements()
@@ -330,7 +358,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
-		{"WithSystemRedisCustomResourceRequirementsAndGlobalResourceRequirementsDisabled",
+		{"WithSystemRedisCustomResourceRequirementsAndGlobalResourceRequirementsDisabled", nil, nil,
 			func() *appsv1alpha1.APIManager {
 				apimanager := basicApimanager()
 				apimanager.Spec.ResourceRequirementsEnabled = &tmpFalseValue
@@ -344,11 +372,43 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				return opts
 			},
 		},
+		{"WithBackendRedisSecret", testBackendRedisSecret(), nil, basicApimanager,
+			func() *component.RedisOptions {
+				opts := defaultRedisOptions()
+				opts.BackendStorageURL = "storageURLValue"
+				opts.BackendQueuesURL = "queueURLValue"
+				opts.BackendRedisStorageSentinelHosts = "storageSentinelHostsValue"
+				opts.BackendRedisStorageSentinelRole = "storageSentinelRoleValue"
+				opts.BackendRedisQueuesSentinelHosts = "queueSentinelHostsValue"
+				opts.BackendRedisQueuesSentinelRole = "queueSentinelRoleValue"
+				return opts
+			},
+		},
+		{"WithSystemRedisSecret", nil, testSystemRedisSecret(), basicApimanager,
+			func() *component.RedisOptions {
+				opts := defaultRedisOptions()
+				opts.SystemRedisURL = "redis://system1:6379"
+				opts.SystemRedisSentinelsHosts = "someHosts1"
+				opts.SystemRedisSentinelsRole = "someRole1"
+				opts.SystemRedisMessageBusURL = "redis://system2:6379"
+				opts.SystemMessageBusRedisSentinelsHosts = "someHosts2"
+				opts.SystemMessageBusRedisSentinelsRole = "someRole2"
+				opts.SystemRedisNamespace = "systemRedis"
+				opts.SystemMessageBusRedisNamespace = "mbus"
+				return opts
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(subT *testing.T) {
 			objs := []runtime.Object{}
+			if tc.backendRedisSecret != nil {
+				objs = append(objs, tc.backendRedisSecret)
+			}
+			if tc.systemRedisSecret != nil {
+				objs = append(objs, tc.systemRedisSecret)
+			}
 			cl := fake.NewFakeClient(objs...)
 			optsProvider := NewRedisOptionsProvider(tc.apimanagerFactory(), namespace, cl)
 			opts, err := optsProvider.GetRedisOptions()

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -92,11 +92,6 @@ func (s *SystemOptionsProvider) setSecretBasedOptions() error {
 		return fmt.Errorf("unable to create System Event Hooks secret options - %s", err)
 	}
 
-	err = s.setSystemRedisOptions()
-	if err != nil {
-		return fmt.Errorf("unable to create System Redis secret options - %s", err)
-	}
-
 	err = s.setSystemAppOptions()
 	if err != nil {
 		return fmt.Errorf("unable to create System App secret options - %s", err)
@@ -173,77 +168,6 @@ func (s *SystemOptionsProvider) setSystemEventHookOptions() error {
 		return err
 	}
 	s.options.EventHooksURL = val
-
-	return nil
-}
-
-func (s *SystemOptionsProvider) setSystemRedisOptions() error {
-	val, err := s.secretSource.FieldValue(
-		component.SystemSecretSystemRedisSecretName,
-		component.SystemSecretSystemRedisURLFieldName,
-		component.DefaultSystemRedisURL())
-	if err != nil {
-		return err
-	}
-	s.options.RedisURL = val
-
-	cases := []struct {
-		field       **string
-		secretName  string
-		secretField string
-		defValue    string
-	}{
-		{
-			&s.options.RedisSentinelHosts,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisSentinelHosts,
-			component.DefaultSystemRedisSentinelHosts(),
-		},
-		{
-			&s.options.RedisSentinelRole,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisSentinelRole,
-			component.DefaultSystemRedisSentinelRole(),
-		},
-		{
-			&s.options.MessageBusRedisURL,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusRedisURLFieldName,
-			component.DefaultSystemMessageBusRedisURL(),
-		},
-		{
-			&s.options.MessageBusRedisSentinelHosts,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusSentinelHosts,
-			component.DefaultSystemMessageBusRedisSentinelHosts(),
-		},
-		{
-			&s.options.MessageBusRedisSentinelRole,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusSentinelRole,
-			component.DefaultSystemMessageBusRedisSentinelRole(),
-		},
-		{
-			&s.options.RedisNamespace,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisNamespace,
-			component.DefaultSystemRedisNamespace(),
-		},
-		{
-			&s.options.MessageBusRedisNamespace,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusRedisNamespace,
-			component.DefaultSystemMessageBusRedisNamespace(),
-		},
-	}
-
-	for _, option := range cases {
-		val, err := s.secretSource.FieldValue(option.secretName, option.secretField, option.defValue)
-		if err != nil {
-			return err
-		}
-		*option.field = &val
-	}
 
 	return nil
 }

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -123,12 +123,6 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// Redis Secret
-	err = r.ReconcileSecret(system.RedisSecret(), reconcilers.DefaultsOnlySecretMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// MasterApicast  Secret
 	err = r.ReconcileSecret(system.MasterApicastSecret(), reconcilers.DefaultsOnlySecretMutator)
 	if err != nil {

--- a/pkg/3scale/amp/operator/system_reconciler_test.go
+++ b/pkg/3scale/amp/operator/system_reconciler_test.go
@@ -88,7 +88,6 @@ func TestSystemReconcilerCreate(t *testing.T) {
 		{"systemEnvironmentCM", "system-environment", &v1.ConfigMap{}},
 		{"systemSMTPSecret", "system-smtp", &v1.Secret{}},
 		{"systemEventsHookSecret", component.SystemSecretSystemEventsHookSecretName, &v1.Secret{}},
-		{"systemRedisSecret", component.SystemSecretSystemRedisSecretName, &v1.Secret{}},
 		{"systemMasterApicastSecret", component.SystemSecretSystemMasterApicastSecretName, &v1.Secret{}},
 		{"systemSeedSecret", component.SystemSecretSystemSeedSecretName, &v1.Secret{}},
 		{"systemRecaptchaSecret", component.SystemSecretSystemRecaptchaSecretName, &v1.Secret{}},

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -211,7 +211,7 @@ func (u *UpgradeApiManager) upgradeMemcachedDeploymentConfig() (reconcile.Result
 	return reconcile.Result{}, nil
 }
 func (u *UpgradeApiManager) upgradeBackendRedisDeploymentConfig() (reconcile.Result, error) {
-	redis, err := Redis(u.apiManager)
+	redis, err := Redis(u.apiManager, u.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -225,7 +225,7 @@ func (u *UpgradeApiManager) upgradeBackendRedisDeploymentConfig() (reconcile.Res
 }
 
 func (u *UpgradeApiManager) upgradeSystemRedisDeploymentConfig() (reconcile.Result, error) {
-	redis, err := Redis(u.apiManager)
+	redis, err := Redis(u.apiManager, u.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -348,7 +348,7 @@ func (u *UpgradeApiManager) upgradeAMPImageStreams() (reconcile.Result, error) {
 }
 
 func (u *UpgradeApiManager) upgradeBackendRedisImageStream() (reconcile.Result, error) {
-	redis, err := Redis(u.apiManager)
+	redis, err := Redis(u.apiManager, u.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -358,7 +358,7 @@ func (u *UpgradeApiManager) upgradeBackendRedisImageStream() (reconcile.Result, 
 }
 
 func (u *UpgradeApiManager) upgradeSystemRedisImageStream() (reconcile.Result, error) {
-	redis, err := Redis(u.apiManager)
+	redis, err := Redis(u.apiManager, u.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/template/adapters/backend.go
+++ b/pkg/3scale/amp/template/adapters/backend.go
@@ -42,7 +42,6 @@ func (b *Backend) componentObjects(c *component.Backend) []common.KubernetesObje
 	environmentConfigMap := c.EnvironmentConfigMap()
 
 	internalAPISecretForSystem := c.InternalAPISecretForSystem()
-	redisSecret := c.RedisSecret()
 	listenerSecret := c.ListenerSecret()
 
 	objects := []common.KubernetesObject{
@@ -53,7 +52,6 @@ func (b *Backend) componentObjects(c *component.Backend) []common.KubernetesObje
 		workerDeploymentConfig,
 		environmentConfigMap,
 		internalAPISecretForSystem,
-		redisSecret,
 		listenerSecret,
 	}
 
@@ -84,8 +82,6 @@ func (b *Backend) options() (*component.BackendOptions, error) {
 	bo.ImageTag = "${AMP_RELEASE}"
 	bo.RouteEndpoint = fmt.Sprintf("https://backend-%s.%s", "${TENANT_NAME}", "${WILDCARD_DOMAIN}")
 	bo.ServiceEndpoint = component.DefaultBackendServiceEndpoint()
-	bo.StorageURL = component.DefaultBackendRedisStorageURL()
-	bo.QueuesURL = component.DefaultBackendRedisQueuesURL()
 	bo.ListenerReplicas = 1
 	bo.WorkerReplicas = 1
 	bo.CronReplicas = 1

--- a/pkg/3scale/amp/template/adapters/ha.go
+++ b/pkg/3scale/amp/template/adapters/ha.go
@@ -183,13 +183,16 @@ func (h *HAAdapter) addParameters(template *templatev1.Template) {
 
 func (h *HAAdapter) options() (*component.HighAvailabilityOptions, error) {
 	o := component.NewHighAvailabilityOptions()
-	o.AppLabel = "${APP_LABEL}"
+	o.SystemDatabaseLabels = h.systemDatabaseLabels()
+
+	o.BackendRedisLabels = h.backendRedisLabels()
 	o.BackendRedisQueuesEndpoint = "${BACKEND_REDIS_QUEUES_ENDPOINT}"
 	o.BackendRedisQueuesSentinelHosts = "${BACKEND_REDIS_QUEUE_SENTINEL_HOSTS}"
 	o.BackendRedisQueuesSentinelRole = "${BACKEND_REDIS_QUEUE_SENTINEL_ROLE}"
 	o.BackendRedisStorageEndpoint = "${BACKEND_REDIS_STORAGE_ENDPOINT}"
 	o.BackendRedisStorageSentinelHosts = "${BACKEND_REDIS_STORAGE_SENTINEL_HOSTS}"
 	o.BackendRedisStorageSentinelRole = "${BACKEND_REDIS_STORAGE_SENTINEL_ROLE}"
+
 	o.SystemDatabaseURL = "${SYSTEM_DATABASE_URL}"
 	o.SystemRedisURL = "${SYSTEM_REDIS_URL}"
 	o.SystemRedisSentinelsHosts = "${SYSTEM_REDIS_SENTINEL_HOSTS}"
@@ -197,6 +200,7 @@ func (h *HAAdapter) options() (*component.HighAvailabilityOptions, error) {
 	o.SystemMessageBusRedisSentinelsHosts = "${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS}"
 	o.SystemMessageBusRedisSentinelsRole = "${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE}"
 	o.SystemMessageBusRedisURL = "${SYSTEM_MESSAGE_BUS_REDIS_URL}"
+	o.SystemRedisLabels = h.systemRedisLabels()
 
 	err := o.Validate()
 	return o, err
@@ -251,5 +255,26 @@ func (h *HAAdapter) parameters() []templatev1.Parameter {
 			Name:        "BACKEND_REDIS_STORAGE_SENTINEL_ROLE",
 			Description: "Define the external backend redis storage sentinel role",
 		},
+	}
+}
+
+func (h *HAAdapter) backendRedisLabels() map[string]string {
+	return map[string]string{
+		"app":                  "${APP_LABEL}",
+		"threescale_component": "backend",
+	}
+}
+
+func (h *HAAdapter) systemRedisLabels() map[string]string {
+	return map[string]string{
+		"app":                  "${APP_LABEL}",
+		"threescale_component": "system",
+	}
+}
+
+func (h *HAAdapter) systemDatabaseLabels() map[string]string {
+	return map[string]string{
+		"app":                  "${APP_LABEL}",
+		"threescale_component": "system",
 	}
 }

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -52,12 +52,16 @@ func (r *RedisAdapter) backendRedisComponentObjects(c *component.Redis) []common
 	cm := c.BackendConfigMap()
 	bpvc := c.BackendPVC()
 	bis := c.BackendImageStream()
+	backendRedisSecret := c.BackendRedisSecret()
+	systemRedisSecret := c.SystemRedisSecret()
 	objects := []common.KubernetesObject{
 		dc,
 		bs,
 		cm,
 		bpvc,
 		bis,
+		backendRedisSecret,
+		systemRedisSecret,
 	}
 	return objects
 }
@@ -97,6 +101,22 @@ func (r *RedisAdapter) options() (*component.RedisOptions, error) {
 	ro.BackendCommonLabels = r.backendCommonLabels()
 	ro.BackendRedisLabels = r.backendRedisLabels()
 	ro.BackendRedisPodTemplateLabels = r.backendRedisPodTemplateLabels()
+
+	ro.SystemRedisURL = "${SYSTEM_REDIS_URL}"
+	ro.SystemRedisSentinelsHosts = component.DefaultSystemRedisSentinelHosts()
+	ro.SystemRedisSentinelsRole = component.DefaultSystemRedisSentinelRole()
+	ro.SystemRedisNamespace = "${SYSTEM_REDIS_NAMESPACE}"
+	ro.SystemRedisMessageBusURL = "${SYSTEM_MESSAGE_BUS_REDIS_URL}"
+	ro.SystemMessageBusRedisSentinelsHosts = component.DefaultSystemMessageBusRedisSentinelHosts()
+	ro.SystemMessageBusRedisSentinelsRole = component.DefaultSystemMessageBusRedisSentinelRole()
+	ro.SystemMessageBusRedisNamespace = "${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}"
+
+	ro.BackendStorageURL = component.DefaultBackendRedisStorageURL()
+	ro.BackendQueuesURL = component.DefaultBackendRedisQueuesURL()
+	ro.BackendRedisStorageSentinelHosts = component.DefaultBackendStorageSentinelHosts()
+	ro.BackendRedisStorageSentinelRole = component.DefaultBackendStorageSentinelRole()
+	ro.BackendRedisQueuesSentinelHosts = component.DefaultBackendQueuesSentinelHosts()
+	ro.BackendRedisQueuesSentinelRole = component.DefaultBackendQueuesSentinelRole()
 
 	err := ro.Validate()
 	return ro, err

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -153,7 +153,6 @@ func (s *System) componentObjects(c *component.System) []common.KubernetesObject
 
 	eventsHookSecret := c.EventsHookSecret()
 
-	redisSecret := c.RedisSecret()
 	masterApicastSecret := c.MasterApicastSecret()
 
 	seedSecret := c.SeedSecret()
@@ -175,7 +174,6 @@ func (s *System) componentObjects(c *component.System) []common.KubernetesObject
 		sidekiqDeploymentConfig,
 		sphinxDeploymentConfig,
 		eventsHookSecret,
-		redisSecret,
 		masterApicastSecret,
 		seedSecret,
 		recaptchaSecret,
@@ -220,21 +218,6 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.RecaptchaPublicKey = &recaptchaPublicKey
 	recaptchaPrivateKey := "${RECAPTCHA_PRIVATE_KEY}"
 	o.RecaptchaPrivateKey = &recaptchaPrivateKey
-	o.RedisURL = "${SYSTEM_REDIS_URL}"
-	redisSentinelHosts := component.DefaultSystemRedisSentinelHosts()
-	o.RedisSentinelHosts = &redisSentinelHosts
-	redisSentinelRole := component.DefaultSystemRedisSentinelRole()
-	o.RedisSentinelRole = &redisSentinelRole
-	redisNamespace := "${SYSTEM_REDIS_NAMESPACE}"
-	o.RedisNamespace = &redisNamespace
-	messageBusRedisURL := "${SYSTEM_MESSAGE_BUS_REDIS_URL}"
-	o.MessageBusRedisURL = &messageBusRedisURL
-	messageBusRedisSentinelHosts := component.DefaultSystemMessageBusRedisSentinelHosts()
-	o.MessageBusRedisSentinelHosts = &messageBusRedisSentinelHosts
-	messageBusRedisSentinelRole := component.DefaultSystemMessageBusRedisSentinelRole()
-	o.MessageBusRedisSentinelRole = &messageBusRedisSentinelRole
-	messageBusRedisNamespace := "${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}"
-	o.MessageBusRedisNamespace = &messageBusRedisNamespace
 	o.AppSecretKeyBase = "${SYSTEM_APP_SECRET_KEY_BASE}"
 	o.BackendSharedSecret = "${SYSTEM_BACKEND_SHARED_SECRET}"
 	o.TenantName = "${TENANT_NAME}"

--- a/pkg/controller/apimanager/apimanager_controller.go
+++ b/pkg/controller/apimanager/apimanager_controller.go
@@ -256,10 +256,10 @@ func (r *ReconcileAPIManager) reconcileAPIManagerLogic(cr *appsv1alpha1.APIManag
 		}
 	} else {
 		// External databases
-		// validate required secrets exist
-		err := r.externalDatabasesCheck(cr)
-		if err != nil {
-			return reconcile.Result{}, err
+		haReconciler := operator.NewHighAvailabilityReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+		result, err = haReconciler.Reconcile()
+		if err != nil || result.Requeue {
+			return result, err
 		}
 	}
 
@@ -387,10 +387,4 @@ func (r *ReconcileAPIManager) setDeploymentStatus(instance *appsv1alpha1.APIMana
 	}
 
 	return updated, nil
-}
-
-func (r *ReconcileAPIManager) externalDatabasesCheck(cr *appsv1alpha1.APIManager) error {
-	optsProvider := operator.NewHighAvailabilityOptionsProvider(cr.Namespace, r.Client())
-	_, err := optsProvider.GetHighAvailabilityOptions()
-	return err
 }


### PR DESCRIPTION
When external databases are enabled, system database secret is not reconciled, hence ower reference is not set.

The implementation required some refactoring:

* Backend redis secret is reconciled in redis_reconciled.go and highavailability_reconciler.go. It has been removed from backend_reconciled.go
* System redis secret is reconciled in redis_reconciled.go and highavailability_reconciler.go. It has been removed from system_reconciled.go
* highavailabiilty_reconciler.go now reconciles three secrets: system redis, backend redis and system database secrets..

*TODO*
- [x] new HA reconciler unittests
- [x] redis option provider unittests update with new redis params