### PR TITLE
Update system-redis internal database from 3.2 to 5.x

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -380,9 +380,9 @@ spec:
                 - name: SYSTEM_MEMCACHED_IMAGE
                   value: memcached:1.5
                 - name: BACKEND_REDIS_IMAGE
-                  value: centos/redis-32-centos7
+                  value: centos/redis-5-centos7
                 - name: SYSTEM_REDIS_IMAGE
-                  value: centos/redis-32-centos7
+                  value: centos/redis-5-centos7
                 - name: SYSTEM_MYSQL_IMAGE
                   value: centos/mysql-57-centos7
                 - name: SYSTEM_POSTGRESQL_IMAGE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,9 +58,9 @@ spec:
         - name: SYSTEM_MEMCACHED_IMAGE
           value: "memcached:1.5"
         - name: BACKEND_REDIS_IMAGE
-          value: "centos/redis-32-centos7"
+          value: "centos/redis-5-centos7"
         - name: SYSTEM_REDIS_IMAGE
-          value: "centos/redis-32-centos7"
+          value: "centos/redis-5-centos7"
         - name: SYSTEM_MYSQL_IMAGE
           value: "centos/mysql-57-centos7"
         - name: SYSTEM_POSTGRESQL_IMAGE

--- a/doc/template-user-guide.md
+++ b/doc/template-user-guide.md
@@ -66,7 +66,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp.yml \
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
 | **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
-| **REDIS_IMAGE** | Redis image to use | centos/redis-32-centos7 |
+| **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
 | **SYSTEM_DATABASE** | System MySQL Database Name | system |
@@ -136,7 +136,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml \
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
 | **SYSTEM_DATABASE_IMAGE** | System PostgreSQL image URL | centos/postgresql-10-centos7 |
-| **REDIS_IMAGE** | Redis image to use | centos/redis-32-centos7 |
+| **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System PostgreSQL User | system |
 | **SYSTEM_DATABASE_PASSWORD** | System PostgreSQL Password | random value |
 | **SYSTEM_DATABASE** | System PostgreSQL Database Name | system |
@@ -212,7 +212,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml \
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
 | **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
-| **REDIS_IMAGE** | Redis image to use | centos/redis-32-centos7 |
+| **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
 | **SYSTEM_DATABASE** | System MySQL Database Name | system |
@@ -371,7 +371,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml \
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
 | **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
-| **REDIS_IMAGE** | Redis image to use | centos/redis-32-centos7 |
+| **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
 | **SYSTEM_DATABASE** | System MySQL Database Name | system |
@@ -441,7 +441,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
 | **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
-| **REDIS_IMAGE** | Redis image to use | centos/redis-32-centos7 |
+| **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
 | **SYSTEM_DATABASE** | System MySQL Database Name | system |

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -474,7 +474,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -582,7 +582,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: centos/redis-32-centos7
+        name: ${REDIS_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -474,7 +474,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -582,7 +582,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: centos/redis-32-centos7
+        name: ${REDIS_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -480,7 +480,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -594,7 +594,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: centos/redis-32-centos7
+        name: ${REDIS_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -480,7 +480,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -594,7 +594,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: centos/redis-32-centos7
+        name: ${REDIS_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -480,7 +480,7 @@ objects:
           - --daemonize
           - "no"
           command:
-          - /opt/rh/rh-redis32/root/usr/bin/redis-server
+          - /opt/rh/rh-redis5/root/usr/bin/redis-server
           image: system-redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -594,7 +594,7 @@ objects:
         openshift.io/display-name: System ${AMP_RELEASE} Redis
       from:
         kind: DockerImage
-        name: centos/redis-32-centos7
+        name: ${REDIS_IMAGE}
       generation: null
       importPolicy:
         insecure: ${{IMAGESTREAM_TAG_IMPORT_INSECURE}}

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -21,7 +21,7 @@ func BackendRedisImageURL() string {
 }
 
 func SystemRedisImageURL() string {
-	return "centos/redis-32-centos7"
+	return "centos/redis-5-centos7"
 }
 
 func SystemMySQLImageURL() string {

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -54,6 +54,7 @@ const (
 	backendRedisConfigMapKey      = "redis.conf"
 	backendRedisContainerName     = "backend-redis"
 	backendRedisContainerCommand  = "/opt/rh/rh-redis5/root/usr/bin/redis-server"
+	systemRedisContainerCommand   = "/opt/rh/rh-redis5/root/usr/bin/redis-server"
 )
 
 func (redis *Redis) buildDeploymentConfigSpec() appsv1.DeploymentConfigSpec {
@@ -500,7 +501,7 @@ func (redis *Redis) SystemDeploymentConfig() *appsv1.DeploymentConfig {
 						v1.Container{
 							Name:      "system-redis",
 							Image:     "system-redis:latest",
-							Command:   []string{"/opt/rh/rh-redis32/root/usr/bin/redis-server"},
+							Command:   []string{systemRedisContainerCommand},
 							Args:      []string{"/etc/redis.d/redis.conf", "--daemonize", "no"},
 							Resources: *redis.Options.SystemRedisContainerResourceRequirements,
 							VolumeMounts: []v1.VolumeMount{

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -88,7 +88,7 @@ func (r *RedisAdapter) options() (*component.RedisOptions, error) {
 	ro.BackendImageTag = "${AMP_RELEASE}"
 	ro.BackendImage = "${REDIS_IMAGE}"
 	ro.SystemImageTag = "${AMP_RELEASE}"
-	ro.SystemImage = component.SystemRedisImageURL()
+	ro.SystemImage = "${REDIS_IMAGE}"
 
 	ro.BackendRedisContainerResourceRequirements = component.DefaultBackendRedisContainerResourceRequirements()
 	ro.SystemRedisContainerResourceRequirements = component.DefaultSystemRedisContainerResourceRequirements()


### PR DESCRIPTION
This PR implements changing the used system-redis internal database Redis version from 3.2 to 5.x
This has been done for both templates and operator.
In case of the productized version the image URLs will be different than the upstream ones that are the ones that can be seen in this PR. The productized URLs will be updated/set on the corresponding downstream repository branch/es.

In the operator case it also includes upgrade automation to migrate from one version to another. The upgrade migration includes:
* Container image change
* Needed command changes
* PodTemplate label changes

In the templates case upgrade documentation will be needed.