### PR TITLE
Circleci trigger image build workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,6 +453,14 @@ jobs:
       docker_layer_caching: true
     resource_class: large
     steps:
+      - run:
+          name: GITREF << pipeline.parameters.components_git_ref >>
+          command: |
+            exit 0
+      - run:
+          name: Remote Image TAG << pipeline.parameters.components_tag_name >>
+          command: |
+            exit 0
       - checkout
       - install-openshift
       - create-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ parameters:
   components_git_ref:
     type: string
     default: "master"
+  build_3scale_images_flag:
+    type: boolean
+    default: false
 
 ##################################### YAML ANCHORS  ############################################
 
@@ -292,10 +295,10 @@ commands:
               --docker-password="${DOCKER_PASSWORD}" \
               --docker-username="${DOCKER_USERNAME}" \
               --docker-server="${DOCKER_REGISTRY}"
-  build-nightly-amp:
+  build-amp-images:
     steps:
       - run:
-          name: Build nightly images
+          name: Build 3scale images
           no_output_timeout: 30m
           command: |
             set -o errexit
@@ -454,7 +457,7 @@ jobs:
       - install-openshift
       - create-secrets
       - create-redhat-registry-io-secret
-      - build-nightly-amp
+      - build-amp-images
       - oc-observe
       - deploy-3scale-eval-from-template-imagestreamsless
       - oc-status
@@ -625,3 +628,8 @@ workflows:
             <<: *tag-trigger
             branches:
               ignore: /.*/
+  images-build:
+    when: << pipeline.parameters.build_3scale_images_flag >>
+    jobs:
+      - build-push-3scale-images:
+          context: org-global

--- a/Makefile
+++ b/Makefile
@@ -285,3 +285,24 @@ bundle-validate:
 bundle-update-test:
 	git diff --exit-code ./bundle
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
+
+.PHONY: build-3scale-images
+build-3scale-images: IMAGES_GIT_REF?=master
+build-3scale-images: IMAGES_REMOTE_TAG?=nightly
+build-3scale-images: INTERNAL_ID=$(shell git config user.email | cut -d '@' -f1)
+build-3scale-images: OPERATOR_BRANCH=$(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+build-3scale-images:
+ifndef CIRCLE_CI_API_TOKEN
+	$(error "CIRCLE_CI_API_TOKEN not set")
+endif
+	CIRCLECI_DATA='$(shell jq -n -c \
+		--arg operator_branch "$(OPERATOR_BRANCH)" \
+		--arg git_ref "$(IMAGES_GIT_REF)" \
+		--arg remote_tag "$(IMAGES_REMOTE_TAG)" \
+		'{branch: $$operator_branch, parameters:{build_3scale_images_flag:true, components_tag_name: $$remote_tag, components_git_ref: $$git_ref}}' )'; \
+	curl -v --request POST -u $(CIRCLE_CI_API_TOKEN): \
+	  --url https://circleci.com/api/v2/project/gh/3scale/3scale-operator/pipeline \
+	  --header 'content-type: application/json' \
+	  --header "x-attribution-actor-id: $(INTERNAL_ID)" \
+	  --header "x-attribution-login: $(INTERNAL_ID)" \
+	  --data "$$CIRCLECI_DATA"

--- a/doc/development.md
+++ b/doc/development.md
@@ -5,19 +5,22 @@
 * [Clone repository](#clone-repository)
 * [Building 3scale operator image](#building-3scale-operator-image)
 * [Run 3scale Operator](#run-3scale-operator)
-  * [Run 3scale Operator Locally](#run-3scale-operator-locally)
-  * [Deploy custom 3scale Operator using OLM](#deploy-custom-3scale-operator-using-olm)
-* [Run tests](#run-tests)
-  * [Run all tests](#run-all-tests)
-  * [Run unit tests](#run-unit-tests)
-  * [Run end-to-end tests](#run-end-to-end-tests)
+   * [Run 3scale Operator Locally](#run-3scale-operator-locally)
+   * [Deploy custom 3scale Operator using OLM](#deploy-custom-3scale-operator-using-olm)
+   * [Run tests](#run-tests)
+      * [Run all tests](#run-all-tests)
+      * [Run unit tests](#run-unit-tests)
+      * [Run end-to-end tests](#run-end-to-end-tests)
 * [Building 3scale templates](#building-3scale-templates)
 * [Bundle management](#bundle-management)
-  * [(re)Generate an operator bundle image](#generate-an-operator-bundle-image)
-  * [Validate an operator bundle image](#validate-an-operator-bundle-image)
-  * [Push an operator bundle into an external container repository](#push-an-operator-bundle-into-an-external-container-repository)
+   * [Generate an operator bundle image](#generate-an-operator-bundle-image)
+   * [Push an operator bundle into an external container repository](#push-an-operator-bundle-into-an-external-container-repository)
+   * [Validate an operator bundle image](#validate-an-operator-bundle-image)
 * [Licenses management](#licenses-management)
-  * [Adding manually a new license](#adding-manually-a-new-license)
+   * [Adding manually a new license](#adding-manually-a-new-license)
+* [Building and pushing 3scale component images](#building-and-pushing-3scale-component-images)
+
+Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc)
 
 ## Prerequisites
 
@@ -215,3 +218,42 @@ license_finder approval add github.com/golang/glog --decisions-file=doc/dependen
 [docker]:https://docs.docker.com/install/
 [kubernetes]:https://kubernetes.io/
 [oc]:https://github.com/openshift/origin/releases
+
+## Building and pushing 3scale component images
+
+3scale component images can be built and pushed with a single command using a CircleCI job.
+In other workds, the command will trigger one parametrized CircleCI job.
+
+Prerequisites:
+* [CircleCI Personal API token](https://circleci.com/docs/2.0/managing-api-tokens/)
+
+Export your CircleCI personal API token to be used to trigger the job.
+
+```
+export CIRCLE_CI_API_TOKEN=<< YOUR TOKEN >>
+```
+
+Command Parameters:
+| Name | Default | Description |
+| ---- | ------- | ----------- |
+| **IMAGES_GIT_REF** | *master* | 3scale component git reference (tag or branch) |
+| **IMAGES_REMOTE_TAG** | *nightly* | Image tag used when pushed to public registry (quay.io) |
+| **OPERATOR_BRANCH** | current branch | Revision of the build configuration |
+
+The workflow triggered is:
+
+* Build image of each 3scale component from revision specified by `IMAGES_GIT_REF`.
+* The images will be deployed using templates from `OPERATOR_BRANCH` revision and e2e tests will be run.
+* When the tests pass, the images will be pushed to `quay.io` repos.
+
+| Component | Quay repo |
+| --------- | --------- |
+| Apicast | quay.io/3scale/apicast:**IMAGES_REMOTE_TAG** |
+| Zync | quay.io/3scale/zync:**IMAGES_REMOTE_TAG** |
+| Apisonator | quay.io/3scale/apisonator:**IMAGES_REMOTE_TAG** |
+| Porta | quay.io/3scale/porta:**IMAGES_REMOTE_TAG** |
+
+
+```
+make build-3scale-images IMAGES_GIT_REF=master IMAGES_REMOTE_TAG=nightly OPERATOR_BRANCH=master
+```


### PR DESCRIPTION
CircleCI job to build 3scale components images and push to quay.io image repo. Includes Makefile target to make it easy to trigger building job.

Depends on https://github.com/3scale/3scale-operator/pull/554. Needs to be merged after.