### PR TITLE
apimanager: Do not set APIManager controller-based ownerReferences on Secrets

### DIFF
--- a/pkg/3scale/amp/operator/highavailability_reconciler_test.go
+++ b/pkg/3scale/amp/operator/highavailability_reconciler_test.go
@@ -77,21 +77,6 @@ func TestHighAvailabilityReconciler(t *testing.T) {
 				subT.Errorf("error fetching object %s: %v", tc.secretName, err)
 			}
 
-			// Assert owner ref
-			if len(secret.GetOwnerReferences()) == 0 {
-				subT.Errorf("secret %s: owner ref not set", tc.secretName)
-			}
-
-			ownerRef := secret.GetOwnerReferences()[0]
-
-			// apimanager.Kind is empty
-			if ownerRef.Kind != "APIManager" {
-				subT.Errorf("secret %s: owner ref kind not matched. Expected: %s, found: %s", tc.secretName, "APIManager", ownerRef.Kind)
-			}
-
-			if ownerRef.Name != apimanager.Name {
-				subT.Errorf("secret %s: owner ref name not matched. Expected: %s, found: %s", tc.secretName, apimanager.Name, ownerRef.Name)
-			}
 		})
 	}
 }


### PR DESCRIPTION
The reason for this is that secrets are often managed by users and users
sometimes manage the secrets themselves by other controllers which also
add controller-based OwnerReferences to the secrets.
In K8s only a single controller-based OwnerReference is allowed per object, which
was preventing users to work with their own controller-based secrets.

An implication of this change is that the responsibility to cleanup
the APIManager secrets deployed belongs to the user.

This changes include an upgrade procedure to remove the APIManager
controller-based ownerReferences from existing APIManager
secrets.