### PR TITLE
APIManager e2e tests with S3

### DIFF
--- a/controllers/apps/suite_test.go
+++ b/controllers/apps/suite_test.go
@@ -18,8 +18,10 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -71,7 +73,16 @@ var _ = BeforeSuite(func(done Done) {
 	}
 
 	var err error
-	cfg, err = testEnv.Start()
+	Eventually(func() bool {
+		fmt.Fprintf(GinkgoWriter, "starting apps testEnv...\n")
+		cfg, err = testEnv.Start()
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "apps testEnv start attempt failed: %v'\n", err)
+			return false
+		}
+		fmt.Fprintf(GinkgoWriter, "apps testEnv started\n")
+		return true
+	}, 5*time.Minute, 5*time.Second).Should(BeTrue(), "testEnv failed to start reached max attempts")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 

--- a/controllers/capabilities/suite_test.go
+++ b/controllers/capabilities/suite_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -59,7 +61,17 @@ var _ = BeforeSuite(func(done Done) {
 	}
 
 	var err error
-	cfg, err = testEnv.Start()
+	Eventually(func() bool {
+		fmt.Fprintf(GinkgoWriter, "starting capabilities testEnv...\n")
+		cfg, err = testEnv.Start()
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "capabilities testEnv start attempt failed: %v'\n", err)
+			return false
+		}
+		fmt.Fprintf(GinkgoWriter, "capabilities testEnv started\n")
+		return true
+	}, 5*time.Minute, 5*time.Second).Should(BeTrue(), "testEnv failed to start reached max attempts")
+
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
@@ -82,4 +94,5 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
+
 })


### PR DESCRIPTION
This changes the E2E tests execution to deploy an APIManager using System's FileStorage as S3 instead of a PVC.
The motivation of this change is to be able to deploy them in a cluster environment that does not provide RWX volumes, which is required by System's FileStorage.

The provided S3 data for the E2E tests is fake data, as it's not needed for the kind of tests we are performing at the moment. In case there's some test functionality that we end up doing that exercises S3 then additional changes will need to be done or change the provided approach.



