### PR TITLE
Feat/Add system prometheus job down alerts

### DIFF
--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -144,15 +144,15 @@ func SystemSidekiqPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 					Name: fmt.Sprintf("%s/system-sidekiq.rules", ns),
 					Rules: []monitoringv1.Rule{
 						{
-							Alert: "SystemSidekiqZyncRuntime",
+							Alert: "ThreescaleSystemSidekiqJobDown",
 							Annotations: map[string]string{
-								"summary":     "Rule example:  Zync runtime average more than 300 seconds",
-								"description": "Rule example:  Zync runtime average more than 300 seconds",
+								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
+								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
 							},
-							Expr: intstr.FromString(fmt.Sprintf(`avg(sidekiq_job_runtime_seconds_sum{queue="zync",worker="ZyncWorker",namespace="%s"}) > 300`, ns)),
-							For:  "10m",
+							Expr: intstr.FromString(fmt.Sprintf(`up{job=~".*system-sidekiq.*",namespace="%s"} == 0`, ns)),
+							For:  "1m",
 							Labels: map[string]string{
-								"severity": "warning",
+								"severity": "critical",
 							},
 						},
 					},

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -96,10 +96,10 @@ func SystemGrafanaDashboard(ns string) *grafanav1alpha1.GrafanaDashboard {
 	}
 }
 
-func SystemPrometheusRules(ns string) *monitoringv1.PrometheusRule {
+func SystemAppPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system",
+			Name: "system-app",
 			Labels: map[string]string{
 				"prometheus": "application-monitoring",
 				"role":       "alert-rules",
@@ -108,10 +108,10 @@ func SystemPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{
-					Name: fmt.Sprintf("%s/system.rules", ns),
+					Name: fmt.Sprintf("%s/system-app.rules", ns),
 					Rules: []monitoringv1.Rule{
 						{
-							Alert: "ThreescaleSystem5XXRequestsHigh",
+							Alert: "ThreescaleSystemApp5XXRequestsHigh",
 							Annotations: map[string]string{
 								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} has more than 50 HTTP 5xx requests in the last minute",
 								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} has more than 50 HTTP 5xx requests in the last minute",
@@ -123,7 +123,7 @@ func SystemPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 							},
 						},
 						{
-							Alert: "ThreescaleSystemJobDown",
+							Alert: "ThreescaleSystemAppJobDown",
 							Annotations: map[string]string{
 								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
 								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -122,6 +122,18 @@ func SystemPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 								"severity": "warning",
 							},
 						},
+						{
+							Alert: "ThreescaleSystemJobDown",
+							Annotations: map[string]string{
+								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
+								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
+							},
+							Expr: intstr.FromString(fmt.Sprintf(`up{job=~".*system-app.*",namespace="%s"} == 0`, ns)),
+							For:  "1m",
+							Labels: map[string]string{
+								"severity": "critical",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -180,7 +180,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.SystemPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(component.SystemAppPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
This PR:
- Replaces initial example (not real) system sidekiq alert with a real prometheis job down alert (now that system monitoring is enabled)
- Add system-app prometheus job down alert
- Rename `system` prometheus rule function to `system-app`, to be consistent with its own `PodMonitor` called `system-app`, and the rest of the components' name