### PR TITLE
[backport] upgrade containerd with a security release to address CVE-2020-15257

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,3 +34,6 @@ replace github.com/openshift/api => github.com/openshift/api v0.0.0-202005271843
 // Required due to other libraries referencing v12.0.0+incompatible and without replace we can't have v0.18.6 specified
 // in the require section
 replace k8s.io/client-go => k8s.io/client-go v0.18.6
+
+// security release to address CVE-2020-15257
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.9

--- a/go.sum
+++ b/go.sum
@@ -17,12 +17,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.3.0/go.mod h1:9IAwXhoyBJ7z9LcAwkj0/7NnPzYaPeZxxVp3zm+5IqA=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/3scale/3scale-porta-go-client v0.0.4 h1:xzqOa3L/4RGzQJsBpPTjFvJiSrwmkYan4ZZUJZVz6nM=
-github.com/3scale/3scale-porta-go-client v0.0.4/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
-github.com/3scale/3scale-porta-go-client v0.1.0 h1:q2rlrYjPWjqLnbV0SYb1R5I/Rq0UTBuREof9MvRpEec=
-github.com/3scale/3scale-porta-go-client v0.1.0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
-github.com/3scale/3scale-porta-go-client v0.2.0 h1:fPr6yGqIweyZteiMqyV243jW8yr+Jt68SWEsuad8qjs=
-github.com/3scale/3scale-porta-go-client v0.2.0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/3scale/3scale-porta-go-client v0.3.0 h1:xzHdcsqu8aHXt9UaOwW8R3TY9vpwppb/ZWsR+3ziH40=
 github.com/3scale/3scale-porta-go-client v0.3.0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/3scale/3scale-porta-go-client v0.4.0 h1:zzmtLHO30hLVizIK1QcXc9PAbSwOsYRu2IkJMz53Utc=
@@ -145,9 +139,7 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
-github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.9/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20200107194136-26c1120b8d41/go.mod h1:Dq467ZllaHgAtVp4p1xUQWBrFXR9s/wyoTpG8zOJGkY=
 github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb/go.mod h1:Dq467ZllaHgAtVp4p1xUQWBrFXR9s/wyoTpG8zOJGkY=


### PR DESCRIPTION
Upgrading to [containerd v1.3.9](https://github.com/containerd/containerd/releases/tag/v1.3.9) which includes a security release to address CVE-2020-15257

Backport from #558 