### PR TITLE
Increase default backend-cron DeploymentConfig memory limits

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -574,7 +574,7 @@ APIManager components are the following ones:
 | system-postgresql | 250m | No limit | 512Mi | 2Gi |
 | backend-listener | 500m | 1000m | 550Mi | 700Mi |
 | backend-worker | 150m | 1000m | 50Mi | 300Mi |
-| backend-cron | 50m | 150m | 40Mi | 80Mi |
+| backend-cron | 50m | 150m | 40Mi | 150Mi |
 | backend-redis | 1000m | 2000m | 1024Mi | 32Gi |
 | apicast-production | 500m | 1000m | 64Mi | 128Mi |
 | apicast-staging | 50m | 100m | 64Mi | 128Mi |

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -290,7 +290,7 @@ objects:
           resources:
             limits:
               cpu: 150m
-              memory: 80Mi
+              memory: 150Mi
             requests:
               cpu: 50m
               memory: 40Mi

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -679,7 +679,7 @@ objects:
           resources:
             limits:
               cpu: 150m
-              memory: 80Mi
+              memory: 150Mi
             requests:
               cpu: 50m
               memory: 40Mi

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -679,7 +679,7 @@ objects:
           resources:
             limits:
               cpu: 150m
-              memory: 80Mi
+              memory: 150Mi
             requests:
               cpu: 50m
               memory: 40Mi

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -679,7 +679,7 @@ objects:
           resources:
             limits:
               cpu: 150m
-              memory: 80Mi
+              memory: 150Mi
             requests:
               cpu: 50m
               memory: 40Mi

--- a/pkg/3scale/amp/component/backend_options.go
+++ b/pkg/3scale/amp/component/backend_options.go
@@ -87,7 +87,7 @@ func DefaultCronResourceRequirements() v1.ResourceRequirements {
 	return v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceCPU:    resource.MustParse("150m"),
-			v1.ResourceMemory: resource.MustParse("80Mi"),
+			v1.ResourceMemory: resource.MustParse("150Mi"),
 		},
 		Requests: v1.ResourceList{
 			v1.ResourceCPU:    resource.MustParse("50m"),


### PR DESCRIPTION
Motivated by issue https://github.com/3scale/3scale-operator/issues/584,

This PR increases the backend-cron memory resource limits from `80Mi` to `150Mi`.

Includes upgrade procedure. The memory limits will be upgraded in the following scenario:
* When `.spec.resourceRequirementsEnabled` is set to `true` and `.spec.backend.cronSpec.resources` is NOT set. In any other cases they will not be upgraded. For example, if the user has overwritten them at `.spec.backend.cronSpec.resources` level or `.spec.resourceRequirementsEnabled` is set to `false`

This will require the writing of an upgrade procedure on the templates side.