### PR TITLE
Fix circleci-update-failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
             SUDO=sudo
             fi
             # Install ruby
-            $SUDO apt-get update && $SUDO apt-get install -y ruby-full
+            $SUDO apt-get update --allow-releaseinfo-change && $SUDO apt-get install -y ruby-full
       - run:
           name: Installing License tool
           command: |


### PR DESCRIPTION
Build fails on apt-get update, some repo updated current state from 'stable' to 'oldstable' and command is failing. 