### PR TITLE
Test suite little fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: test-unit test-e2e test-crds test-manifests-version
 
 # Run unit tests
 TEST_UNIT_PKGS = $(shell $(GO) list ./... | grep -E 'github.com/3scale/3scale-operator/pkg|github.com/3scale/3scale-operator/apis|github.com/3scale/3scale-operator/test/unitcontrollers')
-TEST_UNIT_COVERPKGS = $(shell $(GO) list ./... | grep -v test/unitcontrollers | tr "\n" ",") # Exclude test/unitcontrollers directory as coverpkg does not accept only-tests packages
+TEST_UNIT_COVERPKGS = $(shell $(GO) list ./... | grep -v github.com/3scale/3scale-operator/test | tr "\n" ",") # Exclude test directories as coverpkg does not accept only-tests packages
 test-unit: clean-cov generate fmt vet manifests
 	mkdir -p "$(PROJECT_PATH)/_output"
 	$(GO) test  -v $(TEST_UNIT_PKGS) -covermode=count -coverprofile $(PROJECT_PATH)/_output/unit.cov -coverpkg=$(TEST_UNIT_COVERPKGS)

--- a/controllers/apps/apimanager_suite_test.go
+++ b/controllers/apps/apimanager_suite_test.go
@@ -56,11 +56,11 @@ var testK8sClient client.Client
 var testK8sAPIClient client.Reader
 var testEnv *envtest.Environment
 
-func TestControllerApps(t *testing.T) {
+func TestAPIManager(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controllers apps Suite",
+		"APIManager Controller Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 

--- a/controllers/apps/suite_test.go
+++ b/controllers/apps/suite_test.go
@@ -56,11 +56,11 @@ var testK8sClient client.Client
 var testK8sAPIClient client.Reader
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllerApps(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Controllers apps Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 

--- a/controllers/capabilities/suite_test.go
+++ b/controllers/capabilities/suite_test.go
@@ -44,11 +44,11 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllerCapabilities(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Controllers capabilities Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 

--- a/test/unitcontrollers/apimanager_controller_test.go
+++ b/test/unitcontrollers/apimanager_controller_test.go
@@ -1,4 +1,4 @@
-package unitcontrollers
+package test
 
 import (
 	"context"


### PR DESCRIPTION
* Specific test suite for apimanager. Improved test logs
```
=== RUN   TestAPIManager
Running Suite: APIManager Controller Suite
==========================================
Random Seed: 1611753802
Will run 2 of 2 specs

STEP: bootstrapping test environment
```

* REmove test only packages from coverage base