### PR TITLE
Add more labels to monitoring resources

### DIFF
--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -25,7 +25,12 @@ type ApicastOptions struct {
 	ProductionTolerations          []v1.Toleration   `validate:"-"`
 	StagingAffinity                *v1.Affinity      `validate:"-"`
 	StagingTolerations             []v1.Toleration   `validate:"-"`
-	Namespace                      string            `validate:"required"`
+
+	// Used for monitoring objects
+	// Those objects are namespaced. However, objects includes labels, rules and expressions
+	// that need namespace filtering because they are "global" once imported
+	// to the prometheus or grafana services.
+	Namespace string `validate:"required"`
 }
 
 func NewApicastOptions() *ApicastOptions {

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -25,6 +25,7 @@ type ApicastOptions struct {
 	ProductionTolerations          []v1.Toleration   `validate:"-"`
 	StagingAffinity                *v1.Affinity      `validate:"-"`
 	StagingTolerations             []v1.Toleration   `validate:"-"`
+	Namespace                      string            `validate:"required"`
 }
 
 func NewApicastOptions() *ApicastOptions {

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -36,6 +36,7 @@ type BackendOptions struct {
 	CronPodTemplateLabels        map[string]string `validate:"required"`
 	WorkerMetrics                bool
 	ListenerMetrics              bool
+	Namespace                    string `validate:"required"`
 }
 
 func NewBackendOptions() *BackendOptions {

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -36,7 +36,12 @@ type BackendOptions struct {
 	CronPodTemplateLabels        map[string]string `validate:"required"`
 	WorkerMetrics                bool
 	ListenerMetrics              bool
-	Namespace                    string `validate:"required"`
+
+	// Used for monitoring objects
+	// Those objects are namespaced. However, objects includes labels, rules and expressions
+	// that need namespace filtering because they are "global" once imported
+	// to the prometheus or grafana services.
+	Namespace string `validate:"required"`
 }
 
 func NewBackendOptions() *BackendOptions {

--- a/pkg/3scale/amp/component/generic_monitoring.go
+++ b/pkg/3scale/amp/component/generic_monitoring.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func KubernetesResourcesByNamespaceGrafanaDashboard(ns string) *grafanav1alpha1.GrafanaDashboard {
+func KubernetesResourcesByNamespaceGrafanaDashboard(ns string, appLabel string) *grafanav1alpha1.GrafanaDashboard {
 	data := &struct {
 		Namespace string
 	}{
@@ -22,6 +22,7 @@ func KubernetesResourcesByNamespaceGrafanaDashboard(ns string) *grafanav1alpha1.
 			Name: "kubernetes-resources-by-namespace",
 			Labels: map[string]string{
 				"monitoring-key": common.MonitoringKey,
+				"app":            appLabel,
 			},
 		},
 		Spec: grafanav1alpha1.GrafanaDashboardSpec{
@@ -31,7 +32,7 @@ func KubernetesResourcesByNamespaceGrafanaDashboard(ns string) *grafanav1alpha1.
 	}
 }
 
-func KubernetesResourcesByPodGrafanaDashboard(ns string) *grafanav1alpha1.GrafanaDashboard {
+func KubernetesResourcesByPodGrafanaDashboard(ns string, appLabel string) *grafanav1alpha1.GrafanaDashboard {
 	data := &struct {
 		Namespace string
 	}{
@@ -42,6 +43,7 @@ func KubernetesResourcesByPodGrafanaDashboard(ns string) *grafanav1alpha1.Grafan
 			Name: "kubernetes-resources-by-pod",
 			Labels: map[string]string{
 				"monitoring-key": common.MonitoringKey,
+				"app":            appLabel,
 			},
 		},
 		Spec: grafanav1alpha1.GrafanaDashboardSpec{
@@ -51,13 +53,14 @@ func KubernetesResourcesByPodGrafanaDashboard(ns string) *grafanav1alpha1.Grafan
 	}
 }
 
-func KubeStateMetricsPrometheusRules(ns string) *monitoringv1.PrometheusRule {
+func KubeStateMetricsPrometheusRules(ns string, appLabel string) *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "threescale-kube-state-metrics",
 			Labels: map[string]string{
 				"prometheus": "application-monitoring",
 				"role":       "alert-rules",
+				"app":        appLabel,
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -76,39 +76,34 @@ func (system *System) SystemAppPodMonitor() *monitoringv1.PodMonitor {
 	}
 }
 
-func SystemGrafanaDashboard(ns string) *grafanav1alpha1.GrafanaDashboard {
+func (system *System) SystemGrafanaDashboard() *grafanav1alpha1.GrafanaDashboard {
 	data := &struct {
 		Namespace string
 	}{
-		ns,
+		system.Options.Namespace,
 	}
 	return &grafanav1alpha1.GrafanaDashboard{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system",
-			Labels: map[string]string{
-				"monitoring-key": common.MonitoringKey,
-			},
+			Name:   "system",
+			Labels: system.monitoringLabels(),
 		},
 		Spec: grafanav1alpha1.GrafanaDashboardSpec{
 			Json: assets.TemplateAsset("monitoring/system-grafana-dashboard-1.json.tpl", data),
-			Name: fmt.Sprintf("%s/system-grafana-dashboard-1.json", ns),
+			Name: fmt.Sprintf("%s/system-grafana-dashboard-1.json", system.Options.Namespace),
 		},
 	}
 }
 
-func SystemAppPrometheusRules(ns string) *monitoringv1.PrometheusRule {
+func (system *System) SystemAppPrometheusRules() *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-app",
-			Labels: map[string]string{
-				"prometheus": "application-monitoring",
-				"role":       "alert-rules",
-			},
+			Name:   "system-app",
+			Labels: system.prometheusRulesMonitoringLabels(),
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{
-					Name: fmt.Sprintf("%s/system-app.rules", ns),
+					Name: fmt.Sprintf("%s/system-app.rules", system.Options.Namespace),
 					Rules: []monitoringv1.Rule{
 						{
 							Alert: "ThreescaleSystemApp5XXRequestsHigh",
@@ -116,7 +111,7 @@ func SystemAppPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} has more than 50 HTTP 5xx requests in the last minute",
 								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} has more than 50 HTTP 5xx requests in the last minute",
 							},
-							Expr: intstr.FromString(fmt.Sprintf(`sum(rate(rails_requests_total{namespace="%s",pod=~"system-app-[a-z0-9]+-[a-z0-9]+",status=~"5[0-9]*"}[1m])) by (namespace,job) > 50`, ns)),
+							Expr: intstr.FromString(fmt.Sprintf(`sum(rate(rails_requests_total{namespace="%s",pod=~"system-app-[a-z0-9]+-[a-z0-9]+",status=~"5[0-9]*"}[1m])) by (namespace,job) > 50`, system.Options.Namespace)),
 							For:  "1m",
 							Labels: map[string]string{
 								"severity": "warning",
@@ -128,7 +123,7 @@ func SystemAppPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
 								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
 							},
-							Expr: intstr.FromString(fmt.Sprintf(`up{job=~".*system-app.*",namespace="%s"} == 0`, ns)),
+							Expr: intstr.FromString(fmt.Sprintf(`up{job=~".*system-app.*",namespace="%s"} == 0`, system.Options.Namespace)),
 							For:  "1m",
 							Labels: map[string]string{
 								"severity": "critical",
@@ -141,19 +136,16 @@ func SystemAppPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 	}
 }
 
-func SystemSidekiqPrometheusRules(ns string) *monitoringv1.PrometheusRule {
+func (system *System) SystemSidekiqPrometheusRules() *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system-sidekiq",
-			Labels: map[string]string{
-				"prometheus": "application-monitoring",
-				"role":       "alert-rules",
-			},
+			Name:   "system-sidekiq",
+			Labels: system.prometheusRulesMonitoringLabels(),
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{
-					Name: fmt.Sprintf("%s/system-sidekiq.rules", ns),
+					Name: fmt.Sprintf("%s/system-sidekiq.rules", system.Options.Namespace),
 					Rules: []monitoringv1.Rule{
 						{
 							Alert: "ThreescaleSystemSidekiqJobDown",
@@ -161,7 +153,7 @@ func SystemSidekiqPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 								"summary":     "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
 								"description": "Job {{ $labels.job }} on {{ $labels.namespace }} is DOWN",
 							},
-							Expr: intstr.FromString(fmt.Sprintf(`up{job=~".*system-sidekiq.*",namespace="%s"} == 0`, ns)),
+							Expr: intstr.FromString(fmt.Sprintf(`up{job=~".*system-sidekiq.*",namespace="%s"} == 0`, system.Options.Namespace)),
 							For:  "1m",
 							Labels: map[string]string{
 								"severity": "critical",
@@ -172,4 +164,27 @@ func SystemSidekiqPrometheusRules(ns string) *monitoringv1.PrometheusRule {
 			},
 		},
 	}
+}
+
+func (system *System) monitoringLabels() map[string]string {
+	labels := make(map[string]string)
+
+	for key, value := range system.Options.CommonLabels {
+		labels[key] = value
+	}
+
+	labels["monitoring-key"] = common.MonitoringKey
+	return labels
+}
+
+func (system *System) prometheusRulesMonitoringLabels() map[string]string {
+	labels := make(map[string]string)
+
+	for key, value := range system.Options.CommonLabels {
+		labels[key] = value
+	}
+
+	labels["prometheus"] = "application-monitoring"
+	labels["role"] = "alert-rules"
+	return labels
 }

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -92,6 +92,8 @@ type SystemOptions struct {
 	IncludeOracleOptionalSettings bool
 
 	BackendServiceEndpoint string `validate:"required"`
+
+	Namespace string `validate:"required"`
 }
 
 func NewSystemOptions() *SystemOptions {

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -93,6 +93,10 @@ type SystemOptions struct {
 
 	BackendServiceEndpoint string `validate:"required"`
 
+	// Used for monitoring objects
+	// Those objects are namespaced. However, objects includes labels, rules and expressions
+	// that need namespace filtering because they are "global" once imported
+	// to the prometheus or grafana services.
 	Namespace string `validate:"required"`
 }
 

--- a/pkg/3scale/amp/component/zync_options.go
+++ b/pkg/3scale/amp/component/zync_options.go
@@ -40,6 +40,8 @@ type ZyncOptions struct {
 	ZyncMetrics                   bool
 
 	ZyncQueServiceAccountImagePullSecrets []v1.LocalObjectReference `validate:"required"`
+
+	Namespace string `validate:"required"`
 }
 
 func NewZyncOptions() *ZyncOptions {

--- a/pkg/3scale/amp/component/zync_options.go
+++ b/pkg/3scale/amp/component/zync_options.go
@@ -41,6 +41,10 @@ type ZyncOptions struct {
 
 	ZyncQueServiceAccountImagePullSecrets []v1.LocalObjectReference `validate:"required"`
 
+	// Used for monitoring objects
+	// Those objects are namespaced. However, objects includes labels, rules and expressions
+	// that need namespace filtering because they are "global" once imported
+	// to the prometheus or grafana services.
 	Namespace string `validate:"required"`
 }
 

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -40,6 +40,7 @@ func (a *ApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions,
 	a.apicastOptions.CommonProductionLabels = a.commonProductionLabels()
 	a.apicastOptions.StagingPodTemplateLabels = a.stagingPodTemplateLabels(imageOpts.ApicastImage)
 	a.apicastOptions.ProductionPodTemplateLabels = a.productionPodTemplateLabels(imageOpts.ApicastImage)
+	a.apicastOptions.Namespace = a.apimanager.Namespace
 
 	a.setResourceRequirementsOptions()
 	a.setNodeAffinityAndTolerationsOptions()

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -153,6 +153,7 @@ func defaultApicastOptions() *component.ApicastOptions {
 		CommonProductionLabels:         testApicastProductionLabels(),
 		StagingPodTemplateLabels:       testApicastStagingPodLabels(),
 		ProductionPodTemplateLabels:    testApicastProductionPodLabels(),
+		Namespace:                      namespace,
 	}
 }
 

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -97,17 +97,17 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileGrafanaDashboard(component.ApicastMainAppGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	err = r.ReconcileGrafanaDashboard(apicast.ApicastMainAppGrafanaDashboard(), reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileGrafanaDashboard(component.ApicastServicesGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	err = r.ReconcileGrafanaDashboard(apicast.ApicastServicesGrafanaDashboard(), reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.ApicastPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -58,6 +58,7 @@ func (o *OperatorBackendOptionsProvider) GetBackendOptions() (*component.Backend
 
 	o.backendOptions.WorkerMetrics = true
 	o.backendOptions.ListenerMetrics = true
+	o.backendOptions.Namespace = o.apimanager.Namespace
 
 	err = o.backendOptions.Validate()
 	if err != nil {

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -212,6 +212,7 @@ func defaultBackendOptions(opts *component.BackendOptions) *component.BackendOpt
 		CronPodTemplateLabels:        testBackendCronPodLabels(),
 		WorkerMetrics:                true,
 		ListenerMetrics:              true,
+		Namespace:                    opts.Namespace,
 	}
 }
 

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -101,17 +101,17 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileGrafanaDashboard(component.BackendGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	err = r.ReconcileGrafanaDashboard(backend.BackendGrafanaDashboard(), reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.BackendWorkerPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(backend.BackendWorkerPrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.BackendListenerPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(backend.BackendListenerPrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/generic_monitoring_reconciler.go
+++ b/pkg/3scale/amp/operator/generic_monitoring_reconciler.go
@@ -18,17 +18,20 @@ func NewGenericMonitoringReconciler(baseAPIManagerLogicReconciler *BaseAPIManage
 }
 
 func (r *GenericMonitoringReconciler) Reconcile() (reconcile.Result, error) {
-	err := r.ReconcileGrafanaDashboard(component.KubernetesResourcesByNamespaceGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	grafanaDashboard := component.KubernetesResourcesByNamespaceGrafanaDashboard(r.apiManager.Namespace, *r.apiManager.Spec.AppLabel)
+	err := r.ReconcileGrafanaDashboard(grafanaDashboard, reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileGrafanaDashboard(component.KubernetesResourcesByPodGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	grafanaDashboard = component.KubernetesResourcesByPodGrafanaDashboard(r.apiManager.Namespace, *r.apiManager.Spec.AppLabel)
+	err = r.ReconcileGrafanaDashboard(grafanaDashboard, reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.KubeStateMetricsPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	prometheusRule := component.KubeStateMetricsPrometheusRules(r.apiManager.Namespace, *r.apiManager.Spec.AppLabel)
+	err = r.ReconcilePrometheusRules(prometheusRule, reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -69,6 +69,8 @@ func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, er
 	s.options.AppMetrics = true
 	s.options.IncludeOracleOptionalSettings = true
 
+	s.options.Namespace = s.namespace
+
 	err = s.options.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("GetSystemOptions validating: %w", err)

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -364,6 +364,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		AppMetrics:                    true,
 		IncludeOracleOptionalSettings: true,
 		BackendServiceEndpoint:        fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
+		Namespace:                     opts.Namespace,
 	}
 
 	expectedOpts.ApicastSystemMasterProxyConfigEndpoint = component.DefaultApicastSystemMasterProxyConfigEndpoint(opts.ApicastAccessToken)

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -175,17 +175,17 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileGrafanaDashboard(component.SystemGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	err = r.ReconcileGrafanaDashboard(system.SystemGrafanaDashboard(), reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.SystemAppPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(system.SystemAppPrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.SystemSidekiqPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(system.SystemSidekiqPrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -61,6 +61,8 @@ func (z *ZyncOptionsProvider) GetZyncOptions() (*component.ZyncOptions, error) {
 
 	z.zyncOptions.ZyncQueServiceAccountImagePullSecrets = z.zyncQueServiceAccountImagePullSecrets()
 
+	z.zyncOptions.Namespace = z.apimanager.Namespace
+
 	err = z.zyncOptions.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("GetZyncOptions validating: %w", err)

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -231,6 +231,7 @@ func defaultZyncOptions(opts *component.ZyncOptions) *component.ZyncOptions {
 		ZyncDatabasePodTemplateLabels:         testZyncDatabasePodTemplateCommonLabels(),
 		ZyncMetrics:                           true,
 		ZyncQueServiceAccountImagePullSecrets: component.DefaultZyncQueServiceAccountImagePullSecrets(),
+		Namespace:                             opts.Namespace,
 	}
 
 	expectedOpts.DatabaseURL = component.DefaultZyncDatabaseURL(expectedOpts.DatabasePassword)

--- a/pkg/3scale/amp/operator/zync_reconciler.go
+++ b/pkg/3scale/amp/operator/zync_reconciler.go
@@ -103,17 +103,17 @@ func (r *ZyncReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcileGrafanaDashboard(component.ZyncGrafanaDashboard(r.apiManager.Namespace), reconcilers.GenericGrafanaDashboardsMutator)
+	err = r.ReconcileGrafanaDashboard(zync.ZyncGrafanaDashboard(), reconcilers.GenericGrafanaDashboardsMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.ZyncPrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(zync.ZyncPrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(component.ZyncQuePrometheusRules(r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(zync.ZyncQuePrometheusRules(), reconcilers.CreateOnlyMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -112,7 +112,7 @@ func (a *Apicast) options() (*component.ApicastOptions, error) {
 	ao.ProductionPodTemplateLabels = a.productionPodTemplateLabels()
 
 	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
-	ao.Namespace = "mynamespace"
+	ao.Namespace = "${NAMESPACE}"
 
 	err := ao.Validate()
 	return ao, err

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -111,6 +111,9 @@ func (a *Apicast) options() (*component.ApicastOptions, error) {
 	ao.StagingPodTemplateLabels = a.stagingPodTemplateLabels()
 	ao.ProductionPodTemplateLabels = a.productionPodTemplateLabels()
 
+	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
+	ao.Namespace = "mynamespace"
+
 	err := ao.Validate()
 	return ao, err
 }

--- a/pkg/3scale/amp/template/adapters/backend.go
+++ b/pkg/3scale/amp/template/adapters/backend.go
@@ -98,7 +98,7 @@ func (b *Backend) options() (*component.BackendOptions, error) {
 	bo.CronPodTemplateLabels = b.cronPodTemplateLabels()
 
 	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
-	bo.Namespace = "mynamespace"
+	bo.Namespace = "${NAMESPACE}"
 
 	err := bo.Validate()
 	return bo, err

--- a/pkg/3scale/amp/template/adapters/backend.go
+++ b/pkg/3scale/amp/template/adapters/backend.go
@@ -97,6 +97,9 @@ func (b *Backend) options() (*component.BackendOptions, error) {
 	bo.WorkerPodTemplateLabels = b.workerPodTemplateLabels()
 	bo.CronPodTemplateLabels = b.cronPodTemplateLabels()
 
+	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
+	bo.Namespace = "mynamespace"
+
 	err := bo.Validate()
 	return bo, err
 }

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -268,6 +268,9 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.SMTPLabels = s.smtpLabels()
 	o.BackendServiceEndpoint = s.backendServiceEndpoint()
 
+	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
+	o.Namespace = "mynamespace"
+
 	err := o.Validate()
 	return o, err
 }

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -269,7 +269,7 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.BackendServiceEndpoint = s.backendServiceEndpoint()
 
 	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
-	o.Namespace = "mynamespace"
+	o.Namespace = "${NAMESPACE}"
 
 	err := o.Validate()
 	return o, err

--- a/pkg/3scale/amp/template/adapters/zync.go
+++ b/pkg/3scale/amp/template/adapters/zync.go
@@ -119,7 +119,7 @@ func (z *Zync) options() (*component.ZyncOptions, error) {
 	zo.ZyncQueServiceAccountImagePullSecrets = component.DefaultZyncQueServiceAccountImagePullSecrets()
 
 	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
-	zo.Namespace = "mynamespace"
+	zo.Namespace = "${NAMESPACE}"
 
 	err := zo.Validate()
 	return zo, err

--- a/pkg/3scale/amp/template/adapters/zync.go
+++ b/pkg/3scale/amp/template/adapters/zync.go
@@ -118,6 +118,9 @@ func (z *Zync) options() (*component.ZyncOptions, error) {
 
 	zo.ZyncQueServiceAccountImagePullSecrets = component.DefaultZyncQueServiceAccountImagePullSecrets()
 
+	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
+	zo.Namespace = "mynamespace"
+
 	err := zo.Validate()
 	return zo, err
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-6496

- [x] apicast monitoring resources
- [x] generic monitoring resources
- [x] backend monitoring resources
- [x] system monitoring resources
- [x] zync monitoring resources

The PR adds more labels to existing list of labels. Thus, upgrade procedure is not needed, as first reconciliation loop will add missing labels.