### PR TITLE
apisonator build uses new dockerfile based on ubi8

### DIFF
--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -136,7 +136,7 @@ objects:
               pullSecret:
                   name: "${PULLSECRET_NAME}"
               contextDir: /
-              dockerfilePath: openshift/distro/centos/7/release/Dockerfile
+              dockerfilePath: openshift/distro/ubi/8/release/Dockerfile.min
 
 parameters:
 - name: ZYNC_GIT_REF
@@ -160,6 +160,6 @@ parameters:
   value: "latest"
   required: true
 - name: PULLSECRET_NAME
-  description: PullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker egistries 
+  description: PullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker egistries
   value: "threescale-registry-auth"
   required: true


### PR DESCRIPTION
Update apisonator dockerfile path, as it was changed in https://github.com/3scale/apisonator/pull/268