### PR TITLE
products CRD openapi missing validation added

### DIFF
--- a/deploy/crds/capabilities.3scale.net_products_crd.yaml
+++ b/deploy/crds/capabilities.3scale.net_products_crd.yaml
@@ -243,6 +243,15 @@ spec:
                               type: object
                           type: object
                       type: object
+                      oneOf:
+                       - properties:
+                           userkey:
+                             type: object
+                         required: ["userkey"]
+                       - properties:
+                           appKeyAppID:
+                             type: object
+                         required: ["appKeyAppID"]
                   type: object
                 apicastSelfManaged:
                   description: ApicastSelfManagedSpec defines the desired state of
@@ -331,6 +340,15 @@ spec:
                               type: object
                           type: object
                       type: object
+                      oneOf:
+                       - properties:
+                           userkey:
+                             type: object
+                         required: ["userkey"]
+                       - properties:
+                           appKeyAppID:
+                             type: object
+                         required: ["appKeyAppID"]
                     productionPublicBaseURL:
                       pattern: ^https?:\/\/.*$
                       type: string
@@ -339,6 +357,15 @@ spec:
                       type: string
                   type: object
               type: object
+              oneOf:
+                - properties:
+                    apicastHosted:
+                      type: object
+                  required: ["apicastHosted"]
+                - properties:
+                    apicastSelfManaged:
+                      type: object
+                  required: ["apicastSelfManaged"]
             description:
               description: Description is a human readable text of the product
               type: string


### PR DESCRIPTION
CRD Openapi custom validation added.

it is deleted by `operator-sdk generate crds` and must be maintained manually. Very easy to get lost.