### PR TITLE
Fix APIManager controller e2e tests

### DIFF
--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -114,11 +114,15 @@ var _ = Describe("APIManager controller", func() {
 				return true
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 
+			fmt.Fprintf(GinkgoWriter, "Waiting for all APIManager managed DeploymentConfigs\n")
 			err = waitForAllAPIManagerStandardDeploymentConfigs(testNamespace, 5*time.Second, 15*time.Minute, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "All APIManager managed DeploymentConfigs are ready\n")
 
+			fmt.Fprintf(GinkgoWriter, "Waiting for all APIManager managed Routes\n")
 			err = waitForAllAPIManagerStandardRoutes(testNamespace, 5*time.Second, 15*time.Minute, wildcardDomain, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "All APIManager managed Routes are available\n")
 
 			elapsed := time.Since(start)
 			fmt.Fprintf(GinkgoWriter, "APIManager creation and availability took '%s'\n", elapsed)

--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -170,8 +170,6 @@ func waitForAllAPIManagerStandardDeploymentConfigs(namespace string, retryInterv
 			return false
 
 		}, 15*time.Minute, retryInterval).Should(BeTrue())
-
-		return nil
 	}
 
 	return nil

--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -174,7 +174,7 @@ func waitForAllAPIManagerStandardDeploymentConfigs(namespace string, retryInterv
 			fmt.Fprintf(w, "Waiting for full availability of %s DeploymentConfig (%d/%d)\n", dcName, availableReplicas, desiredReplicas)
 			return false
 
-		}, 15*time.Minute, retryInterval).Should(BeTrue())
+		}, timeout, retryInterval).Should(BeTrue())
 	}
 
 	return nil
@@ -239,7 +239,7 @@ func waitForAllAPIManagerStandardRoutes(namespace string, retryInterval, timeout
 
 			fmt.Fprintf(w, "Route '%s' with host '%s' available\n", route.Name, route.Spec.Host)
 			return true
-		}, 15*time.Minute, retryInterval).Should(BeTrue())
+		}, timeout, retryInterval).Should(BeTrue())
 
 	}
 

--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -185,15 +186,33 @@ func waitForAllAPIManagerStandardRoutes(namespace string, retryInterval, timeout
 		"3scale-admin." + wildcardDomain,                  // System's '3scale' tenant Admin Portal Route
 	}
 	for _, routeHost := range routeHosts {
-		lookupKey := types.NamespacedName{Name: routeHost, Namespace: namespace}
-		createdRoute := &routev1.Route{}
 		Eventually(func() bool {
-			err := testK8sClient.Get(context.Background(), lookupKey, createdRoute)
+			routeList := &routev1.RouteList{}
+			routeListOptions := client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("spec.host", routeHost),
+			}
+			err := testK8sClient.List(context.Background(), routeList, &routeListOptions)
 			if err != nil {
+				if errors.IsNotFound(err) {
+					fmt.Fprintf(w, "Waiting for availability of Route with host '%s'\n", routeHost)
+					return false
+				}
+				fmt.Fprintf(w, "Error Listing Routes with host '%s': %s\n", routeHost, err)
 				return false
 			}
 
-			routeStatusIngresses := createdRoute.Status.Ingress
+			routeItems := routeList.Items
+			if len(routeItems) == 0 {
+				fmt.Fprintf(w, "Waiting for availability of Route with host '%s'\n", routeHost)
+				return false
+			}
+			if len(routeItems) > 1 {
+				fmt.Fprintf(w, "Found unexpected routes with duplicated 'host' fields\n")
+				return false
+			}
+
+			route := routeItems[0]
+			routeStatusIngresses := route.Status.Ingress
 			if routeStatusIngresses == nil || len(routeStatusIngresses) == 0 {
 				fmt.Fprintf(w, "Waiting for availability of Route with host '%s'\n", routeHost)
 				return false
@@ -214,7 +233,7 @@ func waitForAllAPIManagerStandardRoutes(namespace string, retryInterval, timeout
 				}
 			}
 
-			fmt.Fprintf(w, "Route '%s' with host '%s' available\n", createdRoute.Name, createdRoute.Spec.Host)
+			fmt.Fprintf(w, "Route '%s' with host '%s' available\n", route.Name, route.Spec.Host)
 			return true
 		}, 15*time.Minute, retryInterval).Should(BeTrue())
 

--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -121,7 +121,7 @@ var _ = Describe("APIManager controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			elapsed := time.Since(start)
-			fmt.Fprintf(GinkgoWriter, "APIcast creation and availability took '%s'\n", elapsed)
+			fmt.Fprintf(GinkgoWriter, "APIManager creation and availability took '%s'\n", elapsed)
 		})
 	})
 })

--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -191,7 +191,7 @@ func waitForAllAPIManagerStandardRoutes(namespace string, retryInterval, timeout
 			routeListOptions := client.ListOptions{
 				FieldSelector: fields.OneTermEqualSelector("spec.host", routeHost),
 			}
-			err := testK8sClient.List(context.Background(), routeList, &routeListOptions)
+			err := testK8sAPIClient.List(context.Background(), routeList, &routeListOptions)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					fmt.Fprintf(w, "Waiting for availability of Route with host '%s'\n", routeHost)

--- a/controllers/apps/apimanager_controller_test.go
+++ b/controllers/apps/apimanager_controller_test.go
@@ -116,8 +116,8 @@ var _ = Describe("APIManager controller", func() {
 			err = waitForAllAPIManagerStandardDeploymentConfigs(testNamespace, 5*time.Second, 15*time.Minute, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
 
-			// err = waitForAllAPIManagerStandardRoutes(testNamespace, 5*time.Second, 15*time.Minute, wildcardDomain, GinkgoWriter)
-			// Expect(err).ToNot(HaveOccurred())
+			err = waitForAllAPIManagerStandardRoutes(testNamespace, 5*time.Second, 15*time.Minute, wildcardDomain, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
 
 			elapsed := time.Since(start)
 			fmt.Fprintf(GinkgoWriter, "APIcast creation and availability took '%s'\n", elapsed)
@@ -218,7 +218,6 @@ func waitForAllAPIManagerStandardRoutes(namespace string, retryInterval, timeout
 			return true
 		}, 15*time.Minute, retryInterval).Should(BeTrue())
 
-		return nil
 	}
 
 	return nil

--- a/controllers/apps/suite_test.go
+++ b/controllers/apps/suite_test.go
@@ -51,6 +51,7 @@ import (
 
 var cfg *rest.Config
 var testK8sClient client.Client
+var testK8sAPIClient client.Reader
 var testEnv *envtest.Environment
 
 func TestAPIs(t *testing.T) {
@@ -132,6 +133,8 @@ var _ = BeforeSuite(func(done Done) {
 
 	testK8sClient = mgr.GetClient()
 	Expect(testK8sClient).ToNot(BeNil())
+	testK8sAPIClient = mgr.GetAPIReader()
+	Expect(testK8sAPIClient).ToNot(BeNil())
 
 	close(done)
 }, 60)


### PR DESCRIPTION
This PR fixes some bugs on the APIManager controller e2e tests:
* Consider all APIManager managed DCs
* Re-enables waiting for OCP Routes and adapts it to new operator-sdk version used testing framework