### PR TITLE
Improve APIManager reconcile times

### DIFF
--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -191,63 +191,64 @@ func (r *APIManagerReconciler) setAPIManagerDefaults(cr *appsv1alpha1.APIManager
 }
 
 func (r *APIManagerReconciler) reconcileAPIManagerLogic(cr *appsv1alpha1.APIManager) (reconcile.Result, error) {
-	imageReconciler := operator.NewAMPImagesReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	baseAPIManagerLogicReconciler := operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr)
+	imageReconciler := operator.NewAMPImagesReconciler(baseAPIManagerLogicReconciler)
 	result, err := imageReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
 	if !cr.IsExternalDatabaseEnabled() {
-		redisReconciler := operator.NewRedisReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+		redisReconciler := operator.NewRedisReconciler(baseAPIManagerLogicReconciler)
 		result, err = redisReconciler.Reconcile()
 		if err != nil || result.Requeue {
 			return result, err
 		}
 
-		result, err = r.reconcileSystemDatabaseLogic(cr)
+		result, err = r.reconcileSystemDatabaseLogic(cr, baseAPIManagerLogicReconciler)
 		if err != nil || result.Requeue {
 			return result, err
 		}
 	} else {
 		// External databases
-		haReconciler := operator.NewHighAvailabilityReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+		haReconciler := operator.NewHighAvailabilityReconciler(baseAPIManagerLogicReconciler)
 		result, err = haReconciler.Reconcile()
 		if err != nil || result.Requeue {
 			return result, err
 		}
 	}
 
-	backendReconciler := operator.NewBackendReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	backendReconciler := operator.NewBackendReconciler(baseAPIManagerLogicReconciler)
 	result, err = backendReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	memcachedReconciler := operator.NewMemcachedReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	memcachedReconciler := operator.NewMemcachedReconciler(baseAPIManagerLogicReconciler)
 	result, err = memcachedReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	systemReconciler := operator.NewSystemReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	systemReconciler := operator.NewSystemReconciler(baseAPIManagerLogicReconciler)
 	result, err = systemReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	zyncReconciler := operator.NewZyncReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	zyncReconciler := operator.NewZyncReconciler(baseAPIManagerLogicReconciler)
 	result, err = zyncReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	apicastReconciler := operator.NewApicastReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	apicastReconciler := operator.NewApicastReconciler(baseAPIManagerLogicReconciler)
 	result, err = apicastReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	genericMonitoringReconciler := operator.NewGenericMonitoringReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	genericMonitoringReconciler := operator.NewGenericMonitoringReconciler(baseAPIManagerLogicReconciler)
 	result, err = genericMonitoringReconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
@@ -256,35 +257,35 @@ func (r *APIManagerReconciler) reconcileAPIManagerLogic(cr *appsv1alpha1.APIMana
 	return ctrl.Result{}, nil
 }
 
-func (r *APIManagerReconciler) reconcileSystemDatabaseLogic(cr *appsv1alpha1.APIManager) (reconcile.Result, error) {
+func (r *APIManagerReconciler) reconcileSystemDatabaseLogic(cr *appsv1alpha1.APIManager, baseAPIManagerLogicReconciler *operator.BaseAPIManagerLogicReconciler) (reconcile.Result, error) {
 	if cr.Spec.System.DatabaseSpec != nil && cr.Spec.System.DatabaseSpec.PostgreSQL != nil {
-		return r.reconcileSystemPostgreSQLLogic(cr)
+		return r.reconcileSystemPostgreSQLLogic(cr, baseAPIManagerLogicReconciler)
 	}
 
 	// Defaults to MySQL
-	return r.reconcileSystemMySQLLogic(cr)
+	return r.reconcileSystemMySQLLogic(cr, baseAPIManagerLogicReconciler)
 }
 
-func (r *APIManagerReconciler) reconcileSystemPostgreSQLLogic(cr *appsv1alpha1.APIManager) (reconcile.Result, error) {
-	reconciler := operator.NewSystemPostgreSQLReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+func (r *APIManagerReconciler) reconcileSystemPostgreSQLLogic(cr *appsv1alpha1.APIManager, baseAPIManagerLogicReconciler *operator.BaseAPIManagerLogicReconciler) (reconcile.Result, error) {
+	reconciler := operator.NewSystemPostgreSQLReconciler(baseAPIManagerLogicReconciler)
 	result, err := reconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	imageReconciler := operator.NewSystemPostgreSQLImageReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	imageReconciler := operator.NewSystemPostgreSQLImageReconciler(baseAPIManagerLogicReconciler)
 	result, err = imageReconciler.Reconcile()
 	return result, err
 }
 
-func (r *APIManagerReconciler) reconcileSystemMySQLLogic(cr *appsv1alpha1.APIManager) (reconcile.Result, error) {
-	reconciler := operator.NewSystemMySQLReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+func (r *APIManagerReconciler) reconcileSystemMySQLLogic(cr *appsv1alpha1.APIManager, baseAPIManagerLogicReconciler *operator.BaseAPIManagerLogicReconciler) (reconcile.Result, error) {
+	reconciler := operator.NewSystemMySQLReconciler(baseAPIManagerLogicReconciler)
 	result, err := reconciler.Reconcile()
 	if err != nil || result.Requeue {
 		return result, err
 	}
 
-	imageReconciler := operator.NewSystemMySQLImageReconciler(operator.NewBaseAPIManagerLogicReconciler(r.BaseReconciler, cr))
+	imageReconciler := operator.NewSystemMySQLImageReconciler(baseAPIManagerLogicReconciler)
 	result, err = imageReconciler.Reconcile()
 	return result, err
 }

--- a/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
+++ b/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
@@ -29,10 +29,10 @@ type BaseAPIManagerLogicReconciler struct {
 }
 
 type baseAPIManagerLogicReconcilerCRDAvailabilityCache struct {
-	grafanaCRDAvailable        *bool
-	prometheusRuleCRDAvailable *bool
-	podMonitorCRDAvailable     *bool
-	serviceMonitorCRDAvailable *bool
+	grafanaDashboardCRDAvailable *bool
+	prometheusRuleCRDAvailable   *bool
+	podMonitorCRDAvailable       *bool
+	serviceMonitorCRDAvailable   *bool
 }
 
 func NewBaseAPIManagerLogicReconciler(b *reconcilers.BaseReconciler, apiManager *appsv1alpha1.APIManager) *BaseAPIManagerLogicReconciler {
@@ -217,16 +217,16 @@ func (r *BaseAPIManagerLogicReconciler) Logger() logr.Logger {
 }
 
 func (b *BaseAPIManagerLogicReconciler) HasGrafanaDashboards() (bool, error) {
-	if b.crdAvailabilityCache.grafanaCRDAvailable == nil {
+	if b.crdAvailabilityCache.grafanaDashboardCRDAvailable == nil {
 		res, err := b.BaseReconciler.HasGrafanaDashboards()
 		if err != nil {
 			return res, err
 		}
-		b.crdAvailabilityCache.grafanaCRDAvailable = &res
+		b.crdAvailabilityCache.grafanaDashboardCRDAvailable = &res
 		return res, err
 	}
 
-	return *b.crdAvailabilityCache.grafanaCRDAvailable, nil
+	return *b.crdAvailabilityCache.grafanaDashboardCRDAvailable, nil
 }
 
 //HasPrometheusRules checks if the PrometheusRules CRD is supported in current cluster

--- a/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
+++ b/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
@@ -23,15 +23,24 @@ import (
 
 type BaseAPIManagerLogicReconciler struct {
 	*reconcilers.BaseReconciler
-	apiManager *appsv1alpha1.APIManager
-	logger     logr.Logger
+	apiManager           *appsv1alpha1.APIManager
+	logger               logr.Logger
+	crdAvailabilityCache *baseAPIManagerLogicReconcilerCRDAvailabilityCache
+}
+
+type baseAPIManagerLogicReconcilerCRDAvailabilityCache struct {
+	grafanaCRDAvailable        *bool
+	prometheusRuleCRDAvailable *bool
+	podMonitorCRDAvailable     *bool
+	serviceMonitorCRDAvailable *bool
 }
 
 func NewBaseAPIManagerLogicReconciler(b *reconcilers.BaseReconciler, apiManager *appsv1alpha1.APIManager) *BaseAPIManagerLogicReconciler {
 	return &BaseAPIManagerLogicReconciler{
-		BaseReconciler: b,
-		apiManager:     apiManager,
-		logger:         b.Logger().WithValues("APIManager Controller", apiManager.Name),
+		BaseReconciler:       b,
+		apiManager:           apiManager,
+		logger:               b.Logger().WithValues("APIManager Controller", apiManager.Name),
+		crdAvailabilityCache: &baseAPIManagerLogicReconcilerCRDAvailabilityCache{},
 	}
 }
 
@@ -205,4 +214,54 @@ func (r *BaseAPIManagerLogicReconciler) APIManagerMutator(mutateFn reconcilers.M
 
 func (r *BaseAPIManagerLogicReconciler) Logger() logr.Logger {
 	return r.logger
+}
+
+func (b *BaseAPIManagerLogicReconciler) HasGrafanaDashboards() (bool, error) {
+	if b.crdAvailabilityCache.grafanaCRDAvailable == nil {
+		res, err := b.BaseReconciler.HasGrafanaDashboards()
+		if err != nil {
+			return res, err
+		}
+		b.crdAvailabilityCache.grafanaCRDAvailable = &res
+		return res, err
+	}
+
+	return *b.crdAvailabilityCache.grafanaCRDAvailable, nil
+}
+
+//HasPrometheusRules checks if the PrometheusRules CRD is supported in current cluster
+func (b *BaseAPIManagerLogicReconciler) HasPrometheusRules() (bool, error) {
+	if b.crdAvailabilityCache.prometheusRuleCRDAvailable == nil {
+		res, err := b.BaseReconciler.HasPrometheusRules()
+		if err != nil {
+			return res, err
+		}
+		b.crdAvailabilityCache.prometheusRuleCRDAvailable = &res
+		return res, err
+	}
+	return *b.crdAvailabilityCache.prometheusRuleCRDAvailable, nil
+}
+
+func (b *BaseAPIManagerLogicReconciler) HasServiceMonitors() (bool, error) {
+	if b.crdAvailabilityCache.serviceMonitorCRDAvailable == nil {
+		res, err := b.BaseReconciler.HasServiceMonitors()
+		if err != nil {
+			return res, err
+		}
+		b.crdAvailabilityCache.serviceMonitorCRDAvailable = &res
+		return res, err
+	}
+	return *b.crdAvailabilityCache.serviceMonitorCRDAvailable, nil
+}
+
+func (b *BaseAPIManagerLogicReconciler) HasPodMonitors() (bool, error) {
+	if b.crdAvailabilityCache.podMonitorCRDAvailable == nil {
+		res, err := b.BaseReconciler.HasPodMonitors()
+		if err != nil {
+			return res, err
+		}
+		b.crdAvailabilityCache.podMonitorCRDAvailable = &res
+		return res, err
+	}
+	return *b.crdAvailabilityCache.podMonitorCRDAvailable, nil
 }

--- a/pkg/3scale/amp/operator/base_apimanager_logic_reconciler_test.go
+++ b/pkg/3scale/amp/operator/base_apimanager_logic_reconciler_test.go
@@ -7,6 +7,8 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,5 +95,413 @@ func TestBaseAPIManagerLogicReconcilerUpdateOwnerRef(t *testing.T) {
 
 	if reconciledConfigmap.GetOwnerReferences()[0].Name != apimanagerName {
 		t.Errorf("reconciled owner reference is not apimanager, expected: %s, got: %s", apimanagerName, reconciledConfigmap.GetOwnerReferences()[0].Name)
+	}
+}
+
+func TestBaseAPIManagerLogicReconcilerHasPrometheusRules(t *testing.T) {
+	var (
+		apimanagerName = "example-apimanager"
+		namespace      = "operator-unittest"
+		log            = logf.Log.WithName("operator_test")
+	)
+
+	ctx := context.TODO()
+	apimanager := &appsv1alpha1.APIManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apimanagerName,
+			Namespace: namespace,
+		},
+		Spec: appsv1alpha1.APIManagerSpec{},
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	if err := monitoringv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := grafanav1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{apimanager}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+
+	prometheusAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: monitoringv1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: monitoringv1.PrometheusRuleName, Namespaced: true, Kind: monitoringv1.PrometheusRuleKind},
+			{Name: monitoringv1.PodMonitorName, Namespaced: true, Kind: monitoringv1.PodMonitorsKind},
+			{Name: monitoringv1.ServiceMonitorName, Namespaced: false, Kind: monitoringv1.ServiceMonitorsKind},
+		},
+	}
+	grafanaAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: grafanav1alpha1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: "grafanadashboards", Namespaced: true, Kind: grafanav1alpha1.GrafanaDashboardKind},
+		},
+	}
+
+	clientset.Resources = []*metav1.APIResourceList{
+		prometheusAPIResourceList,
+		grafanaAPIResourceList,
+	}
+	baseReconciler := reconcilers.NewBaseReconciler(cl, s, clientAPIReader, ctx, log, clientset.Discovery(), recorder)
+	apimanagerLogicReconciler := NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+
+	// Test uncached request. Resource should exist
+	exists, err := apimanagerLogicReconciler.HasPrometheusRules()
+	if err != nil {
+		t.Fatalf("Unexpected error received")
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test cached request. It should return the same results as before
+	exists, err = apimanagerLogicReconciler.HasPrometheusRules()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test that we are indeed receiving cached requests by simulating
+	// the removal of CRD types. We now expect to still receive that the
+	// resource exists even when we've removed it from the defined CRDs because
+	// the cache should be working and not seeing the new change.
+	clientset.Resources = []*metav1.APIResourceList{
+		grafanaAPIResourceList,
+	}
+	exists, err = apimanagerLogicReconciler.HasPrometheusRules()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Create a new APIManagerLogicReconciler to simulate a new state of cache
+	// with the resource now removed. We now should receive that it does not
+	// exist
+	apimanagerLogicReconciler = NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+	exists, err = apimanagerLogicReconciler.HasPrometheusRules()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", false, exists)
+	}
+}
+
+func TestBaseAPIManagerLogicReconcilerHasGrafanaDashboards(t *testing.T) {
+	var (
+		apimanagerName = "example-apimanager"
+		namespace      = "operator-unittest"
+		log            = logf.Log.WithName("operator_test")
+	)
+
+	ctx := context.TODO()
+	apimanager := &appsv1alpha1.APIManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apimanagerName,
+			Namespace: namespace,
+		},
+		Spec: appsv1alpha1.APIManagerSpec{},
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	if err := monitoringv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := grafanav1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{apimanager}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+
+	prometheusAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: monitoringv1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: monitoringv1.PrometheusRuleName, Namespaced: true, Kind: monitoringv1.PrometheusRuleKind},
+			{Name: monitoringv1.PodMonitorName, Namespaced: true, Kind: monitoringv1.PodMonitorsKind},
+			{Name: monitoringv1.ServiceMonitorName, Namespaced: false, Kind: monitoringv1.ServiceMonitorsKind},
+		},
+	}
+	grafanaAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: grafanav1alpha1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: "grafanadashboards", Namespaced: true, Kind: grafanav1alpha1.GrafanaDashboardKind},
+		},
+	}
+
+	clientset.Resources = []*metav1.APIResourceList{
+		prometheusAPIResourceList,
+		grafanaAPIResourceList,
+	}
+	baseReconciler := reconcilers.NewBaseReconciler(cl, s, clientAPIReader, ctx, log, clientset.Discovery(), recorder)
+	apimanagerLogicReconciler := NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+
+	// Test uncached request. Resource should exist
+	exists, err := apimanagerLogicReconciler.HasGrafanaDashboards()
+	if err != nil {
+		t.Fatalf("Unexpected error received")
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test cached request. It should return the same results as before
+	exists, err = apimanagerLogicReconciler.HasGrafanaDashboards()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test that we are indeed receiving cached requests by simulating
+	// the removal of CRD types. We now expect to still receive that the
+	// resource exists even when we've removed it from the defined CRDs because
+	// the cache should be working and not seeing the new change.
+	clientset.Resources = []*metav1.APIResourceList{
+		prometheusAPIResourceList,
+	}
+	exists, err = apimanagerLogicReconciler.HasGrafanaDashboards()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Create a new APIManagerLogicReconciler to simulate a new state of cache
+	// with the resource now removed. We now should receive that it does not
+	// exist
+	apimanagerLogicReconciler = NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+	exists, err = apimanagerLogicReconciler.HasGrafanaDashboards()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", false, exists)
+	}
+}
+
+func TestBaseAPIManagerLogicReconcilerHasPodMonitors(t *testing.T) {
+	var (
+		apimanagerName = "example-apimanager"
+		namespace      = "operator-unittest"
+		log            = logf.Log.WithName("operator_test")
+	)
+
+	ctx := context.TODO()
+	apimanager := &appsv1alpha1.APIManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apimanagerName,
+			Namespace: namespace,
+		},
+		Spec: appsv1alpha1.APIManagerSpec{},
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	if err := monitoringv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := grafanav1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{apimanager}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+
+	prometheusAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: monitoringv1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: monitoringv1.PrometheusRuleName, Namespaced: true, Kind: monitoringv1.PrometheusRuleKind},
+			{Name: monitoringv1.PodMonitorName, Namespaced: true, Kind: monitoringv1.PodMonitorsKind},
+			{Name: monitoringv1.ServiceMonitorName, Namespaced: false, Kind: monitoringv1.ServiceMonitorsKind},
+		},
+	}
+	grafanaAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: grafanav1alpha1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: "grafanadashboards", Namespaced: true, Kind: grafanav1alpha1.GrafanaDashboardKind},
+		},
+	}
+
+	clientset.Resources = []*metav1.APIResourceList{
+		prometheusAPIResourceList,
+		grafanaAPIResourceList,
+	}
+	baseReconciler := reconcilers.NewBaseReconciler(cl, s, clientAPIReader, ctx, log, clientset.Discovery(), recorder)
+	apimanagerLogicReconciler := NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+
+	// Test uncached request. Resource should exist
+	exists, err := apimanagerLogicReconciler.HasPodMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received")
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test cached request. It should return the same results as before
+	exists, err = apimanagerLogicReconciler.HasPodMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test that we are indeed receiving cached requests by simulating
+	// the removal of CRD types. We now expect to still receive that the
+	// resource exists even when we've removed it from the defined CRDs because
+	// the cache should be working and not seeing the new change.
+	clientset.Resources = []*metav1.APIResourceList{
+		grafanaAPIResourceList,
+	}
+	exists, err = apimanagerLogicReconciler.HasPodMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Create a new APIManagerLogicReconciler to simulate a new state of cache
+	// with the resource now removed. We now should receive that it does not
+	// exist
+	apimanagerLogicReconciler = NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+	exists, err = apimanagerLogicReconciler.HasPodMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", false, exists)
+	}
+}
+
+func TestBaseAPIManagerLogicReconcilerHasServiceMonitors(t *testing.T) {
+	var (
+		apimanagerName = "example-apimanager"
+		namespace      = "operator-unittest"
+		log            = logf.Log.WithName("operator_test")
+	)
+
+	ctx := context.TODO()
+	apimanager := &appsv1alpha1.APIManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apimanagerName,
+			Namespace: namespace,
+		},
+		Spec: appsv1alpha1.APIManagerSpec{},
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	if err := monitoringv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := grafanav1alpha1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{apimanager}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+
+	prometheusAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: monitoringv1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: monitoringv1.PrometheusRuleName, Namespaced: true, Kind: monitoringv1.PrometheusRuleKind},
+			{Name: monitoringv1.PodMonitorName, Namespaced: true, Kind: monitoringv1.PodMonitorsKind},
+			{Name: monitoringv1.ServiceMonitorName, Namespaced: false, Kind: monitoringv1.ServiceMonitorsKind},
+		},
+	}
+	grafanaAPIResourceList := &metav1.APIResourceList{
+		GroupVersion: grafanav1alpha1.SchemeGroupVersion.String(),
+		APIResources: []metav1.APIResource{
+			{Name: "grafanadashboards", Namespaced: true, Kind: grafanav1alpha1.GrafanaDashboardKind},
+		},
+	}
+
+	clientset.Resources = []*metav1.APIResourceList{
+		prometheusAPIResourceList,
+		grafanaAPIResourceList,
+	}
+	baseReconciler := reconcilers.NewBaseReconciler(cl, s, clientAPIReader, ctx, log, clientset.Discovery(), recorder)
+	apimanagerLogicReconciler := NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+
+	// Test uncached request. Resource should exist
+	exists, err := apimanagerLogicReconciler.HasServiceMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received")
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test cached request. It should return the same results as before
+	exists, err = apimanagerLogicReconciler.HasServiceMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Test that we are indeed receiving cached requests by simulating
+	// the removal of CRD types. We now expect to still receive that the
+	// resource exists even when we've removed it from the defined CRDs because
+	// the cache should be working and not seeing the new change.
+	clientset.Resources = []*metav1.APIResourceList{
+		grafanaAPIResourceList,
+	}
+	exists, err = apimanagerLogicReconciler.HasServiceMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if !exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", true, exists)
+	}
+
+	// Create a new APIManagerLogicReconciler to simulate a new state of cache
+	// with the resource now removed. We now should receive that it does not
+	// exist
+	apimanagerLogicReconciler = NewBaseAPIManagerLogicReconciler(baseReconciler, apimanager)
+	exists, err = apimanagerLogicReconciler.HasServiceMonitors()
+	if err != nil {
+		t.Fatalf("Unexpected error received: %s", err)
+	}
+	if exists {
+		t.Fatalf("Unexpected exists value received. Expected: %t, got: %t", false, exists)
 	}
 }


### PR DESCRIPTION
### Summary
I detected reconciliation times for APIManager were abnormally long.
This PR improves the time it takes to perform a reconciliation event from 1.5 minutes to 2-3 seconds approximately (a 96.7%  reduction approximately)

### Detailed investigation
After investigating the issue I noticed that reconciliation was taking abnormally long time in the APIManager controller. After measuring it I observed it was taking abnormally long times:
```
2020-11-17T14:42:13.952+0100	INFO	controllers.APIManager	Full reconciliation took 1m33.955830582s
```
Going into a little bit more of detail I observed that the cause of this long execution times was due to the requests we do to check whether monitoring CRDs exist or not via the K8s DiscoveryClient. This was introduced when monitoring functionality was added into the operator. This slowness happened independently of the value of the `.spec.monitoring.enabled` flag.

I measured that each call to check whether a CRD existed or not with the DiscoveryClient took 3-4 seconds approximately:
```
2020-11-17T14:51:44.736+0100    INFO    controllers.APIManager  Backend Worker PrometheusRules reconcile took 4.119325517s      {"APIManager Controller": "example-apimanager"}
```

In each reconcile event we do multiple calls to check whether CRDs exist. One time per each CR related to monitoring that we have thus explaining this 1.5 minutes for each reconciliation event.

To reduce this long times two optimizations have been applied:
1. The DiscoveryClient call to `ServerGroupsAndResources` has been replaced by `ServerResourcesForGroupVersion`. This reduced the processing that the K8s APIServer had to do and the response size reducing considerably the time taken for the calls
2. In BaseAPIManagerLogicReconciler we have added a cache that contains CRD availability states allowing us avoiding to do real API calls with the DiscoveryClient once cached. Now all APIManager contents receive the same shared BaseAPIManagerLogicReconciler instance so they are able to share the cache. BaseAPIManagerLogicReconciler is created once per reconcile event so the cache lifecycle is one reconciliation event.

### Results
This optimizations have reduced the reconciliation event times to 2-3 seconds:
```
2020-11-17T18:04:52.855+0100    INFO    controllers.APIManager  Full reconciliation took 2.683286778s
```

Now real calls to DiscoveryClient CRD checking take 200-500ms:
```
2020-11-17T18:04:52.267+0100    INFO    controllers.APIManager  Backend Worker PodMonitor reconcile took 292.082717ms   {"APIManager Controller": "example-apimanager"}
```

And cached calls are in the order of microseconds:
```
2020-11-17T18:04:52.267+0100    INFO    controllers.APIManager  Backend Listener PodMonitor reconcile took 24.658µs     {"APIManager Controller": "example-apimanager"}
```