### PR TITLE
Fix system env var backend route

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -400,7 +400,7 @@ The available configurable secrets are:
 
 | **Field** | **Description** | **Default value** |
 | --- | --- | --- |
-| service_endpoint | Backend listener service endpoint. Used by System | `http://backend-listener:3000` |
+| service_endpoint | Backend listener service endpoint. Used by System and Apicast | `http://backend-listener:3000` |
 | route_endpoint | Backend listener route endpoint. Used by System | `https://backend-<tenantName>.<wildcardDomain>` |
 
 ### backend-redis

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1734,10 +1734,7 @@ objects:
                   key: route_endpoint
                   name: backend-listener
             - name: BACKEND_ROUTE
-              valueFrom:
-                secretKeyRef:
-                  key: route_endpoint
-                  name: backend-listener
+              value: http://backend-listener:3000/internal/
             - name: SMTP_ADDRESS
               valueFrom:
                 secretKeyRef:
@@ -2056,10 +2053,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2389,10 +2383,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2721,10 +2712,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -3112,10 +3100,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1750,10 +1750,7 @@ objects:
                   key: route_endpoint
                   name: backend-listener
             - name: BACKEND_ROUTE
-              valueFrom:
-                secretKeyRef:
-                  key: route_endpoint
-                  name: backend-listener
+              value: http://backend-listener:3000/internal/
             - name: SMTP_ADDRESS
               valueFrom:
                 secretKeyRef:
@@ -2031,10 +2028,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2323,10 +2317,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2614,10 +2605,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2968,10 +2956,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -1270,10 +1270,7 @@ objects:
                   key: route_endpoint
                   name: backend-listener
             - name: BACKEND_ROUTE
-              valueFrom:
-                secretKeyRef:
-                  key: route_endpoint
-                  name: backend-listener
+              value: http://backend-listener:3000/internal/
             - name: SMTP_ADDRESS
               valueFrom:
                 secretKeyRef:
@@ -1551,10 +1548,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -1849,10 +1843,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2146,10 +2137,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2506,10 +2494,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1742,10 +1742,7 @@ objects:
                   key: route_endpoint
                   name: backend-listener
             - name: BACKEND_ROUTE
-              valueFrom:
-                secretKeyRef:
-                  key: route_endpoint
-                  name: backend-listener
+              value: http://backend-listener:3000/internal/
             - name: SMTP_ADDRESS
               valueFrom:
                 secretKeyRef:
@@ -2023,10 +2020,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2321,10 +2315,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2618,10 +2609,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2978,10 +2966,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1775,10 +1775,7 @@ objects:
                   key: route_endpoint
                   name: backend-listener
             - name: BACKEND_ROUTE
-              valueFrom:
-                secretKeyRef:
-                  key: route_endpoint
-                  name: backend-listener
+              value: http://backend-listener:3000/internal/
             - name: SMTP_ADDRESS
               valueFrom:
                 secretKeyRef:
@@ -2097,10 +2094,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2436,10 +2430,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2774,10 +2765,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -3171,10 +3159,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1791,10 +1791,7 @@ objects:
                   key: route_endpoint
                   name: backend-listener
             - name: BACKEND_ROUTE
-              valueFrom:
-                secretKeyRef:
-                  key: route_endpoint
-                  name: backend-listener
+              value: http://backend-listener:3000/internal/
             - name: SMTP_ADDRESS
               valueFrom:
                 secretKeyRef:
@@ -2072,10 +2069,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2370,10 +2364,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -2667,10 +2658,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:
@@ -3027,10 +3015,7 @@ objects:
                 key: route_endpoint
                 name: backend-listener
           - name: BACKEND_ROUTE
-            valueFrom:
-              secretKeyRef:
-                key: route_endpoint
-                name: backend-listener
+            value: http://backend-listener:3000/internal/
           - name: SMTP_ADDRESS
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -314,7 +314,7 @@ func (apicast *Apicast) ProductionDeploymentConfig() *appsv1.DeploymentConfig {
 func (apicast *Apicast) buildApicastCommonEnv() []v1.EnvVar {
 	result := []v1.EnvVar{
 		helper.EnvVarFromSecret("THREESCALE_PORTAL_ENDPOINT", "system-master-apicast", SystemSecretSystemMasterApicastProxyConfigsEndpointFieldName),
-		helper.EnvVarFromSecret("BACKEND_ENDPOINT_OVERRIDE", "backend-listener", "service_endpoint"),
+		helper.EnvVarFromSecret("BACKEND_ENDPOINT_OVERRIDE", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerServiceEndpointFieldName),
 		helper.EnvVarFromConfigMap("APICAST_MANAGEMENT_API", "apicast-environment", "APICAST_MANAGEMENT_API"),
 		helper.EnvVarFromConfigMap("OPENSSL_VERIFY", "apicast-environment", "OPENSSL_VERIFY"),
 		helper.EnvVarFromConfigMap("APICAST_RESPONSE_CODES", "apicast-environment", "APICAST_RESPONSE_CODES"),

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -48,7 +48,7 @@ func (b *BackendOptions) Validate() error {
 }
 
 func DefaultBackendServiceEndpoint() string {
-	return "http://backend-listener:3000/internal/"
+	return "http://backend-listener:3000"
 }
 
 func DefaultBackendListenerResourceRequirements() v1.ResourceRequirements {

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -48,7 +48,7 @@ func (b *BackendOptions) Validate() error {
 }
 
 func DefaultBackendServiceEndpoint() string {
-	return "http://backend-listener:3000"
+	return "http://backend-listener:3000/internal/"
 }
 
 func DefaultBackendListenerResourceRequirements() v1.ResourceRequirements {

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -220,7 +220,7 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 	result = append(result, system.SystemRedisEnvVars()...)
 	result = append(result, system.BackendRedisEnvVars()...)
 	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", "backend-listener", "route_endpoint")
-	bckListenerRouteEnv := helper.EnvVarFromSecret("BACKEND_ROUTE", "backend-listener", "route_endpoint")
+	bckListenerRouteEnv := helper.EnvVarFromSecret("BACKEND_ROUTE", "backend-listener", BackendSecretBackendListenerServiceEndpointFieldName)
 	result = append(result, bckListenerApicastRouteEnv, bckListenerRouteEnv)
 
 	smtpEnvSecretEnvs := system.getSystemSMTPEnvsFromSMTPSecret()

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -219,8 +219,8 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 
 	result = append(result, system.SystemRedisEnvVars()...)
 	result = append(result, system.BackendRedisEnvVars()...)
-	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", "backend-listener", "route_endpoint")
-	bckListenerRouteEnv := helper.EnvVarFromSecret("BACKEND_ROUTE", "backend-listener", BackendSecretBackendListenerServiceEndpointFieldName)
+	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
+	bckListenerRouteEnv := helper.EnvVarFromValue("BACKEND_ROUTE", system.Options.BackendRouteEndpoint)
 	result = append(result, bckListenerApicastRouteEnv, bckListenerRouteEnv)
 
 	smtpEnvSecretEnvs := system.getSystemSMTPEnvsFromSMTPSecret()

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -220,7 +220,7 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 	result = append(result, system.SystemRedisEnvVars()...)
 	result = append(result, system.BackendRedisEnvVars()...)
 	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
-	bckListenerRouteEnv := helper.EnvVarFromValue("BACKEND_ROUTE", system.Options.BackendRouteEndpoint)
+	bckListenerRouteEnv := helper.EnvVarFromValue("BACKEND_ROUTE", system.Options.BackendServiceEndpoint)
 	result = append(result, bckListenerApicastRouteEnv, bckListenerRouteEnv)
 
 	smtpEnvSecretEnvs := system.getSystemSMTPEnvsFromSMTPSecret()

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -90,6 +90,8 @@ type SystemOptions struct {
 	AppMetrics               bool
 
 	IncludeOracleOptionalSettings bool
+
+	BackendRouteEndpoint string `validate:"required"`
 }
 
 func NewSystemOptions() *SystemOptions {

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -91,7 +91,7 @@ type SystemOptions struct {
 
 	IncludeOracleOptionalSettings bool
 
-	BackendRouteEndpoint string `validate:"required"`
+	BackendServiceEndpoint string `validate:"required"`
 }
 
 func NewSystemOptions() *SystemOptions {

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+	"net/url"
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
@@ -110,6 +111,11 @@ func (s *SystemOptionsProvider) setSecretBasedOptions() error {
 	err = s.setSystemSMTPOptions()
 	if err != nil {
 		return fmt.Errorf("unable to create System SMTP secret options - %s", err)
+	}
+
+	err = s.setBackendOptions()
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -339,6 +345,29 @@ func (s *SystemOptionsProvider) setSystemSMTPOptions() error {
 	}
 
 	s.options.SmtpSecretOptions = smtpSecretOptions
+	return nil
+}
+
+func (s *SystemOptionsProvider) setBackendOptions() error {
+	rawURL, err := s.secretSource.FieldValue(
+		component.BackendSecretBackendListenerSecretName,
+		component.BackendSecretBackendListenerServiceEndpointFieldName,
+		component.DefaultBackendServiceEndpoint())
+	if err != nil {
+		return err
+	}
+
+	urlObj, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("'%s' field of '%s' secret must have 'scheme://user:password@host/path' format", component.BackendSecretBackendListenerServiceEndpointFieldName, component.BackendSecretBackendListenerSecretName)
+	}
+
+	if urlObj.Path == "" {
+		urlObj.Path = "/internal/"
+	}
+
+	s.options.BackendRouteEndpoint = urlObj.String()
+
 	return nil
 }
 

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -366,7 +366,7 @@ func (s *SystemOptionsProvider) setBackendOptions() error {
 		urlObj.Path = "/internal/"
 	}
 
-	s.options.BackendRouteEndpoint = urlObj.String()
+	s.options.BackendServiceEndpoint = urlObj.String()
 
 	return nil
 }

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -362,6 +363,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		SideKiqMetrics:                true,
 		AppMetrics:                    true,
 		IncludeOracleOptionalSettings: true,
+		BackendRouteEndpoint:          fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
 	}
 
 	expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(opts.ApicastAccessToken)

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -363,7 +363,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		SideKiqMetrics:                true,
 		AppMetrics:                    true,
 		IncludeOracleOptionalSettings: true,
-		BackendRouteEndpoint:          fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
+		BackendServiceEndpoint:        fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
 	}
 
 	expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(opts.ApicastAccessToken)

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -1,6 +1,8 @@
 package adapters
 
 import (
+	"fmt"
+
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/common"
 	templatev1 "github.com/openshift/api/template/v1"
@@ -264,6 +266,7 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.SphinxPodTemplateLabels = s.sphinxPodTemplateLabels()
 	o.MemcachedLabels = s.memcachedLabels()
 	o.SMTPLabels = s.smtpLabels()
+	o.BackendRouteEndpoint = s.backendRouteEndpoint()
 
 	err := o.Validate()
 	return o, err
@@ -340,4 +343,8 @@ func (s *System) smtpLabels() map[string]string {
 	labels := s.commonLabels()
 	labels["threescale_component_element"] = "smtp"
 	return labels
+}
+
+func (s *System) backendRouteEndpoint() string {
+	return fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/")
 }

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -266,7 +266,7 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.SphinxPodTemplateLabels = s.sphinxPodTemplateLabels()
 	o.MemcachedLabels = s.memcachedLabels()
 	o.SMTPLabels = s.smtpLabels()
-	o.BackendRouteEndpoint = s.backendRouteEndpoint()
+	o.BackendServiceEndpoint = s.backendServiceEndpoint()
 
 	err := o.Validate()
 	return o, err
@@ -345,6 +345,6 @@ func (s *System) smtpLabels() map[string]string {
 	return labels
 }
 
-func (s *System) backendRouteEndpoint() string {
+func (s *System) backendServiceEndpoint() string {
 	return fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/")
 }


### PR DESCRIPTION
Recently, it was merged in Porta [this PR](https://github.com/3scale/porta/pull/2268) 

Now, they are respecting the `BACKEND_ROUTE` env var set in deployment. 

Before, Porta was reading some unset env var `THREESCALE_CORE_INTERNAL_API` and it did not exist, so they were using as backend route: `http://backend-listener:3000/internal/`. It worked as expected. 

But now, as `BACKEND_ROUTE` env var is respected, in 3scale operator CI, 3scale system tries to connect to `https://backend-3scale.lvh.me`, and ovbiously, it fails. 
```
Errno::ECONNREFUSED: Connection refused - connect(2) for "backend-3scale.lvh.me" port 443
/opt/system/vendor/bundle/ruby/2.5.0/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:692:in `start'
/opt/system/vendor/bundle/ruby/2.5.0/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:622:in `connection_for'
/opt/system/vendor/bundle/ruby/2.5.0/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:927:in `request'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/adapter/net_http_persistent.rb:36:in `perform_request'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/adapter/net_http.rb:43:in `block in call'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/adapter/net_http.rb:92:in `with_net_http_connection'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/adapter/net_http.rb:38:in `call'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/rack_builder.rb:143:in `build_response'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/connection.rb:387:in `run_request'
/opt/system/vendor/bundle/ruby/2.5.0/gems/faraday-0.15.3/lib/faraday/connection.rb:138:in `get'
/opt/system/vendor/bundle/ruby/2.5.0/gems/pisoni-1.29.0/lib/3scale/core/api_client/operations.rb:103:in `api_http'
/opt/system/vendor/bundle/ruby/2.5.0/gems/pisoni-1.29.0/lib/3scale/core/api_client/operations.rb:186:in `api'
/opt/system/lib/tasks/boot.rake:6:in `block (2 levels) in <top (required)>'
/opt/system/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag/integrations/rake.rb:18:in `execute_with_bugsnag'
/opt/system/vendor/bundle/ruby/2.5.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/cli.rb:18:in `start'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/opt/rh/rh-ruby25/root/usr/local/share/gems/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
/opt/rh/rh-ruby25/root/usr/local/bin/bundle:23:in `load'
/opt/rh/rh-ruby25/root/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => boot => boot:all => boot:backend
(See full trace by running task with --trace)
```

The initial consequence is that CI tests for nightly builds do not work, therefore, nightly images are not being pushed.  

The proposed solution is to pass internal service endpoint which uses OCP service domain name.

An alternative solution would be to leave templates as they are. When OCP cluster domain names are not fake (like mydomain.lvh.me), the route is supposed to work. Maybe it is missing the `/internal` path. With this approach, our CI tests should be changed to override the passed env var to use OCP service endpoint, because cluster domain name is not usable. I did not pick this approach because there is no need to pass FQDN to system to reach backend, as they are pods inside the same namespace and service level connection is preferred. 

Checked that apicast services receive external backend route instead of internal endpoint. Required for self managed apicast services running in another namespace and/or cluster.

TODO:
- [x] upgrade procedure
