### PR TITLE
local installation of development tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+OS := $(shell uname | awk '{print tolower($$0)}' | sed -e s/linux/linux-gnu/ )
+ARCH := $(shell uname -m)
+
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/3scale/3scale-operator:master
 
@@ -95,8 +98,11 @@ $(KUSTOMIZE):
 kustomize: $(KUSTOMIZE)
 
 OPERATOR_SDK = $(PROJECT_PATH)/bin/operator-sdk
+# Note: release file patterns changed after v1.2.0
+# More info https://sdk.operatorframework.io/docs/installation/
+OPERATOR_SDK_VERSION=v1.2.0
 $(OPERATOR_SDK):
-	curl -sSL https://github.com/operator-framework/operator-sdk/releases/download/v1.2.0/operator-sdk-v1.2.0-x86_64-linux-gnu -o $(OPERATOR_SDK)
+	curl -sSL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-${OPERATOR_SDK_VERSION}-$(ARCH)-${OS} -o $(OPERATOR_SDK)
 	chmod +x $(OPERATOR_SDK)
 
 .PHONY: operator-sdk


### PR DESCRIPTION
Install development tools at `${PROJECT_BASE_PATH}/bin`. Avoid conflict with the same development tools for different releases required in other working projects. 

* Operator-sdk
* kustomize
* controller-gen
* go-bindata
