### PR TITLE
Build Zync from ubi8/ruby-27

### DIFF
--- a/pkg/3scale/amp/manual-templates/amp/build.yml
+++ b/pkg/3scale/amp/manual-templates/amp/build.yml
@@ -11,12 +11,12 @@ objects:
     annotations:
     labels:
       app: zync
-    name: ruby-25-ubi7
+    name: ruby-27-ubi8
   spec:
     tags:
     - from:
         kind: DockerImage
-        name: registry.redhat.io/ubi7/ruby-25
+        name: registry.redhat.io/ubi8/ruby-27
       name: latest
 
 - apiVersion: v1
@@ -42,7 +42,7 @@ objects:
           name: "${PULLSECRET_NAME}"
         from:
           kind: ImageStreamTag
-          name: ruby-25-ubi7:latest
+          name: ruby-27-ubi8:latest
       type: Docker
 
 - apiVersion: v1


### PR DESCRIPTION
Related to https://github.com/3scale/zync/pull/457/commits/a8b830f766a51bbe17d723c3a83b22cbc41303fc
Fixes build error such as https://app.circleci.com/pipelines/github/3scale/3scale-operator/3642/workflows/200d2213-492a-4fa3-a36a-b15232342809/jobs/26702