### PR TITLE
Refactor component labels values retrieval in options providers unit tests

### DIFF
--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -54,7 +54,7 @@ func testApicastStagingPodLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "apicast-staging",
 	}
 }
@@ -68,7 +68,7 @@ func testApicastProductionPodLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "apicast-production",
 	}
 }

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ func testApicastStagingPodLabels() map[string]string {
 		"threescale_component_element": "staging",
 		"com.redhat.component-name":    "apicast-staging",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(ApicastImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "apicast-staging",
@@ -66,7 +67,7 @@ func testApicastProductionPodLabels() map[string]string {
 		"threescale_component_element": "production",
 		"com.redhat.component-name":    "apicast-production",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(ApicastImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "apicast-production",

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -60,7 +61,7 @@ func testBackendListenerPodLabels() map[string]string {
 		"threescale_component_element": "listener",
 		"com.redhat.component-name":    "backend-listener",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(BackendImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-listener",
@@ -74,7 +75,7 @@ func testBackendWorkerPodLabels() map[string]string {
 		"threescale_component_element": "worker",
 		"com.redhat.component-name":    "backend-worker",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(BackendImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-worker",
@@ -88,7 +89,7 @@ func testBackendCronPodLabels() map[string]string {
 		"threescale_component_element": "cron",
 		"com.redhat.component-name":    "backend-cron",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(BackendImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-cron",

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -62,7 +62,7 @@ func testBackendListenerPodLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-listener",
 	}
 }
@@ -76,7 +76,7 @@ func testBackendWorkerPodLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-worker",
 	}
 }
@@ -90,7 +90,7 @@ func testBackendCronPodLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-cron",
 	}
 }

--- a/pkg/3scale/amp/operator/memcached_options_provider_test.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider_test.go
@@ -7,6 +7,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -28,7 +29,7 @@ func testPodTemplateLabels() map[string]string {
 		"threescale_component_element": "memcache",
 		"com.redhat.component-name":    "system-memcache",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "1.5",
+		"com.redhat.component-version": helper.ParseVersion(SystemMemcachedImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-memcache",

--- a/pkg/3scale/amp/operator/memcached_options_provider_test.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider_test.go
@@ -30,7 +30,7 @@ func testPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "1.5",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-memcache",
 	}
 }

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -7,6 +7,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -38,7 +39,7 @@ func testRedisSystemRedisPodTemplateLabels() map[string]string {
 		"threescale_component_element": "redis",
 		"com.redhat.component-name":    "system-redis",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "32",
+		"com.redhat.component-version": helper.ParseVersion(SystemRedisImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-redis",
@@ -67,7 +68,7 @@ func testRedisBackendRedisPodTemplateLabels() map[string]string {
 		"threescale_component_element": "redis",
 		"com.redhat.component-name":    "backend-redis",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "5",
+		"com.redhat.component-version": helper.ParseVersion(BackendRedisImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-redis",

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -40,7 +40,7 @@ func testRedisSystemRedisPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "32",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-redis",
 	}
 }
@@ -69,7 +69,7 @@ func testRedisBackendRedisPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "5",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "backend-redis",
 	}
 }

--- a/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -45,7 +46,7 @@ func testSystemMysqlPodTemplateLabels() map[string]string {
 		"threescale_component_element": "mysql",
 		"com.redhat.component-name":    "system-mysql",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "57",
+		"com.redhat.component-version": helper.ParseVersion(SystemMySQLImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-mysql",

--- a/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
@@ -47,7 +47,7 @@ func testSystemMysqlPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "57",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-mysql",
 	}
 }

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -45,7 +46,7 @@ func testSystemAppPodTemplateLabels() map[string]string {
 		"threescale_component_element": "app",
 		"com.redhat.component-name":    "system-app",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(SystemImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-app",
@@ -67,7 +68,7 @@ func testSystemSidekiqPodTemplateLabels() map[string]string {
 		"threescale_component_element": "sidekiq",
 		"com.redhat.component-name":    "system-sidekiq",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(SystemImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-sidekiq",
@@ -113,7 +114,7 @@ func testSystemSphinxPodTemplateLabels() map[string]string {
 		"threescale_component_element": "sphinx",
 		"com.redhat.component-name":    "system-sphinx",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(SystemImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-sphinx",

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -47,7 +47,7 @@ func testSystemAppPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-app",
 	}
 }
@@ -69,7 +69,7 @@ func testSystemSidekiqPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-sidekiq",
 	}
 }
@@ -115,7 +115,7 @@ func testSystemSphinxPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-sphinx",
 	}
 }

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -45,7 +46,7 @@ func testSystemPostgreSQLPodTemplateLabels() map[string]string {
 		"threescale_component_element": "postgresql",
 		"com.redhat.component-name":    "system-postgresql",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "10",
+		"com.redhat.component-version": helper.ParseVersion(SystemPostgreSQLImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-postgresql",

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
@@ -47,7 +47,7 @@ func testSystemPostgreSQLPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "10",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "system-postgresql",
 	}
 }

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -66,7 +66,7 @@ func testZyncPodTemplateLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "zync",
 	}
 }
@@ -80,7 +80,7 @@ func testZyncQuePodTemplateCommonLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "nightly",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "zync-que",
 	}
 }
@@ -94,7 +94,7 @@ func testZyncDatabasePodTemplateCommonLabels() map[string]string {
 		"com.redhat.component-type":    "application",
 		"com.redhat.component-version": "10",
 		"com.redhat.product-name":      "3scale",
-		"com.redhat.product-version":   "master",
+		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "zync-database",
 	}
 }

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -64,7 +65,7 @@ func testZyncPodTemplateLabels() map[string]string {
 		"threescale_component_element": "zync",
 		"com.redhat.component-name":    "zync",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(ZyncImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "zync",
@@ -78,7 +79,7 @@ func testZyncQuePodTemplateCommonLabels() map[string]string {
 		"threescale_component_element": "zync-que",
 		"com.redhat.component-name":    "zync-que",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "nightly",
+		"com.redhat.component-version": helper.ParseVersion(ZyncImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "zync-que",
@@ -92,7 +93,7 @@ func testZyncDatabasePodTemplateCommonLabels() map[string]string {
 		"threescale_component_element": "database",
 		"com.redhat.component-name":    "zync-database",
 		"com.redhat.component-type":    "application",
-		"com.redhat.component-version": "10",
+		"com.redhat.component-version": helper.ParseVersion(ZyncPostgreSQLImageURL()),
 		"com.redhat.product-name":      "3scale",
 		"com.redhat.product-version":   product.ThreescaleRelease,
 		"deploymentConfig":             "zync-database",


### PR DESCRIPTION
Refactors references to component labels values from centralized places in the options_provider_* unit tests

The motivation of this is to avoid having to perform manual patches in this tests files depending on the version branch