### PR TITLE
Update backend-redis internal database version from 3.2 to 5.x

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -238,7 +238,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -582,7 +582,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: ${REDIS_IMAGE}
+        name: centos/redis-32-centos7
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
@@ -4285,7 +4285,7 @@ parameters:
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: centos/redis-32-centos7
+  value: centos/redis-5-centos7
 - description: Username for System's MySQL user that will be used for accessing the database.
   displayName: System MySQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -238,7 +238,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -582,7 +582,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: ${REDIS_IMAGE}
+        name: centos/redis-32-centos7
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
@@ -4092,7 +4092,7 @@ parameters:
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: centos/redis-32-centos7
+  value: centos/redis-5-centos7
 - description: Username for System's MySQL user that will be used for accessing the database.
   displayName: System MySQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -238,7 +238,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -594,7 +594,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: ${REDIS_IMAGE}
+        name: centos/redis-32-centos7
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
@@ -4144,7 +4144,7 @@ parameters:
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: centos/redis-32-centos7
+  value: centos/redis-5-centos7
 - description: Username for PostgreSQL user that will be used for accessing the database.
   displayName: System PostgreSQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -238,7 +238,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -594,7 +594,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: ${REDIS_IMAGE}
+        name: centos/redis-32-centos7
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
@@ -4386,7 +4386,7 @@ parameters:
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: centos/redis-32-centos7
+  value: centos/redis-5-centos7
 - description: Username for System's MySQL user that will be used for accessing the database.
   displayName: System MySQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -238,7 +238,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: backend-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -594,7 +594,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: ${REDIS_IMAGE}
+        name: centos/redis-32-centos7
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}
@@ -4193,7 +4193,7 @@ parameters:
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true
-  value: centos/redis-32-centos7
+  value: centos/redis-5-centos7
 - description: Username for System's MySQL user that will be used for accessing the database.
   displayName: System MySQL User
   name: SYSTEM_DATABASE_USER

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -17,7 +17,7 @@ func ZyncImageURL() string {
 }
 
 func BackendRedisImageURL() string {
-	return "centos/redis-32-centos7"
+	return "centos/redis-5-centos7"
 }
 
 func SystemRedisImageURL() string {

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -53,7 +53,7 @@ const (
 	backendRedisConfigVolumeName  = "redis-config"
 	backendRedisConfigMapKey      = "redis.conf"
 	backendRedisContainerName     = "backend-redis"
-	backendRedisContainerCommand  = "/opt/rh/rh-redis32/root/usr/bin/redis-server"
+	backendRedisContainerCommand  = "/opt/rh/rh-redis5/root/usr/bin/redis-server"
 )
 
 func (redis *Redis) buildDeploymentConfigSpec() appsv1.DeploymentConfigSpec {

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -67,7 +67,7 @@ func testRedisBackendRedisPodTemplateLabels() map[string]string {
 		"threescale_component_element": "redis",
 		"com.redhat.component-name":    "backend-redis",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "32",
+		"com.redhat.component-version": "5",
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   "master",
 		"deploymentConfig":             "backend-redis",

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -295,10 +295,29 @@ func (u *UpgradeApiManager) upgradeBackendRedisDeploymentConfig() (reconcile.Res
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	desired := redis.BackendDeploymentConfig()
 
-	res, err := u.upgradeDeploymentConfigImageChangeTrigger(redis.BackendDeploymentConfig())
-	if res.Requeue || err != nil {
-		return res, err
+	existing := &appsv1.DeploymentConfig{}
+	err = u.Client().Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: u.apiManager.Namespace}, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	changed := false
+	tmpChanged, err := u.ensureDeploymentConfigImageChangeTrigger(desired, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	changed = changed || tmpChanged
+
+	tmpChanged, err = u.ensureRedisCommand(desired, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	changed = changed || tmpChanged
+
+	if changed {
+		return reconcile.Result{Requeue: true}, u.UpdateResource(existing)
 	}
 
 	return reconcile.Result{}, nil
@@ -395,6 +414,25 @@ func (u *UpgradeApiManager) upgradeDeploymentConfigImageChangeTrigger(desired *a
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) ensureRedisCommand(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	if len(existing.Spec.Template.Spec.Containers) == 0 {
+		return false, fmt.Errorf("DeploymentConfig %s spec.template.spec.containers length is %d, should be 1", existing.Name, len(existing.Spec.Template.Spec.Containers))
+
+	}
+	if len(desired.Spec.Template.Spec.Containers) == 0 {
+		return false, fmt.Errorf("DeploymentConfig %s spec.template.spec.containers length is %d, should be 1", desired.Name, len(desired.Spec.Template.Spec.Containers))
+	}
+
+	changed := false
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Command, desired.Spec.Template.Spec.Containers[0].Command) {
+		existing.Spec.Template.Spec.Containers[0].Command = desired.Spec.Template.Spec.Containers[0].Command
+		u.Logger().V(1).Info(fmt.Sprintf("DeploymentConfig %s container command changed", desired.Name))
+		changed = true
+	}
+
+	return changed, nil
 }
 
 func (u *UpgradeApiManager) ensureDeploymentConfigImageChangeTrigger(desired, existing *appsv1.DeploymentConfig) (bool, error) {

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -88,7 +88,7 @@ func (r *RedisAdapter) options() (*component.RedisOptions, error) {
 	ro.BackendImageTag = "${AMP_RELEASE}"
 	ro.BackendImage = "${REDIS_IMAGE}"
 	ro.SystemImageTag = "${AMP_RELEASE}"
-	ro.SystemImage = "${REDIS_IMAGE}"
+	ro.SystemImage = component.SystemRedisImageURL()
 
 	ro.BackendRedisContainerResourceRequirements = component.DefaultBackendRedisContainerResourceRequirements()
 	ro.SystemRedisContainerResourceRequirements = component.DefaultSystemRedisContainerResourceRequirements()


### PR DESCRIPTION
This PR implements changing the used backend-redis internal database Redis version from 3.2 to 5.x
This has been done for both templates and operator.
In case of the productized version the image URLs will be different than the upstream ones that are the ones that can be seen in this PR. The productized URLs will be updated/set on the version-specific branch.

In the operator case it also includes upgrade automation to migrate from one version to another. The upgrade migration includes:
* Container image change
* Needed command changes
* PodTemplate label changes

In the templates case upgrade documentation will be needed.