### PR TITLE
development mode running controlled by flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ manager: generate fmt vet
 run: export WATCH_NAMESPACE=$(LOCAL_RUN_NAMESPACE)
 run: export THREESCALE_DEBUG=1
 run: generate fmt vet manifests
-	$(GO) run ./main.go
+	$(GO) run ./main.go --zap-devel
 
 # Install CRDs into a cluster
 install: manifests kustomize

--- a/main.go
+++ b/main.go
@@ -74,13 +74,20 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+
+	// https://v1-2-x.sdk.operatorframework.io/docs/building-operators/golang/references/logging/#a-simple-example
+	// Add the zap logger flag set to the CLI. The flag set must
+	// be added before calling flag.Parse().
+	loggerOpts := zap.Options{}
+	loggerOpts.BindFlags(flag.CommandLine)
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&loggerOpts)))
 
 	printVersion()
 


### PR DESCRIPTION
* `make run` will run in development mode with DEBUG log enabled
* operator deployed by deployment manifests will not run in dev mode. 