### PR TITLE
Fix Zync monitoring annotations location

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3578,9 +3578,6 @@ objects:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      prometheus.io/port: "9393"
-      prometheus.io/scrape: "true"
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
@@ -3594,6 +3591,9 @@ objects:
       resources: {}
     template:
       metadata:
+        annotations:
+          prometheus.io/port: "9393"
+          prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
           app: ${APP_LABEL}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3396,9 +3396,6 @@ objects:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      prometheus.io/port: "9393"
-      prometheus.io/scrape: "true"
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
@@ -3412,6 +3409,9 @@ objects:
       resources: {}
     template:
       metadata:
+        annotations:
+          prometheus.io/port: "9393"
+          prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
           app: ${APP_LABEL}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2984,9 +2984,6 @@ objects:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      prometheus.io/port: "9393"
-      prometheus.io/scrape: "true"
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
@@ -3000,6 +2997,9 @@ objects:
       resources: {}
     template:
       metadata:
+        annotations:
+          prometheus.io/port: "9393"
+          prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
           app: ${APP_LABEL}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3418,9 +3418,6 @@ objects:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      prometheus.io/port: "9393"
-      prometheus.io/scrape: "true"
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
@@ -3434,6 +3431,9 @@ objects:
       resources: {}
     template:
       metadata:
+        annotations:
+          prometheus.io/port: "9393"
+          prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
           app: ${APP_LABEL}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3649,9 +3649,6 @@ objects:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      prometheus.io/port: "9393"
-      prometheus.io/scrape: "true"
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
@@ -3665,6 +3662,9 @@ objects:
       resources: {}
     template:
       metadata:
+        annotations:
+          prometheus.io/port: "9393"
+          prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
           app: ${APP_LABEL}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3467,9 +3467,6 @@ objects:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      prometheus.io/port: "9393"
-      prometheus.io/scrape: "true"
     creationTimestamp: null
     labels:
       app: ${APP_LABEL}
@@ -3483,6 +3480,9 @@ objects:
       resources: {}
     template:
       metadata:
+        annotations:
+          prometheus.io/port: "9393"
+          prometheus.io/scrape: "true"
         creationTimestamp: null
         labels:
           app: ${APP_LABEL}

--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -170,10 +170,6 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   ZyncName,
 			Labels: zync.Options.CommonZyncLabels,
-			Annotations: map[string]string{
-				"prometheus.io/port":   "9393",
-				"prometheus.io/scrape": "true",
-			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
 			Triggers: appsv1.DeploymentTriggerPolicies{
@@ -200,6 +196,10 @@ func (zync *Zync) DeploymentConfig() *appsv1.DeploymentConfig {
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: zync.Options.ZyncPodTemplateLabels,
+					Annotations: map[string]string{
+						"prometheus.io/port":   "9393",
+						"prometheus.io/scrape": "true",
+					},
 				},
 				Spec: v1.PodSpec{
 					Affinity:           zync.Options.ZyncAffinity,


### PR DESCRIPTION
Zync DeploymentConfig had the following annotations defined as part of the DC annotations:
```
    annotations:
      prometheus.io/port: "9393"
      prometheus.io/scrape: "true"
```

They should belong to Zync's PodTemplate annotations and not Zync's DC annotations themselves.

This does not affect operator monitoring functionality because we use `PodMonitor` there but we should fix this anyway (it's provided in templates too and there there's no CRs)

This PR takes care of changing that.

Related issue: https://issues.redhat.com/browse/THREESCALE-6509