### PR TITLE
Add configurable noreply FROM mail address

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -551,7 +551,7 @@ existing secret names.
 | username | In case the mail server requires authentication and the authentication type requires it | `""` |
 | password | In case the mail server requires authentication and the authentication type requires it | `""` |
 | openssl.verify.mode | When using TLS, you can set how OpenSSL checks the certificate. This is really useful if you need to validate a self-signed and/or a wildcard certificate. You can use the name of an OpenSSL verify constant: `none` or `peer` | `""` |
-
+| from_address | `from` address value for the no-reply mail | `""` |
 
 ## Default APIManager components compute resources
 

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -85,6 +85,7 @@ const (
 	SystemSecretSystemSMTPPortFieldName              = "port"
 	SystemSecretSystemSMTPAuthenticationFieldName    = "authentication"
 	SystemSecretSystemSMTPOpenSSLVerifyModeFieldName = "openssl.verify.mode"
+	SystemSecretSystemSMTPFromAddressFieldName       = "from_address"
 )
 
 const (
@@ -148,6 +149,11 @@ func (system *System) getSystemSMTPEnvsFromSMTPSecret() []v1.EnvVar {
 		helper.EnvVarFromSecret("SMTP_PORT", SystemSecretSystemSMTPSecretName, SystemSecretSystemSMTPPortFieldName),
 		helper.EnvVarFromSecret("SMTP_AUTHENTICATION", SystemSecretSystemSMTPSecretName, SystemSecretSystemSMTPAuthenticationFieldName),
 		helper.EnvVarFromSecret("SMTP_OPENSSL_VERIFY_MODE", SystemSecretSystemSMTPSecretName, SystemSecretSystemSMTPOpenSSLVerifyModeFieldName),
+	}
+
+	if system.Options.SmtpSecretOptions.FromAddress != nil &&
+		*system.Options.SmtpSecretOptions.FromAddress != "" {
+		result = append(result, helper.EnvVarFromSecret("NOREPLY_EMAIL", SystemSecretSystemSMTPSecretName, SystemSecretSystemSMTPFromAddressFieldName))
 	}
 
 	return result
@@ -1043,7 +1049,7 @@ func (system *System) MemcachedService() *v1.Service {
 }
 
 func (system *System) SMTPSecret() *v1.Secret {
-	return &v1.Secret{
+	res := &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -1062,6 +1068,12 @@ func (system *System) SMTPSecret() *v1.Secret {
 			SystemSecretSystemSMTPUserNameFieldName:          *system.Options.SmtpSecretOptions.Username,
 		},
 	}
+
+	if system.Options.SmtpSecretOptions.FromAddress != nil {
+		res.StringData[SystemSecretSystemSMTPFromAddressFieldName] = *system.Options.SmtpSecretOptions.FromAddress
+	}
+
+	return res
 }
 
 func (system *System) SystemConfigMap() *v1.ConfigMap {

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -21,6 +21,7 @@ type SystemSMTPSecretOptions struct {
 	Password          *string `validate:"required"`
 	Port              *string `validate:"required"`
 	Username          *string `validate:"required"`
+	FromAddress       *string
 }
 
 type PVCFileStorageOptions struct {
@@ -204,6 +205,10 @@ func DefaultSystemSMTPPort() string {
 }
 
 func DefaultSystemSMTPUsername() string {
+	return ""
+}
+
+func DefaultSystemSMTPFromAddress() string {
 	return ""
 }
 

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -336,6 +336,12 @@ func (s *SystemOptionsProvider) setSystemSMTPOptions() error {
 			component.SystemSecretSystemSMTPUserNameFieldName,
 			component.DefaultSystemSMTPUsername(),
 		},
+		{
+			&smtpSecretOptions.FromAddress,
+			component.SystemSecretSystemSMTPSecretName,
+			component.SystemSecretSystemSMTPFromAddressFieldName,
+			component.DefaultSystemSMTPFromAddress(),
+		},
 	}
 
 	for _, option := range cases {


### PR DESCRIPTION
Make the 'from' address value of the noreply mail address configurable.
This is an operator-only functionality.

In system, the `NOREPLY_EMAIL` environment variable is used to set the 'from' address of the noreply mail. The behavior in system with this environment variable currently is:
* If the environment variable is defined then its value is used. If it is defined as the empty string `""` that value is literally used instead of a default one
* If the environment variable is not defined then a default value specified by system is used.

All SMTP-related settings are stored in the `system-smtp` Secret. This PR adds the ability to
set the field `from_address` in the `system-smtp` secret. The field value must be set before deploying the APIManager in case the user wants a non-default behavior for that field, as with all other non-default field values in secrets.

As with other fields in secrets, it is a creation-only field and it is not automatically reconciled when changed once set.

* We only set System's environment variable when the from address secret field is set AND it is set to a non-empty value.
* By default, we explicitly set the from address field into the 'smtp' secret with the vale "" to be explicit and consistent with the other fields. From the point of view of the user "" means "use the default value" as with the other fields and the user can explicitly set it too with that meaning.
* An upgrade process is not needed for this due to secret defaults are automatically reconciled during the usual reconcile process.
* This is an operator-only functionality: On templates no from address field can be set on the secret nor the environment variable is set in any way (this is also the reason in System options component we still define the smtp from address field as a pointer, to avoid setting it into the secret).

- [x] Documentation
- [x] Testing
