### PR TITLE
apicast loglevel

### DIFF
--- a/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
+++ b/deploy/crds/apps.3scale.net_apimanagers_crd.yaml
@@ -667,6 +667,17 @@ spec:
                               type: array
                           type: object
                       type: object
+                    logLevel:
+                      enum:
+                      - debug
+                      - info
+                      - notice
+                      - warn
+                      - error
+                      - crit
+                      - alert
+                      - emerg
+                      type: string
                     replicas:
                       format: int64
                       type: integer
@@ -1368,6 +1379,17 @@ spec:
                               type: array
                           type: object
                       type: object
+                    logLevel:
+                      enum:
+                      - debug
+                      - info
+                      - notice
+                      - warn
+                      - error
+                      - crit
+                      - alert
+                      - emerg
+                      type: string
                     replicas:
                       format: int64
                       type: integer

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -103,6 +103,7 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
 | Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
 | Workers | `workers` | integer | No | Automatically computed. Check [apicast doc](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_workers) for further info. | Defines the number of worker processes |
+| LogLevel | `logLevel` | string | No | N/A | Log level for the OpenResty logs  (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_log_level)) |
 
 ### ApicastStagingSpec
 
@@ -112,6 +113,7 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 | Affinity | `affinity` | [v1.Affinity](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core) | No | `nil` | Affinity is a group of affinity scheduling rules |
 | Tolerations | `tolerations` | \[\][v1.Tolerations](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) | No | `nil` | Tolerations allow pods to schedule onto nodes with matching taints |
 | Resources | `resources` | [v1.ResourceRequirements](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core) | No | `nil` | Resources describes the compute resource requirements. Takes precedence over `spec.resourceRequirementsEnabled` with replace behavior |
+| LogLevel | `logLevel` | string | No | N/A | Log level for the OpenResty logs  (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_log_level)) |
 
 ### BackendSpec
 

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -336,6 +336,11 @@ func (apicast *Apicast) buildApicastStagingEnv() []v1.EnvVar {
 		helper.EnvVarFromValue("APICAST_CONFIGURATION_CACHE", "0"),
 		helper.EnvVarFromValue("THREESCALE_DEPLOYMENT_ENV", "staging"),
 	)
+
+	if apicast.Options.StagingLogLevel != nil {
+		result = append(result, helper.EnvVarFromValue("APICAST_LOG_LEVEL", *apicast.Options.StagingLogLevel))
+	}
+
 	return result
 }
 
@@ -350,6 +355,10 @@ func (apicast *Apicast) buildApicastProductionEnv() []v1.EnvVar {
 	if apicast.Options.ProductionWorkers != nil {
 		result = append(result, helper.EnvVarFromValue("APICAST_WORKERS", strconv.Itoa(int(*apicast.Options.ProductionWorkers))))
 	}
+	if apicast.Options.ProductionLogLevel != nil {
+		result = append(result, helper.EnvVarFromValue("APICAST_LOG_LEVEL", *apicast.Options.ProductionLogLevel))
+	}
+
 	return result
 }
 

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -26,6 +26,8 @@ type ApicastOptions struct {
 	StagingAffinity                *v1.Affinity      `validate:"-"`
 	StagingTolerations             []v1.Toleration   `validate:"-"`
 	ProductionWorkers              *int32            `validate:"-"`
+	ProductionLogLevel             *string
+	StagingLogLevel                *string
 }
 
 func NewApicastOptions() *ApicastOptions {

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -42,6 +42,9 @@ func (a *ApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions,
 	a.apicastOptions.ProductionPodTemplateLabels = a.productionPodTemplateLabels(imageOpts.ApicastImage)
 	a.apicastOptions.ProductionWorkers = a.apimanager.Spec.Apicast.ProductionSpec.Workers
 
+	a.apicastOptions.ProductionLogLevel = a.apimanager.Spec.Apicast.ProductionSpec.LogLevel
+	a.apicastOptions.StagingLogLevel = a.apimanager.Spec.Apicast.StagingSpec.LogLevel
+
 	a.setResourceRequirementsOptions()
 	a.setNodeAffinityAndTolerationsOptions()
 	a.setReplicas()

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -57,7 +57,14 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 	}
 
 	// Staging DC
-	err = r.ReconcileDeploymentConfig(apicast.StagingDeploymentConfig(), reconcilers.GenericDeploymentConfigMutator())
+	stagingDCMutator := reconcilers.DeploymentConfigMutator(
+		reconcilers.DeploymentConfigReplicasMutator,
+		reconcilers.DeploymentConfigContainerResourcesMutator,
+		reconcilers.DeploymentConfigAffinityMutator,
+		reconcilers.DeploymentConfigTolerationsMutator,
+		r.apicastLogLevelEnvVarMutator,
+	)
+	err = r.ReconcileDeploymentConfig(apicast.StagingDeploymentConfig(), stagingDCMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -69,6 +76,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigAffinityMutator,
 		reconcilers.DeploymentConfigTolerationsMutator,
 		r.apicastProductionWorkersEnvVarMutator,
+		r.apicastLogLevelEnvVarMutator,
 	)
 	err = r.ReconcileDeploymentConfig(apicast.ProductionDeploymentConfig(), productionDCMutator)
 	if err != nil {
@@ -136,6 +144,11 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 func (r *ApicastReconciler) apicastProductionWorkersEnvVarMutator(desired, existing *appsv1.DeploymentConfig) bool {
 	// Reconcile EnvVar only for "APICAST_WORKERS"
 	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_WORKERS")
+}
+
+func (r *ApicastReconciler) apicastLogLevelEnvVarMutator(desired, existing *appsv1.DeploymentConfig) bool {
+	// Reconcile EnvVar only for "APICAST_LOG_LEVEL"
+	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_LOG_LEVEL")
 }
 
 func Apicast(apimanager *appsv1alpha1.APIManager) (*component.Apicast, error) {

--- a/pkg/apis/apps/v1alpha1/apimanager_types.go
+++ b/pkg/apis/apps/v1alpha1/apimanager_types.go
@@ -172,6 +172,9 @@ type ApicastProductionSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	Workers *int32 `json:"workers,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Enum=debug;info;notice;warn;error;crit;alert;emerg
+	LogLevel *string `json:"logLevel,omitempty"` // APICAST_LOG_LEVEL
 }
 
 type ApicastStagingSpec struct {
@@ -183,6 +186,9 @@ type ApicastStagingSpec struct {
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// +optional
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Enum=debug;info;notice;warn;error;crit;alert;emerg
+	LogLevel *string `json:"logLevel,omitempty"` // APICAST_LOG_LEVEL
 }
 
 type BackendSpec struct {

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -512,6 +512,11 @@ func (in *ApicastProductionSpec) DeepCopyInto(out *ApicastProductionSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.LogLevel != nil {
+		in, out := &in.LogLevel, &out.LogLevel
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -600,6 +605,11 @@ func (in *ApicastStagingSpec) DeepCopyInto(out *ApicastStagingSpec) {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.LogLevel != nil {
+		in, out := &in.LogLevel, &out.LogLevel
+		*out = new(string)
+		**out = **in
 	}
 	return
 }


### PR DESCRIPTION
Adds configurability of `APICAST_LOG_LEVEL` in apicast production and apicast staging spec.

Includes reconciliation of env vars for apicast production and staging deploymentconfigs only for the specified env var `APICAST_LOG_LEVEL`. 

No need to implement upgrade procedure.

```
apiVersion: apps.3scale.net/v1alpha1                                    
kind: APIManager                                                        
metadata:                                                               
  name: apimanager1                                                     
spec:                                                                   
  wildcardDomain: example.com                     
  apicast:                                                              
    productionSpec:                                                     
      logLevel: debug
    stagingSpec:
      logLevel: debug
```