### PR TITLE
Fix CRD role permissions level for some CRDs

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -666,86 +666,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - activedocs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - activedocs/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - custompolicydefinitions
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - custompolicydefinitions/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - developeraccounts
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - developeraccounts/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - developerusers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - capabilities.3scale.net
-          resources:
-          - developerusers/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - console.openshift.io
           resources:
           - consolelinks
@@ -1013,6 +933,26 @@ spec:
         - apiGroups:
           - capabilities.3scale.net
           resources:
+          - activedocs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - activedocs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
           - backends
           verbs:
           - create
@@ -1038,6 +978,66 @@ spec:
           - capabilities.3scale.net
           resources:
           - backends/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - custompolicydefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - custompolicydefinitions/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - developeraccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - developeraccounts/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - developerusers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - developerusers/status
           verbs:
           - get
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,86 +7,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - activedocs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - activedocs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - custompolicydefinitions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - custompolicydefinitions/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - developeraccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - developeraccounts/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - developerusers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - capabilities.3scale.net
-  resources:
-  - developerusers/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - console.openshift.io
   resources:
   - consolelinks
@@ -248,6 +168,26 @@ rules:
 - apiGroups:
   - capabilities.3scale.net
   resources:
+  - activedocs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - activedocs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
   - backends
   verbs:
   - create
@@ -273,6 +213,66 @@ rules:
   - capabilities.3scale.net
   resources:
   - backends/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - custompolicydefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - custompolicydefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - developeraccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - developeraccounts/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - developerusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - developerusers/status
   verbs:
   - get
   - patch

--- a/controllers/capabilities/activedoc_controller.go
+++ b/controllers/capabilities/activedoc_controller.go
@@ -43,8 +43,8 @@ type ActiveDocReconciler struct {
 // blank assignment to verify that BackendReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &ActiveDocReconciler{}
 
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=activedocs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=activedocs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=activedocs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=activedocs/status,verbs=get;update;patch
 
 func (r *ActiveDocReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/capabilities/custompolicydefinition_controller.go
+++ b/controllers/capabilities/custompolicydefinition_controller.go
@@ -42,8 +42,8 @@ type CustomPolicyDefinitionReconciler struct {
 // blank assignment to verify that PolicyReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &CustomPolicyDefinitionReconciler{}
 
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=custompolicydefinitions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=custompolicydefinitions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=custompolicydefinitions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=custompolicydefinitions/status,verbs=get;update;patch
 
 func (r *CustomPolicyDefinitionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/capabilities/developeraccount_controller.go
+++ b/controllers/capabilities/developeraccount_controller.go
@@ -43,8 +43,8 @@ type DeveloperAccountReconciler struct {
 // blank assignment to verify that DeveloperAccountReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &DeveloperAccountReconciler{}
 
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=developeraccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=developeraccounts/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developeraccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developeraccounts/status,verbs=get;update;patch
 
 func (r *DeveloperAccountReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/capabilities/developeruser_controller.go
+++ b/controllers/capabilities/developeruser_controller.go
@@ -44,8 +44,8 @@ type DeveloperUserReconciler struct {
 // blank assignment to verify that DeveloperUserReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &DeveloperUserReconciler{}
 
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=developerusers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=capabilities.3scale.net,resources=developerusers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developerusers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developerusers/status,verbs=get;update;patch
 
 func (r *DeveloperUserReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Logger().WithValues("developeruser", req.NamespacedName)


### PR DESCRIPTION
This PR fixes CRD role permissions level from ClusterRole to Role for ActiveDocs, DeveloperAccount, DeveloperUser and CustomPolicyDefinition(formerly Policy) CRDs.

By default operator-sdk generates the roles for the CRDs as ClusterRoles unless the 'namespace' attribute in the role permissions annotations appears there. This was not done for the CRDs mentioned above causing the incorrect cluster level permissions to be generated.

Changes have been performed in the controller files where role permission annotations are defined and manifests and bundle have been regenerated