### PR TITLE
Unit test coverage github.com/3scale/3scale-operator/pkg/controller/helper

### DIFF
--- a/pkg/controller/helper/application_plan_entity_test.go
+++ b/pkg/controller/helper/application_plan_entity_test.go
@@ -1,0 +1,464 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
+
+	logrtesting "github.com/go-logr/logr/testing"
+)
+
+func TestApplicationPlanEntityBasics(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+	planItem := threescaleapi.ApplicationPlanItem{
+		ID:               4567,
+		Name:             "some plan",
+		ApprovalRequired: true,
+		TrialPeriodDays:  3,
+		SetupFee:         5.67,
+		CostPerMonth:     8.67,
+	}
+
+	client := threescaleapi.NewThreeScale(nil, token, nil)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, planItem, client, logrtesting.NullLogger{})
+	equals(t, appPlanEntity.ID(), planItem.ID)
+	equals(t, appPlanEntity.Name(), planItem.Name)
+	equals(t, appPlanEntity.ApprovalRequired(), planItem.ApprovalRequired)
+	equals(t, appPlanEntity.TrialPeriodDays(), planItem.TrialPeriodDays)
+	equals(t, appPlanEntity.SetupFee(), planItem.SetupFee)
+	equals(t, appPlanEntity.CostPerMonth(), planItem.CostPerMonth)
+}
+
+func TestApplicationPlanEntityUpdate(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := threescaleapi.ApplicationPlan{
+			Element: threescaleapi.ApplicationPlanItem{
+				ID:               4567,
+				Name:             "some plan",
+				ApprovalRequired: true,
+				TrialPeriodDays:  3,
+				SetupFee:         5.67,
+				CostPerMonth:     8.67,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.Update(threescaleapi.Params{})
+	ok(t, err)
+	equals(t, appPlanEntity.ID(), int64(4567))
+	equals(t, appPlanEntity.Name(), "some plan")
+	equals(t, appPlanEntity.ApprovalRequired(), true)
+	equals(t, appPlanEntity.TrialPeriodDays(), 3)
+	equals(t, appPlanEntity.SetupFee(), 5.67)
+	equals(t, appPlanEntity.CostPerMonth(), 8.67)
+}
+
+func TestApplicationPlanEntityUpdateError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.Update(threescaleapi.Params{})
+	assert(t, err != nil, "update did not return error")
+}
+
+func TestApplicationPlanEntityLimits(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := threescaleapi.ApplicationPlanLimitList{
+			Limits: []threescaleapi.ApplicationPlanLimit{
+				{
+					Element: threescaleapi.ApplicationPlanLimitItem{
+						ID:       int64(1),
+						Period:   "eternity",
+						MetricID: int64(10),
+						Value:    1000,
+					},
+				},
+				{
+					Element: threescaleapi.ApplicationPlanLimitItem{
+						ID:       int64(2),
+						Period:   "year",
+						MetricID: int64(10),
+						Value:    1000,
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	limits, err := appPlanEntity.Limits()
+	ok(t, err)
+	assert(t, limits != nil, "Limits returned nil")
+	equals(t, len(limits.Limits), 2)
+}
+
+func TestApplicationPlanEntityLimitsError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	_, err := appPlanEntity.Limits()
+	assert(t, err != nil, "Limits did not return error")
+}
+
+func TestApplicationPlanEntityDeleteLimit(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.DeleteLimit(int64(1234), int64(10))
+	ok(t, err)
+}
+
+func TestApplicationPlanEntityDeleteLimitError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.DeleteLimit(int64(1234), int64(10))
+	assert(t, err != nil, "DeleteLimit did not return error")
+}
+
+func TestApplicationPlanEntityCreateLimit(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := threescaleapi.ApplicationPlanLimit{
+			Element: threescaleapi.ApplicationPlanLimitItem{
+				ID:       int64(1),
+				Period:   "eternity",
+				MetricID: int64(10),
+				Value:    1000,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.CreateLimit(int64(1234), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestApplicationPlanEntityCreateLimitError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.CreateLimit(int64(1234), threescaleapi.Params{})
+	assert(t, err != nil, "CreateLimit did not return error")
+}
+
+func TestApplicationPlanEntityPricingRules(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := threescaleapi.ApplicationPlanPricingRuleList{
+			Rules: []threescaleapi.ApplicationPlanPricingRule{
+				{
+					Element: threescaleapi.ApplicationPlanPricingRuleItem{
+						ID:          int64(1),
+						MetricID:    int64(10),
+						CostPerUnit: "123",
+						Min:         1,
+						Max:         10,
+					},
+				},
+				{
+					Element: threescaleapi.ApplicationPlanPricingRuleItem{
+						ID:          int64(1),
+						MetricID:    int64(10),
+						CostPerUnit: "123",
+						Min:         11,
+						Max:         20,
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	rules, err := appPlanEntity.PricingRules()
+	ok(t, err)
+	assert(t, rules != nil, "PricingRules returned nil")
+	equals(t, len(rules.Rules), 2)
+}
+
+func TestApplicationPlanEntityPricingRulesError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	_, err := appPlanEntity.PricingRules()
+	assert(t, err != nil, "PricingRules did not return error")
+}
+
+func TestApplicationPlanEntityDeletePricingRule(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.DeletePricingRule(int64(1234), int64(10))
+	ok(t, err)
+}
+
+func TestApplicationPlanEntityDeletePricingRuleError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.DeletePricingRule(int64(1234), int64(10))
+	assert(t, err != nil, "DeletePricingRule did not return error")
+}
+
+func TestApplicationPlanEntityCreatePricingRule(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := threescaleapi.ApplicationPlanPricingRule{
+			Element: threescaleapi.ApplicationPlanPricingRuleItem{
+				ID:          int64(1),
+				MetricID:    int64(10),
+				CostPerUnit: "123",
+				Min:         11,
+				Max:         20,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.CreatePricingRule(int64(1234), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestApplicationPlanEntityCreatePricingRuleError(t *testing.T) {
+	var productID int64 = 1293
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	appPlanEntity := NewApplicationPlanEntity(productID, threescaleapi.ApplicationPlanItem{}, client, logrtesting.NullLogger{})
+	err := appPlanEntity.CreatePricingRule(int64(1234), threescaleapi.Params{})
+	assert(t, err != nil, "CreatePricingRule did not return error")
+}

--- a/pkg/controller/helper/backend_list_test.go
+++ b/pkg/controller/helper/backend_list_test.go
@@ -9,7 +9,6 @@ import (
 	logrtesting "github.com/go-logr/logr/testing"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -99,8 +98,7 @@ func TestBackendList(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(subT *testing.T) {
-			objs := []runtime.Object{anotherProviderSecret, providerSecret, tc.backend}
-			cl := fake.NewFakeClient(objs...)
+			cl := fake.NewFakeClient(anotherProviderSecret, providerSecret, tc.backend)
 			backendList, err := BackendList(ns, cl, providerAccountURLStr, logrtesting.NullLogger{})
 			if err != nil {
 				subT.Fatal(err)

--- a/pkg/controller/helper/backend_list_test.go
+++ b/pkg/controller/helper/backend_list_test.go
@@ -1,0 +1,114 @@
+package helper
+
+import (
+	"testing"
+
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+	"github.com/3scale/3scale-operator/pkg/common"
+
+	logrtesting "github.com/go-logr/logr/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBackendList(t *testing.T) {
+	ns := "somenamespace"
+	providerAccountURLStr := "https://example.com"
+	providerAccountToken := "12345"
+	anotherProviderSecretName := "anotherSecretName"
+
+	data := map[string]string{
+		providerAccountSecretURLFieldName:   providerAccountURLStr,
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	providerSecret := GetTestSecret(ns, providerAccountDefaultSecretName, data)
+
+	data = map[string]string{
+		providerAccountSecretURLFieldName:   "https://other.example.com",
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	anotherProviderSecret := GetTestSecret(ns, anotherProviderSecretName, data)
+
+	s := scheme.Scheme
+	err := capabilitiesv1beta1.AddToScheme(s)
+	if err != nil {
+		t.Fatalf("Unable to add Apps scheme: (%v)", err)
+	}
+
+	cases := []struct {
+		testName string
+		backend  *capabilitiesv1beta1.Backend
+		expected bool
+	}{
+		{
+			"sync'ed backend and same providerAccount",
+			&capabilitiesv1beta1.Backend{
+				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+				Spec:       capabilitiesv1beta1.BackendSpec{},
+				Status: capabilitiesv1beta1.BackendStatus{
+					Conditions: common.Conditions{
+						common.Condition{
+							Type:   capabilitiesv1beta1.BackendSyncedConditionType,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"Not sync'ed backend",
+			&capabilitiesv1beta1.Backend{
+				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+				Spec:       capabilitiesv1beta1.BackendSpec{},
+				Status: capabilitiesv1beta1.BackendStatus{
+					Conditions: common.Conditions{
+						common.Condition{
+							Type:   capabilitiesv1beta1.BackendSyncedConditionType,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"provider not matching backend",
+			&capabilitiesv1beta1.Backend{
+				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+				Spec: capabilitiesv1beta1.BackendSpec{
+					ProviderAccountRef: &corev1.LocalObjectReference{
+						Name: anotherProviderSecretName,
+					},
+				},
+				Status: capabilitiesv1beta1.BackendStatus{
+					Conditions: common.Conditions{
+						common.Condition{
+							Type:   capabilitiesv1beta1.BackendSyncedConditionType,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			objs := []runtime.Object{anotherProviderSecret, providerSecret, tc.backend}
+			cl := fake.NewFakeClient(objs...)
+			backendList, err := BackendList(ns, cl, providerAccountURLStr, logrtesting.NullLogger{})
+			if err != nil {
+				subT.Fatal(err)
+			}
+
+			if (len(backendList) == 0) == tc.expected {
+				subT.Errorf("backend included: %t, expected: %t", len(backendList) != 0, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/helper/backendapi_entity_test.go
+++ b/pkg/controller/helper/backendapi_entity_test.go
@@ -1,8 +1,15 @@
 package helper
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"regexp"
 	"testing"
 
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
+	logrtesting "github.com/go-logr/logr/testing"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -24,6 +31,483 @@ func TestSanitizeBackendSystemName(t *testing.T) {
 				diff := cmp.Diff(newName, tc.expectedSystemName)
 				subT.Errorf("diff %s", diff)
 			}
+		})
+	}
+}
+
+func TestBackendAPIEntityBasics(t *testing.T) {
+	token := "12345"
+	backendItem := &threescaleapi.BackendApi{
+		Element: threescaleapi.BackendApiItem{
+			ID:              int64(4567),
+			Name:            "some backend",
+			SystemName:      "my_backend",
+			Description:     "some descr",
+			PrivateEndpoint: "https://example.com",
+			AccountID:       int64(12),
+		},
+	}
+
+	client := threescaleapi.NewThreeScale(nil, token, nil)
+
+	backendEntity := NewBackendAPIEntity(backendItem, client, logrtesting.NullLogger{})
+	equals(t, backendEntity.ID(), backendItem.Element.ID)
+	equals(t, backendEntity.Name(), backendItem.Element.Name)
+	equals(t, backendEntity.SystemName(), backendItem.Element.SystemName)
+	equals(t, backendEntity.Description(), backendItem.Element.Description)
+	equals(t, backendEntity.PrivateEndpoint(), backendItem.Element.PrivateEndpoint)
+}
+
+func TestBackendAPIEntityUpdate(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.BackendApi{
+			Element: threescaleapi.BackendApiItem{
+				ID:              int64(4567),
+				Name:            "some backend",
+				SystemName:      "my_backend",
+				Description:     "some descr",
+				PrivateEndpoint: "https://example.com",
+				AccountID:       int64(12),
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.Update(threescaleapi.Params{})
+	ok(t, err)
+	equals(t, int64(4567), backendEntity.ID())
+	equals(t, "some backend", backendEntity.Name())
+	equals(t, "my_backend", backendEntity.SystemName())
+	equals(t, "some descr", backendEntity.Description())
+	equals(t, "https://example.com", backendEntity.PrivateEndpoint())
+}
+
+func TestBackendAPIEntityUpdateError(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.Update(threescaleapi.Params{})
+	assert(t, err != nil, "update did not return error")
+}
+
+func TestBackendAPIEntityMethods(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	methodList, err := backendEntity.Methods()
+	ok(t, err)
+	assert(t, methodList != nil, "method list returned nil")
+	equals(t, 1, len(methodList.Methods))
+	equals(t, "method_01", methodList.Methods[0].Element.SystemName)
+}
+
+func TestBackendAPIEntityMethodsError(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		errObj := struct {
+			Errors map[string][]string `json:"errors"`
+		}{
+			map[string][]string{"some_attr": []string{"not valid"}},
+		}
+
+		responseBodyBytes, err := json.Marshal(errObj)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	_, err := backendEntity.Methods()
+	assert(t, err != nil, "Methods did not return error")
+}
+
+func TestBackendAPIEntityCreateMethod(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == "GET" && regexp.MustCompile("metrics.json").FindString(req.URL.Path) != "" {
+			return GetMethodsMetricsRoundTripFunc(req)
+		}
+
+		respObject := &threescaleapi.Method{
+			Element: threescaleapi.MethodItem{
+				ID:         int64(4),
+				Name:       "Method 02",
+				ParentID:   int64(1),
+				SystemName: "method_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.CreateMethod(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestBackendAPIEntityDeleteMethod(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == "GET" && regexp.MustCompile("metrics.json").FindString(req.URL.Path) != "" {
+			return GetMethodsMetricsRoundTripFunc(req)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.DeleteMethod(int64(3))
+	ok(t, err)
+}
+
+func TestBackendAPIEntityUpdateMethod(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == "GET" && regexp.MustCompile("metrics.json").FindString(req.URL.Path) != "" {
+			return GetMethodsMetricsRoundTripFunc(req)
+		}
+
+		respObject := &threescaleapi.Method{
+			Element: threescaleapi.MethodItem{
+				ID:         int64(2),
+				Name:       "Method 02",
+				ParentID:   int64(1),
+				SystemName: "method_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.UpdateMethod(int64(3), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestBackendAPIEntityCreateMetric(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MetricJSON{
+			Element: threescaleapi.MetricItem{
+				ID:         int64(5),
+				Name:       "Metric 02",
+				SystemName: "metric_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.CreateMetric(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestBackendAPIEntityDeleteMetric(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.DeleteMetric(int64(5))
+	ok(t, err)
+}
+
+func TestBackendAPIEntityUpdateMetric(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MetricJSON{
+			Element: threescaleapi.MetricItem{
+				ID:         int64(5),
+				Name:       "Metric 02",
+				SystemName: "metric_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.UpdateMetric(int64(3), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestBackendAPIEntityMetricsAndMethods(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	metricList, err := backendEntity.MetricsAndMethods()
+	ok(t, err)
+	assert(t, metricList != nil, "metric list returned nil")
+	equals(t, 3, len(metricList.Metrics))
+	assert(t, FindMetric(metricList, "hits"), "hits metric not found")
+	assert(t, FindMetric(metricList, "metric_01"), "metric_01 metric not found")
+	assert(t, FindMetric(metricList, "method_01"), "method_01 metric not found")
+}
+
+func TestBackendAPIEntityMetrics(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	metricList, err := backendEntity.Metrics()
+	ok(t, err)
+	assert(t, metricList != nil, "metric list returned nil")
+	equals(t, 2, len(metricList.Metrics))
+	assert(t, FindMetric(metricList, "hits"), "hits metric not found")
+	assert(t, FindMetric(metricList, "metric_01"), "metric_01 metric not found")
+}
+
+func TestBackendAPIEntityMappingRules(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MappingRuleJSONList{
+			MappingRules: []threescaleapi.MappingRuleJSON{
+				{
+					Element: threescaleapi.MappingRuleItem{
+						MetricID:   int64(1),
+						Pattern:    "/pets",
+						HTTPMethod: "GET",
+						Delta:      1,
+						Position:   1,
+					},
+				},
+				{
+					Element: threescaleapi.MappingRuleItem{
+						MetricID:   int64(1),
+						Pattern:    "/cats",
+						HTTPMethod: "GET",
+						Delta:      1,
+						Position:   1,
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	ruleList, err := backendEntity.MappingRules()
+	ok(t, err)
+	assert(t, ruleList != nil, "mapping rule list returned nil")
+	equals(t, 2, len(ruleList.MappingRules))
+}
+
+func TestBackendAPIEntityDeleteMappingRule(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.DeleteMappingRule(int64(3))
+	ok(t, err)
+}
+
+func TestBackendAPIEntityCreateMappingRule(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MappingRuleJSON{
+			Element: threescaleapi.MappingRuleItem{
+				MetricID:   int64(1),
+				Pattern:    "/pets",
+				HTTPMethod: "GET",
+				Delta:      1,
+				Position:   1,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.CreateMappingRule(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestBackendAPIEntityUpdateMappingRule(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MappingRuleJSON{
+			Element: threescaleapi.MappingRuleItem{
+				MetricID:   int64(1),
+				Pattern:    "/pets",
+				HTTPMethod: "GET",
+				Delta:      1,
+				Position:   1,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+	err := backendEntity.UpdateMappingRule(int64(1), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestBackendAPIEntityFindMethodMetricIDBySystemName(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	backendEntity := NewBackendAPIEntity(&threescaleapi.BackendApi{}, client, logrtesting.NullLogger{})
+
+	cases := []struct {
+		name       string
+		systemName string
+		expectedID int64
+	}{
+		{"hits exists", "hits", 1},
+		{"metric_01 exists", "metric_01", 2},
+		{"method_01 exists", "method_01", 3},
+		{"method_02 does not exist", "method_02", -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(subT *testing.T) {
+			metricID, err := backendEntity.FindMethodMetricIDBySystemName(tc.systemName)
+			ok(subT, err)
+			equals(subT, tc.expectedID, metricID)
 		})
 	}
 }

--- a/pkg/controller/helper/backendapi_remote_index_test.go
+++ b/pkg/controller/helper/backendapi_remote_index_test.go
@@ -1,0 +1,167 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
+	logrtesting "github.com/go-logr/logr/testing"
+)
+
+func TestBackendAPIRemoteIndexFindByID(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.BackendApiList{
+			Backends: []threescaleapi.BackendApi{
+				{
+					Element: threescaleapi.BackendApiItem{
+						ID:              int64(1),
+						Name:            "Backend 01",
+						SystemName:      "backend_01",
+						Description:     "some descr 01",
+						PrivateEndpoint: "https://example.com",
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+	remoteIndex, err := NewBackendAPIRemoteIndex(client, logrtesting.NullLogger{})
+	ok(t, err)
+
+	backendEntity, ok := remoteIndex.FindByID(int64(1))
+	assert(t, ok, "backend 1 not found")
+	assert(t, backendEntity != nil, "backend entity returned nil")
+	equals(t, int64(1), backendEntity.ID())
+
+	backendEntity, ok = remoteIndex.FindByID(int64(2))
+	assert(t, !ok, "backend 2 found")
+}
+
+func TestBackendAPIRemoteIndexFindBySystemName(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.BackendApiList{
+			Backends: []threescaleapi.BackendApi{
+				{
+					Element: threescaleapi.BackendApiItem{
+						ID:              int64(1),
+						Name:            "Backend 01",
+						SystemName:      "backend_01",
+						Description:     "some descr 01",
+						PrivateEndpoint: "https://example.com",
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+	remoteIndex, err := NewBackendAPIRemoteIndex(client, logrtesting.NullLogger{})
+	ok(t, err)
+
+	backendEntity, ok := remoteIndex.FindBySystemName("backend_01")
+	assert(t, ok, "backend_01 not found")
+	assert(t, backendEntity != nil, "backend entity returned nil")
+	equals(t, "backend_01", backendEntity.SystemName())
+
+	backendEntity, ok = remoteIndex.FindBySystemName("not_existing_system_name")
+	assert(t, !ok, "unexpected backend found")
+}
+
+func TestBackendAPIRemoteIndexCreateBackendAPI(t *testing.T) {
+	token := "12345"
+
+	listBackendHandler := func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.BackendApiList{
+			Backends: []threescaleapi.BackendApi{
+				{
+					Element: threescaleapi.BackendApiItem{
+						ID:              int64(1),
+						Name:            "Backend 01",
+						SystemName:      "backend_01",
+						Description:     "some descr 01",
+						PrivateEndpoint: "https://example.com",
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	}
+
+	createBackendHandler := func(req *http.Request) *http.Response {
+		respObject := threescaleapi.BackendApi{
+			Element: threescaleapi.BackendApiItem{
+				ID:              int64(2),
+				Name:            "New Backend",
+				SystemName:      "new_backend",
+				Description:     "some descr",
+				PrivateEndpoint: "https://example.com",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	}
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		switch req.Method {
+		case "GET":
+			return listBackendHandler(req)
+		default:
+			return createBackendHandler(req)
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+	remoteIndex, err := NewBackendAPIRemoteIndex(client, logrtesting.NullLogger{})
+	ok(t, err)
+
+	backendEntity, err := remoteIndex.CreateBackendAPI(threescaleapi.Params{})
+	ok(t, err)
+	assert(t, backendEntity != nil, "backend entity returned nil")
+	equals(t, "new_backend", backendEntity.SystemName())
+
+	backendEntity, ok := remoteIndex.FindBySystemName("new_backend")
+	assert(t, ok, "new backend not found")
+	assert(t, backendEntity != nil, "backend entity returned nil")
+	equals(t, "new_backend", backendEntity.SystemName())
+}

--- a/pkg/controller/helper/developeruser_test.go
+++ b/pkg/controller/helper/developeruser_test.go
@@ -1,0 +1,71 @@
+package helper
+
+import (
+	"testing"
+
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+
+	logrtesting "github.com/go-logr/logr/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFindDeveloperUserList(t *testing.T) {
+	ns := "some_namespace"
+	adminRole := "admin"
+	memberRole := "member"
+	providerAccountURLStr := "https://example.com"
+	providerAccountToken := "12345"
+	anotherProviderSecretName := "anotherSecretName"
+
+	data := map[string]string{
+		providerAccountSecretURLFieldName:   providerAccountURLStr,
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	providerSecret := GetTestSecret(ns, providerAccountDefaultSecretName, data)
+
+	data = map[string]string{
+		providerAccountSecretURLFieldName:   "https://other.example.com",
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	anotherProviderSecret := GetTestSecret(ns, anotherProviderSecretName, data)
+
+	devUser1 := &capabilitiesv1beta1.DeveloperUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "devUser1", Namespace: ns},
+		Spec: capabilitiesv1beta1.DeveloperUserSpec{
+			Username: "devUser1", Email: "devUser1@example.com", Role: &adminRole,
+		},
+	}
+
+	devUser2 := &capabilitiesv1beta1.DeveloperUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "devUser2", Namespace: ns},
+		Spec: capabilitiesv1beta1.DeveloperUserSpec{
+			Username: "devUser2", Email: "devUser2@example.com", Role: &memberRole,
+		},
+	}
+
+	devUser3 := &capabilitiesv1beta1.DeveloperUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "devUser3", Namespace: ns},
+		Spec: capabilitiesv1beta1.DeveloperUserSpec{
+			Username: "devUser3", Email: "devUser3@example.com", Role: &adminRole,
+			ProviderAccountRef: &corev1.LocalObjectReference{Name: anotherProviderSecretName},
+		},
+	}
+
+	cl := fake.NewFakeClient(anotherProviderSecret, providerSecret, devUser1, devUser2, devUser3)
+
+	// Find only admin users from the same provider account
+	adminRoleFilter := func(developerUser *capabilitiesv1beta1.DeveloperUser) (bool, error) {
+		return developerUser.Spec.Role != nil && *developerUser.Spec.Role == "admin", nil
+	}
+
+	providerAccountFilter := DeveloperUserProviderAccountFilter(cl, ns, providerAccountURLStr, logrtesting.NullLogger{})
+
+	adminUserList, err := FindDeveloperUserList(logrtesting.NullLogger{}, cl, nil, adminRoleFilter, providerAccountFilter)
+	ok(t, err)
+	equals(t, 1, len(adminUserList))
+	equals(t, "devUser1", adminUserList[0].Spec.Username)
+	equals(t, "admin", *adminUserList[0].Spec.Role)
+	assert(t, adminUserList[0].Spec.ProviderAccountRef == nil, "wrong provider account")
+}

--- a/pkg/controller/helper/helper_test.go
+++ b/pkg/controller/helper/helper_test.go
@@ -152,3 +152,30 @@ func FindMetric(l *threescaleapi.MetricJSONList, systemName string) bool {
 	}
 	return false
 }
+
+func FindBackendUsage(l threescaleapi.BackendAPIUsageList, path string) bool {
+	for _, n := range l {
+		if path == n.Element.Path {
+			return true
+		}
+	}
+	return false
+}
+
+func FindApplicationPlan(plans []threescaleapi.ApplicationPlan, systemName string) bool {
+	for _, n := range plans {
+		if systemName == n.Element.SystemName {
+			return true
+		}
+	}
+	return false
+}
+
+func FindPolicy(policies []threescaleapi.PolicyConfig, name string) bool {
+	for _, n := range policies {
+		if name == n.Name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/helper/helper_test.go
+++ b/pkg/controller/helper/helper_test.go
@@ -1,0 +1,22 @@
+package helper
+
+import (
+	"github.com/3scale/3scale-operator/pkg/helper"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetTestSecret(namespace, secretName string, data map[string]string) *v1.Secret {
+	secret := &v1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		StringData: data,
+		Type:       v1.SecretTypeOpaque,
+	}
+	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
+	return secret
+}

--- a/pkg/controller/helper/helper_test.go
+++ b/pkg/controller/helper/helper_test.go
@@ -1,11 +1,53 @@
 package helper
 
 import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
 	"github.com/3scale/3scale-operator/pkg/helper"
 
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// assert fails the test if the condition is false.
+func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// ok fails the test if an err is not nil.
+func ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// equals fails the test if exp is not equal to act.
+func equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+}
+
+func NewTestAdminPortal(t *testing.T) *threescaleapi.AdminPortal {
+	t.Helper()
+	ap, err := threescaleapi.NewAdminPortalFromStr("https://www.test.com:443")
+	ok(t, err)
+	return ap
+}
 
 func GetTestSecret(namespace, secretName string, data map[string]string) *v1.Secret {
 	secret := &v1.Secret{
@@ -19,4 +61,19 @@ func GetTestSecret(namespace, secretName string, data map[string]string) *v1.Sec
 	}
 	secret.Data = helper.GetSecretDataFromStringData(secret.StringData)
 	return secret
+}
+
+// RoundTripFunc .
+type RoundTripFunc func(req *http.Request) *http.Response
+
+// RoundTrip .
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+//NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
 }

--- a/pkg/controller/helper/lookup_provider_account_test.go
+++ b/pkg/controller/helper/lookup_provider_account_test.go
@@ -1,0 +1,99 @@
+package helper
+
+import (
+	"errors"
+	"testing"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+
+	logrtesting "github.com/go-logr/logr/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLookupProviderAccountSecretReference(t *testing.T) {
+	ns := "some_namespace"
+	secretName := "provideraccount"
+	providerAccountURLStr := "https://example.com"
+	providerAccountToken := "12345"
+
+	data := map[string]string{
+		providerAccountSecretURLFieldName:   providerAccountURLStr,
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	providerSecret := GetTestSecret(ns, secretName, data)
+
+	providerAccountRef := &corev1.LocalObjectReference{
+		Name: secretName,
+	}
+
+	cl := fake.NewFakeClient(providerSecret)
+
+	providerAccount, err := LookupProviderAccount(cl, ns, providerAccountRef, logrtesting.NullLogger{})
+	ok(t, err)
+	assert(t, providerAccount != nil, "provider account returned nil")
+	equals(t, providerAccount.AdminURLStr, providerAccountURLStr)
+	equals(t, providerAccount.Token, providerAccountToken)
+}
+
+func TestLookupProviderAccountDefaultSecret(t *testing.T) {
+	ns := "some_namespace"
+	providerAccountURLStr := "https://example.com"
+	providerAccountToken := "12345"
+
+	data := map[string]string{
+		providerAccountSecretURLFieldName:   providerAccountURLStr,
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	providerSecret := GetTestSecret(ns, providerAccountDefaultSecretName, data)
+
+	cl := fake.NewFakeClient(providerSecret)
+
+	providerAccount, err := LookupProviderAccount(cl, ns, nil, logrtesting.NullLogger{})
+	ok(t, err)
+	assert(t, providerAccount != nil, "provider account returned nil")
+	equals(t, providerAccount.AdminURLStr, providerAccountURLStr)
+	equals(t, providerAccount.Token, providerAccountToken)
+}
+
+func TestLookupProviderAccountLocal3scale(t *testing.T) {
+	ns := "some_namespace"
+	providerAccountToken := "12345"
+	tenantName := "testaccount"
+
+	s := scheme.Scheme
+	err := appsv1alpha1.AddToScheme(s)
+
+	apimanager := &appsv1alpha1.APIManager{
+		ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+		Spec: appsv1alpha1.APIManagerSpec{
+			APIManagerCommonSpec: appsv1alpha1.APIManagerCommonSpec{
+				WildcardDomain: "example.com",
+				TenantName:     &tenantName,
+			},
+		},
+	}
+
+	data := map[string]string{
+		component.SystemSecretSystemSeedAdminAccessTokenFieldName: providerAccountToken,
+	}
+	secret := GetTestSecret(ns, component.SystemSecretSystemSeedSecretName, data)
+
+	cl := fake.NewFakeClient(apimanager, secret)
+
+	providerAccount, err := LookupProviderAccount(cl, ns, nil, logrtesting.NullLogger{})
+	ok(t, err)
+	assert(t, providerAccount != nil, "provider account returned nil")
+	equals(t, providerAccount.AdminURLStr, "https://testaccount-admin.example.com")
+	equals(t, providerAccount.Token, providerAccountToken)
+}
+
+func TestLookupProviderAccountNotFoundError(t *testing.T) {
+	ns := "some_namespace"
+	cl := fake.NewFakeClient()
+	_, err := LookupProviderAccount(cl, ns, nil, logrtesting.NullLogger{})
+	equals(t, errors.New("LookupProviderAccount: no provider account found"), err)
+}

--- a/pkg/controller/helper/product_entity.go
+++ b/pkg/controller/helper/product_entity.go
@@ -3,7 +3,6 @@ package helper
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/helper"
 	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
@@ -174,15 +173,6 @@ func (b *ProductEntity) Metrics() (*threescaleapi.MetricJSONList, error) {
 		b.metrics = metrics
 	}
 	return b.metrics, nil
-}
-
-func SanitizeProductSystemName(systemName string) string {
-	lastIndex := strings.LastIndex(systemName, ".")
-	if lastIndex < 0 {
-		return systemName
-	}
-
-	return systemName[:lastIndex]
 }
 
 func (b *ProductEntity) MappingRules() (*threescaleapi.MappingRuleJSONList, error) {

--- a/pkg/controller/helper/product_entity_test.go
+++ b/pkg/controller/helper/product_entity_test.go
@@ -1,0 +1,825 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"testing"
+
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
+	logrtesting "github.com/go-logr/logr/testing"
+)
+
+func TestProductEntityBasics(t *testing.T) {
+	token := "12345"
+	product := &threescaleapi.Product{
+		Element: threescaleapi.ProductItem{
+			ID:               int64(4567),
+			Name:             "some product",
+			SystemName:       "my_product",
+			State:            "active",
+			Description:      "some descr",
+			DeploymentOption: "hosted",
+			BackendVersion:   "1",
+		},
+	}
+
+	client := threescaleapi.NewThreeScale(nil, token, nil)
+	productEntity := NewProductEntity(product, client, logrtesting.NullLogger{})
+	equals(t, product.Element.ID, productEntity.ID())
+	equals(t, product.Element.Name, productEntity.Name())
+	equals(t, product.Element.State, productEntity.State())
+	equals(t, product.Element.Description, productEntity.Description())
+	equals(t, product.Element.DeploymentOption, productEntity.DeploymentOption())
+	equals(t, product.Element.BackendVersion, productEntity.BackendVersion())
+}
+
+func TestProductEntityUpdate(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.Product{
+			Element: threescaleapi.ProductItem{
+				ID: int64(4567), Name: "some product", SystemName: "my_product", State: "active",
+				Description: "some descr", DeploymentOption: "hosted", BackendVersion: "1",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.Update(threescaleapi.Params{})
+	ok(t, err)
+	equals(t, int64(4567), productEntity.ID())
+	equals(t, "some product", productEntity.Name())
+	equals(t, "some descr", productEntity.Description())
+}
+
+func TestProductEntityMethods(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	methodList, err := productEntity.Methods()
+	ok(t, err)
+	assert(t, methodList != nil, "method list returned nil")
+	equals(t, 1, len(methodList.Methods))
+	equals(t, "method_01", methodList.Methods[0].Element.SystemName)
+}
+
+func TestProductEntityCreateMethod(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == "GET" && regexp.MustCompile("metrics.json").FindString(req.URL.Path) != "" {
+			return GetMethodsMetricsRoundTripFunc(req)
+		}
+
+		respObject := &threescaleapi.Method{
+			Element: threescaleapi.MethodItem{
+				ID:         int64(4),
+				Name:       "Method 02",
+				ParentID:   int64(1),
+				SystemName: "method_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.CreateMethod(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityDeleteMethod(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == "GET" && regexp.MustCompile("metrics.json").FindString(req.URL.Path) != "" {
+			return GetMethodsMetricsRoundTripFunc(req)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.DeleteMethod(int64(3))
+	ok(t, err)
+}
+
+func TestProductEntityUpdateMethod(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.Method == "GET" && regexp.MustCompile("metrics.json").FindString(req.URL.Path) != "" {
+			return GetMethodsMetricsRoundTripFunc(req)
+		}
+
+		respObject := &threescaleapi.Method{
+			Element: threescaleapi.MethodItem{
+				ID:         int64(2),
+				Name:       "Method 02",
+				ParentID:   int64(1),
+				SystemName: "method_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdateMethod(int64(3), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityCreateMetric(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MetricJSON{
+			Element: threescaleapi.MetricItem{
+				ID:         int64(5),
+				Name:       "Metric 02",
+				SystemName: "metric_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.CreateMetric(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityDeleteMetric(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.DeleteMetric(int64(5))
+	ok(t, err)
+}
+
+func TestProductEntityUpdateMetric(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MetricJSON{
+			Element: threescaleapi.MetricItem{
+				ID:         int64(5),
+				Name:       "Metric 02",
+				SystemName: "metric_02",
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdateMetric(int64(3), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityMetricsAndMethods(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	metricList, err := productEntity.MetricsAndMethods()
+	ok(t, err)
+	assert(t, metricList != nil, "metric list returned nil")
+	equals(t, 3, len(metricList.Metrics))
+	assert(t, FindMetric(metricList, "hits"), "hits metric not found")
+	assert(t, FindMetric(metricList, "metric_01"), "metric_01 metric not found")
+	assert(t, FindMetric(metricList, "method_01"), "method_01 metric not found")
+}
+
+func TestProductEntityMetrics(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	metricList, err := productEntity.Metrics()
+	ok(t, err)
+	assert(t, metricList != nil, "metric list returned nil")
+	equals(t, 2, len(metricList.Metrics))
+	assert(t, FindMetric(metricList, "hits"), "hits metric not found")
+	assert(t, FindMetric(metricList, "metric_01"), "metric_01 metric not found")
+}
+
+func TestProductEntityMappingRules(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MappingRuleJSONList{
+			MappingRules: []threescaleapi.MappingRuleJSON{
+				{
+					Element: threescaleapi.MappingRuleItem{
+						MetricID:   int64(1),
+						Pattern:    "/pets",
+						HTTPMethod: "GET",
+						Delta:      1,
+						Position:   1,
+					},
+				},
+				{
+					Element: threescaleapi.MappingRuleItem{
+						MetricID:   int64(1),
+						Pattern:    "/cats",
+						HTTPMethod: "GET",
+						Delta:      1,
+						Position:   1,
+					},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	ruleList, err := productEntity.MappingRules()
+	ok(t, err)
+	assert(t, ruleList != nil, "mapping rule list returned nil")
+	equals(t, 2, len(ruleList.MappingRules))
+}
+
+func TestProductEntityDeleteMappingRule(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.DeleteMappingRule(int64(3))
+	ok(t, err)
+}
+
+func TestProductEntityCreateMappingRule(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MappingRuleJSON{
+			Element: threescaleapi.MappingRuleItem{
+				MetricID:   int64(1),
+				Pattern:    "/pets",
+				HTTPMethod: "GET",
+				Delta:      1,
+				Position:   1,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.CreateMappingRule(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityUpdateMappingRule(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.MappingRuleJSON{
+			Element: threescaleapi.MappingRuleItem{
+				MetricID:   int64(1),
+				Pattern:    "/pets",
+				HTTPMethod: "GET",
+				Delta:      1,
+				Position:   1,
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdateMappingRule(int64(1), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityFindMethodMetricIDBySystemName(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(GetMethodsMetricsRoundTripFunc)
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+
+	cases := []struct {
+		name       string
+		systemName string
+		expectedID int64
+	}{
+		{"hits exists", "hits", 1},
+		{"metric_01 exists", "metric_01", 2},
+		{"method_01 exists", "method_01", 3},
+		{"method_02 does not exist", "method_02", -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(subT *testing.T) {
+			metricID, err := productEntity.FindMethodMetricIDBySystemName(tc.systemName)
+			ok(subT, err)
+			equals(subT, tc.expectedID, metricID)
+		})
+	}
+}
+
+func TestProductEntityBackendUsages(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := threescaleapi.BackendAPIUsageList{
+			{
+				Element: threescaleapi.BackendAPIUsageItem{
+					Path: "/v1", ProductID: int64(1), BackendAPIID: int64(1),
+				},
+			},
+			{
+				Element: threescaleapi.BackendAPIUsageItem{
+					Path: "/v2", ProductID: int64(1), BackendAPIID: int64(2),
+				},
+			},
+			{
+				Element: threescaleapi.BackendAPIUsageItem{
+					Path: "/v3", ProductID: int64(1), BackendAPIID: int64(3),
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	backendUsageList, err := productEntity.BackendUsages()
+	ok(t, err)
+	equals(t, 3, len(backendUsageList))
+	assert(t, FindBackendUsage(backendUsageList, "/v1"), "/v1 backend usage not found")
+	assert(t, FindBackendUsage(backendUsageList, "/v2"), "/v2 backend usage not found")
+	assert(t, FindBackendUsage(backendUsageList, "/v3"), "/v3 backend usage not found")
+}
+
+func TestProductEntityDeleteBackendUsage(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.DeleteBackendUsage(int64(3))
+	ok(t, err)
+}
+
+func TestProductEntityUpdateBackendUsage(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.BackendAPIUsage{
+			Element: threescaleapi.BackendAPIUsageItem{
+				Path: "/v1", ProductID: int64(1), BackendAPIID: int64(1),
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdateBackendUsage(int64(1), threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityCreateBackendUsage(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.BackendAPIUsage{
+			Element: threescaleapi.BackendAPIUsageItem{
+				Path: "/v1", ProductID: int64(1), BackendAPIID: int64(1),
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.CreateBackendUsage(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityProxy(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.ProxyJSON{
+			Element: threescaleapi.ProxyItem{Endpoint: "https://gw.example.com"},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	proxy, err := productEntity.Proxy()
+	ok(t, err)
+	assert(t, proxy != nil, "proxy returned nil")
+	equals(t, "https://gw.example.com", proxy.Element.Endpoint)
+}
+
+func TestProductEntityUpdateProxy(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.ProxyJSON{
+			Element: threescaleapi.ProxyItem{Endpoint: "https://gw.example.com"},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdateProxy(threescaleapi.Params{})
+	ok(t, err)
+}
+
+func TestProductEntityApplicationPlans(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.ApplicationPlanJSONList{
+			Plans: []threescaleapi.ApplicationPlan{
+				{
+					Element: threescaleapi.ApplicationPlanItem{SystemName: "plan01"},
+				},
+				{
+					Element: threescaleapi.ApplicationPlanItem{SystemName: "plan02"},
+				},
+				{
+					Element: threescaleapi.ApplicationPlanItem{SystemName: "plan03"},
+				},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	plans, err := productEntity.ApplicationPlans()
+	ok(t, err)
+	assert(t, plans != nil, "plans returned nil")
+	equals(t, 3, len(plans.Plans))
+	assert(t, FindApplicationPlan(plans.Plans, "plan01"), "plan01 plan not found")
+	assert(t, FindApplicationPlan(plans.Plans, "plan02"), "plan02 plan not found")
+	assert(t, FindApplicationPlan(plans.Plans, "plan03"), "plan03 plan not found")
+}
+
+func TestProductEntityDeleteApplicationPlan(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.DeleteApplicationPlan(int64(1))
+	ok(t, err)
+}
+
+func TestProductEntityCreateApplicationPlan(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.ApplicationPlan{
+			Element: threescaleapi.ApplicationPlanItem{SystemName: "plan01"},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	plan, err := productEntity.CreateApplicationPlan(threescaleapi.Params{})
+	ok(t, err)
+	assert(t, plan != nil, "plan returned nil")
+	equals(t, "plan01", plan.Element.SystemName)
+}
+
+func TestProductEntityPromoteProxyToStaging(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.ProxyJSON{
+			Element: threescaleapi.ProxyItem{Endpoint: "https://gw.example.com"},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.PromoteProxyToStaging()
+	ok(t, err)
+}
+
+func TestProductEntityPolicies(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.PoliciesConfigList{
+			Policies: []threescaleapi.PolicyConfig{
+				{Name: "policy01"},
+				{Name: "policy02"},
+				{Name: "policy03"},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	policies, err := productEntity.Policies()
+	ok(t, err)
+	assert(t, policies != nil, "policies returned nil")
+	equals(t, 3, len(policies.Policies))
+	assert(t, FindPolicy(policies.Policies, "policy01"), "policy01 policy not found")
+	assert(t, FindPolicy(policies.Policies, "policy02"), "policy02 policy not found")
+	assert(t, FindPolicy(policies.Policies, "policy03"), "policy03 policy not found")
+}
+
+func TestProductEntityUpdatePolicies(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.PoliciesConfigList{
+			Policies: []threescaleapi.PolicyConfig{
+				{Name: "policy01"},
+				{Name: "policy02"},
+				{Name: "policy03"},
+			},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdatePolicies(&threescaleapi.PoliciesConfigList{})
+	ok(t, err)
+}
+
+func TestProductEntityOIDCConfiguration(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.OIDCConfiguration{
+			Element: threescaleapi.OIDCConfigurationItem{ID: int64(1)},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	oidcConf, err := productEntity.OIDCConfiguration()
+	ok(t, err)
+	assert(t, oidcConf != nil, "oidcConf returned nil")
+	equals(t, int64(1), oidcConf.Element.ID)
+}
+
+func TestProductEntityUpdateOIDCConfiguration(t *testing.T) {
+	token := "12345"
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		respObject := &threescaleapi.OIDCConfiguration{
+			Element: threescaleapi.OIDCConfigurationItem{ID: int64(1)},
+		}
+
+		responseBodyBytes, err := json.Marshal(respObject)
+		ok(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	client := threescaleapi.NewThreeScale(NewTestAdminPortal(t), token, httpClient)
+
+	productEntity := NewProductEntity(&threescaleapi.Product{}, client, logrtesting.NullLogger{})
+	err := productEntity.UpdateOIDCConfiguration(&threescaleapi.OIDCConfiguration{})
+	ok(t, err)
+}

--- a/pkg/controller/helper/product_list_test.go
+++ b/pkg/controller/helper/product_list_test.go
@@ -1,0 +1,148 @@
+package helper
+
+import (
+	"testing"
+
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+	"github.com/3scale/3scale-operator/pkg/common"
+
+	logrtesting "github.com/go-logr/logr/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestProductList(t *testing.T) {
+	ns := "somenamespace"
+	providerAccountURLStr := "https://example.com"
+	providerAccountToken := "12345"
+	anotherProviderSecretName := "anotherSecretName"
+
+	data := map[string]string{
+		providerAccountSecretURLFieldName:   providerAccountURLStr,
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	providerSecret := GetTestSecret(ns, providerAccountDefaultSecretName, data)
+
+	data = map[string]string{
+		providerAccountSecretURLFieldName:   "https://other.example.com",
+		providerAccountSecretTokenFieldName: providerAccountToken,
+	}
+	anotherProviderSecret := GetTestSecret(ns, anotherProviderSecretName, data)
+
+	s := scheme.Scheme
+	err := capabilitiesv1beta1.AddToScheme(s)
+	if err != nil {
+		t.Fatalf("Unable to add Apps scheme: (%v)", err)
+	}
+
+	cases := []struct {
+		testName string
+		product  *capabilitiesv1beta1.Product
+		expected bool
+	}{
+		{
+			"sync'ed product and same providerAccount",
+			&capabilitiesv1beta1.Product{
+				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+				Spec:       capabilitiesv1beta1.ProductSpec{},
+				Status: capabilitiesv1beta1.ProductStatus{
+					Conditions: common.Conditions{
+						common.Condition{
+							Type:   capabilitiesv1beta1.ProductSyncedConditionType,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"Not sync'ed product",
+			&capabilitiesv1beta1.Product{
+				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+				Spec:       capabilitiesv1beta1.ProductSpec{},
+				Status: capabilitiesv1beta1.ProductStatus{
+					Conditions: common.Conditions{
+						common.Condition{
+							Type:   capabilitiesv1beta1.ProductSyncedConditionType,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"provider not matching product",
+			&capabilitiesv1beta1.Product{
+				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: ns},
+				Spec: capabilitiesv1beta1.ProductSpec{
+					ProviderAccountRef: &corev1.LocalObjectReference{
+						Name: anotherProviderSecretName,
+					},
+				},
+				Status: capabilitiesv1beta1.ProductStatus{
+					Conditions: common.Conditions{
+						common.Condition{
+							Type:   capabilitiesv1beta1.ProductSyncedConditionType,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			cl := fake.NewFakeClient(anotherProviderSecret, providerSecret, tc.product)
+			productList, err := ProductList(ns, cl, providerAccountURLStr, logrtesting.NullLogger{})
+			if err != nil {
+				subT.Fatal(err)
+			}
+
+			if (len(productList) == 0) == tc.expected {
+				subT.Errorf("product included: %t, expected: %t", len(productList) != 0, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFindProductBySystemName(t *testing.T) {
+	ns := "somenamespace"
+	productList := []capabilitiesv1beta1.Product{
+		capabilitiesv1beta1.Product{
+			ObjectMeta: metav1.ObjectMeta{Name: "A", Namespace: ns},
+			Spec:       capabilitiesv1beta1.ProductSpec{SystemName: "A"},
+		},
+		capabilitiesv1beta1.Product{
+			ObjectMeta: metav1.ObjectMeta{Name: "B", Namespace: ns},
+			Spec:       capabilitiesv1beta1.ProductSpec{SystemName: "B"},
+		},
+		capabilitiesv1beta1.Product{
+			ObjectMeta: metav1.ObjectMeta{Name: "C", Namespace: ns},
+			Spec:       capabilitiesv1beta1.ProductSpec{SystemName: "C"},
+		},
+	}
+
+	cases := []struct {
+		testName    string
+		systemName  string
+		expectedRes int
+	}{
+		{"Looking for non existing", "not existing", -1},
+		{"Looking for A", "A", 0},
+		{"Looking for B", "B", 1},
+		{"Looking for C", "C", 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			res := FindProductBySystemName(productList, tc.systemName)
+			equals(subT, tc.expectedRes, res)
+		})
+	}
+}

--- a/pkg/controller/helper/threescale_api_test.go
+++ b/pkg/controller/helper/threescale_api_test.go
@@ -1,0 +1,34 @@
+package helper
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestPortaClientInvalidURL(t *testing.T) {
+	providerAccount := &ProviderAccount{AdminURLStr: ":foo", Token: "some token"}
+	_, err := PortaClient(providerAccount)
+	assert(t, err != nil, "error should not be nil")
+}
+
+func TestPortaClient(t *testing.T) {
+	providerAccount := &ProviderAccount{AdminURLStr: "http://somedomain.example.com", Token: "some token"}
+	_, err := PortaClient(providerAccount)
+	ok(t, err)
+}
+
+func TestPortaClientFromURLStringInvalidURL(t *testing.T) {
+	_, err := PortaClientFromURLString(":foo", "some token")
+	assert(t, err != nil, "error should not be nil")
+}
+
+func TestPortaClientFromURLString(t *testing.T) {
+	_, err := PortaClientFromURLString("http://somedomain.example.com", "some token")
+	ok(t, err)
+}
+
+func TestPortaClientFromURL(t *testing.T) {
+	url := &url.URL{}
+	_, err := PortaClientFromURL(url, "some token")
+	assert(t, err != nil, "error should not be nil")
+}

--- a/pkg/controller/helper/url_test.go
+++ b/pkg/controller/helper/url_test.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestURLFromDomain(t *testing.T) {
+	cases := []struct {
+		testName    string
+		domain      string
+		expectedErr bool
+		expectedURL url.URL
+	}{
+		{"Invalid domain", ":foo", true, url.URL{}},
+		{
+			"Valid domain", "http://somedomain.example.com", false,
+			url.URL{
+				Scheme: "https",
+				Host:   "somedomain.example.com",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			res, err := URLFromDomain(tc.domain)
+			if !tc.expectedErr {
+				ok(subT, err)
+				equals(subT, tc.expectedURL, *res)
+			} else {
+				assert(subT, err != nil, "error should not be nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added unittest coverage for `github.com/3scale/3scale-operator/pkg/controller/helper`

Initially, unittest coverage was **33.8%**

```
$ make coverage_total_report
....
33.8%
```

After this PR, **42.4%**

```
$ make coverage_total_report
....
42.4%
```
