### PR TITLE
Fix go bindata assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,6 @@ jobs:
     steps:
       - checkout
       - install-operator-sdk
-      - run: make
       - run: make assets-update-test
 
 workflows:

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -6,7 +6,8 @@ import (
 )
 
 // Important: Run "make" to regenerate code after modifying/adding/removing any asset
-//go:generate go-bindata --prefix assets -pkg $GOPACKAGE -o bindata.go assets/...
+// adding -nometadata to not preserve size, mode, and modtime info. It should not be necessary as the content will be embedded in custom resources.
+//go:generate go-bindata --prefix assets -pkg $GOPACKAGE -nometadata -o bindata.go assets/...
 
 // SafeStringAsset Returns asset data as string
 // panic if not found or any err is detected

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -99,7 +99,7 @@ func monitoringApicastGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-1.json.tpl", size: 84787, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
+	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-1.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func monitoringApicastGrafanaDashboard2JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-2.json.tpl", size: 17167, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
+	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-2.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func monitoringBackendGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/backend-grafana-dashboard-1.json.tpl", size: 252065, mode: os.FileMode(436), modTime: time.Unix(1608652245, 0)}
+	info := bindataFileInfo{name: "monitoring/backend-grafana-dashboard-1.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func monitoringKubernetesResourcesByNamespaceGrafanaDashboard1JsonTpl() (*asset,
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-namespace-grafana-dashboard-1.json.tpl", size: 46750, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
+	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-namespace-grafana-dashboard-1.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func monitoringKubernetesResourcesByPodGrafanaDashboard1JsonTpl() (*asset, error
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-pod-grafana-dashboard-1.json.tpl", size: 41705, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
+	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-pod-grafana-dashboard-1.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func monitoringSystemGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/system-grafana-dashboard-1.json.tpl", size: 85358, mode: os.FileMode(436), modTime: time.Unix(1614683788, 0)}
+	info := bindataFileInfo{name: "monitoring/system-grafana-dashboard-1.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func monitoringZyncGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/zync-grafana-dashboard-1.json.tpl", size: 70873, mode: os.FileMode(436), modTime: time.Unix(1612286781, 0)}
+	info := bindataFileInfo{name: "monitoring/zync-grafana-dashboard-1.json.tpl", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -99,7 +99,7 @@ func monitoringApicastGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-1.json.tpl", size: 84787, mode: os.FileMode(436), modTime: time.Unix(1607279464, 0)}
+	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-1.json.tpl", size: 84787, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func monitoringApicastGrafanaDashboard2JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-2.json.tpl", size: 17167, mode: os.FileMode(436), modTime: time.Unix(1607279464, 0)}
+	info := bindataFileInfo{name: "monitoring/apicast-grafana-dashboard-2.json.tpl", size: 17167, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func monitoringBackendGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/backend-grafana-dashboard-1.json.tpl", size: 252065, mode: os.FileMode(436), modTime: time.Unix(1608819863, 0)}
+	info := bindataFileInfo{name: "monitoring/backend-grafana-dashboard-1.json.tpl", size: 252065, mode: os.FileMode(436), modTime: time.Unix(1608652245, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func monitoringKubernetesResourcesByNamespaceGrafanaDashboard1JsonTpl() (*asset,
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-namespace-grafana-dashboard-1.json.tpl", size: 46750, mode: os.FileMode(436), modTime: time.Unix(1608212460, 0)}
+	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-namespace-grafana-dashboard-1.json.tpl", size: 46750, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func monitoringKubernetesResourcesByPodGrafanaDashboard1JsonTpl() (*asset, error
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-pod-grafana-dashboard-1.json.tpl", size: 41705, mode: os.FileMode(436), modTime: time.Unix(1607279464, 0)}
+	info := bindataFileInfo{name: "monitoring/kubernetes-resources-by-pod-grafana-dashboard-1.json.tpl", size: 41705, mode: os.FileMode(436), modTime: time.Unix(1605030128, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func monitoringSystemGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/system-grafana-dashboard-1.json.tpl", size: 85358, mode: os.FileMode(436), modTime: time.Unix(1612800460, 0)}
+	info := bindataFileInfo{name: "monitoring/system-grafana-dashboard-1.json.tpl", size: 85358, mode: os.FileMode(436), modTime: time.Unix(1614683788, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func monitoringZyncGrafanaDashboard1JsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "monitoring/zync-grafana-dashboard-1.json.tpl", size: 70873, mode: os.FileMode(436), modTime: time.Unix(1612437807, 0)}
+	info := bindataFileInfo{name: "monitoring/zync-grafana-dashboard-1.json.tpl", size: 70873, mode: os.FileMode(436), modTime: time.Unix(1612286781, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
There is no magic. assets have to be generated with the go-bindata tool. The asset generation is added to the `generate` makefile target.

In this PR I learnt that the generated code does not change each time you execute go-bindata. There will be changes in the generated code if template file modification times or content is changed. The file modification times are changed each time the project is cloned. In order to avoid this behavior, adding `-nometadata` to the generate command to not preserve size, mode, and modtime info