### PR TITLE
Add app label to 3scale CRDs

### DIFF
--- a/bundle/manifests/apps.3scale.net_apimanagerbackups.yaml
+++ b/bundle/manifests/apps.3scale.net_apimanagerbackups.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: apimanagerbackups.apps.3scale.net
 spec:
   group: apps.3scale.net

--- a/bundle/manifests/apps.3scale.net_apimanagerrestores.yaml
+++ b/bundle/manifests/apps.3scale.net_apimanagerrestores.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: apimanagerrestores.apps.3scale.net
 spec:
   group: apps.3scale.net

--- a/bundle/manifests/apps.3scale.net_apimanagers.yaml
+++ b/bundle/manifests/apps.3scale.net_apimanagers.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: apimanagers.apps.3scale.net
 spec:
   group: apps.3scale.net

--- a/bundle/manifests/capabilities.3scale.net_backends.yaml
+++ b/bundle/manifests/capabilities.3scale.net_backends.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: backends.capabilities.3scale.net
 spec:
   group: capabilities.3scale.net

--- a/bundle/manifests/capabilities.3scale.net_openapis.yaml
+++ b/bundle/manifests/capabilities.3scale.net_openapis.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: openapis.capabilities.3scale.net
 spec:
   group: capabilities.3scale.net

--- a/bundle/manifests/capabilities.3scale.net_products.yaml
+++ b/bundle/manifests/capabilities.3scale.net_products.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: products.capabilities.3scale.net
 spec:
   group: capabilities.3scale.net

--- a/bundle/manifests/capabilities.3scale.net_tenants.yaml
+++ b/bundle/manifests/capabilities.3scale.net_tenants.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
+  labels:
+    app: 3scale-api-management
   name: tenants.capabilities.3scale.net
 spec:
   group: capabilities.3scale.net

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -54,6 +54,10 @@ patchesStrategicMerge:
 # does not support `oneOf` statement OpenAPI validation
 - patches/product_authentication_openapi_validation_in_products.yaml
 # +kubebuilder:scaffold:crdkustomizeproductproductauthenticationopenapivalidationpatch
+#
+# [3scale CRDs additional app label]. This patch adds the 'app' label for the 3scale CRDs
+- patches/additional_app_label_in_crds.yaml
+# +kubebuilder:scaffold:crdkustomizeadditionalapplabelincrdspatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/config/crd/patches/additional_app_label_in_crds.yaml
+++ b/config/crd/patches/additional_app_label_in_crds.yaml
@@ -1,0 +1,51 @@
+# The following patch adds the 'app' label
+# for the 3scale CRDs
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apimanagers.apps.3scale.net
+  labels:
+    app: 3scale-api-management
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apimanagerbackups.apps.3scale.net
+  labels:
+    app: 3scale-api-management
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apimanagerrestores.apps.3scale.net
+  labels:
+    app: 3scale-api-management
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backends.capabilities.3scale.net
+  labels:
+    app: 3scale-api-management
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: products.capabilities.3scale.net
+  labels:
+    app: 3scale-api-management
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tenants.capabilities.3scale.net
+  labels:
+    app: 3scale-api-management
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: openapis.capabilities.3scale.net
+  labels:
+    app: 3scale-api-management


### PR DESCRIPTION
Adds the 'app' label to 3scale CRDs with value `3scale-api-management`. The chosen value is the same as the default 'app' label value when an APIManager CR is created (although there it can be changed by the user).

operator-sdk and kubebuilder do not provide a way to set the label through any marker so a patch to include the label has been needed.

I've observed in kustomize there's a global variable named `commonLabels` but that adds the labels to all objects, not to just CRDs and also adds it to selectors so that option has not been chosen.