### PR TITLE
fix upgrade when monitoring is disabled

### DIFF
--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -530,6 +530,10 @@ func (u *UpgradeApiManager) ensureSystemAppMonitoringSettings() (bool, error) {
 }
 
 func (u *UpgradeApiManager) upgradePrometheusRules(desired *monitoringv1.PrometheusRule) (bool, error) {
+	if !u.apiManager.IsMonitoringEnabled() {
+		return false, nil
+	}
+
 	existing := &monitoringv1.PrometheusRule{}
 	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: u.apiManager.Namespace}, existing)
 	if err != nil {


### PR DESCRIPTION
When monitoring was disabled, the operator still tried to fetch monitoring resources, which were expected to exist. 

This PR frees the upgrade procedure from upgrading monitoring resources. 

However, the operator still upgrades deployment config env vars for monitoring ports (for system components)