### PR TITLE
Remove AMP_RELEASE system env var

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1490,7 +1490,6 @@ objects:
     username: ""
 - apiVersion: v1
   data:
-    AMP_RELEASE: ${AMP_RELEASE}
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     FILE_UPLOAD_STORAGE: s3
     FORCE_SSL: "true"
@@ -1544,11 +1543,6 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
-            - name: AMP_RELEASE
-              valueFrom:
-                configMapKeyRef:
-                  key: AMP_RELEASE
-                  name: system-environment
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1863,11 +1857,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2198,11 +2187,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2532,11 +2516,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2925,11 +2904,6 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1507,7 +1507,6 @@ objects:
     username: ""
 - apiVersion: v1
   data:
-    AMP_RELEASE: ${AMP_RELEASE}
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
@@ -1560,11 +1559,6 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
-            - name: AMP_RELEASE
-              valueFrom:
-                configMapKeyRef:
-                  key: AMP_RELEASE
-                  name: system-environment
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1838,11 +1832,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2132,11 +2121,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2425,11 +2409,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2781,11 +2760,6 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -1027,7 +1027,6 @@ objects:
     username: ""
 - apiVersion: v1
   data:
-    AMP_RELEASE: ${AMP_RELEASE}
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
@@ -1080,11 +1079,6 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
-            - name: AMP_RELEASE
-              valueFrom:
-                configMapKeyRef:
-                  key: AMP_RELEASE
-                  name: system-environment
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1358,11 +1352,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -1658,11 +1647,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -1957,11 +1941,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2319,11 +2298,6 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1499,7 +1499,6 @@ objects:
     username: ""
 - apiVersion: v1
   data:
-    AMP_RELEASE: ${AMP_RELEASE}
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
@@ -1552,11 +1551,6 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
-            - name: AMP_RELEASE
-              valueFrom:
-                configMapKeyRef:
-                  key: AMP_RELEASE
-                  name: system-environment
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1830,11 +1824,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2130,11 +2119,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2429,11 +2413,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2791,11 +2770,6 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1531,7 +1531,6 @@ objects:
     username: ""
 - apiVersion: v1
   data:
-    AMP_RELEASE: ${AMP_RELEASE}
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     FILE_UPLOAD_STORAGE: s3
     FORCE_SSL: "true"
@@ -1585,11 +1584,6 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
-            - name: AMP_RELEASE
-              valueFrom:
-                configMapKeyRef:
-                  key: AMP_RELEASE
-                  name: system-environment
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1904,11 +1898,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2245,11 +2234,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2585,11 +2569,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2984,11 +2963,6 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1548,7 +1548,6 @@ objects:
     username: ""
 - apiVersion: v1
   data:
-    AMP_RELEASE: ${AMP_RELEASE}
     APICAST_REGISTRY_URL: ${APICAST_REGISTRY_URL}
     FORCE_SSL: "true"
     PROVIDER_PLAN: enterprise
@@ -1601,11 +1600,6 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
-            - name: AMP_RELEASE
-              valueFrom:
-                configMapKeyRef:
-                  key: AMP_RELEASE
-                  name: system-environment
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1879,11 +1873,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2179,11 +2168,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2478,11 +2462,6 @@ objects:
           - -c
           - config/unicorn.rb
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2840,11 +2819,6 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
-          - name: AMP_RELEASE
-            valueFrom:
-              configMapKeyRef:
-                key: AMP_RELEASE
-                name: system-environment
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -356,7 +356,6 @@ func (system *System) EnvironmentConfigMap() *v1.ConfigMap {
 			"RAILS_LOG_LEVEL":        "info",
 			"THINKING_SPHINX_PORT":   "9306",
 			"THREESCALE_SANDBOX_PROXY_OPENSSL_VERIFY_MODE": "VERIFY_NONE",
-			"AMP_RELEASE":  system.Options.AmpRelease,
 			"SSL_CERT_DIR": "/etc/pki/tls/certs",
 		},
 	}

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -54,7 +54,6 @@ type SystemOptions struct {
 	AdminAccessToken    string  `validate:"required"`
 	AdminPassword       string  `validate:"required"`
 	AdminUsername       string  `validate:"required"`
-	AmpRelease          string  `validate:"required"`
 	ApicastAccessToken  string  `validate:"required"`
 	ApicastRegistryURL  string  `validate:"required"`
 	MasterAccessToken   string  `validate:"required"`

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -32,7 +32,6 @@ func NewSystemOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace str
 }
 
 func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, error) {
-	s.options.AmpRelease = product.ThreescaleRelease
 	s.options.ImageTag = product.ThreescaleRelease
 	s.options.ApicastRegistryURL = *s.apimanager.Spec.Apicast.RegistryURL
 	s.options.TenantName = *s.apimanager.Spec.TenantName

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -320,13 +320,12 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 	storageRequests := component.DefaultSharedStorageResources()
 
 	expectedOpts := &component.SystemOptions{
-		TenantName:                               tenantName,
-		WildcardDomain:                           wildcardDomain,
-		AmpRelease:                               product.ThreescaleRelease,
-		ImageTag:                                 product.ThreescaleRelease,
-		ApicastRegistryURL:                       apicastRegistryURL,
-		AppMasterContainerResourceRequirements:   component.DefaultAppMasterContainerResourceRequirements(),
-		AppProviderContainerResourceRequirements: component.DefaultAppProviderContainerResourceRequirements(),
+		TenantName:                                tenantName,
+		WildcardDomain:                            wildcardDomain,
+		ImageTag:                                  product.ThreescaleRelease,
+		ApicastRegistryURL:                        apicastRegistryURL,
+		AppMasterContainerResourceRequirements:    component.DefaultAppMasterContainerResourceRequirements(),
+		AppProviderContainerResourceRequirements:  component.DefaultAppProviderContainerResourceRequirements(),
 		AppDeveloperContainerResourceRequirements: component.DefaultAppDeveloperContainerResourceRequirements(),
 		SidekiqContainerResourceRequirements:      component.DefaultSidekiqContainerResourceRequirements(),
 		SphinxContainerResourceRequirements:       component.DefaultSphinxContainerResourceRequirements(),

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -6,11 +6,13 @@ import (
 	"reflect"
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -30,12 +32,130 @@ func NewUpgradeApiManager(b *reconcilers.BaseReconciler, apiManager *appsv1alpha
 }
 
 func (u *UpgradeApiManager) Upgrade() (reconcile.Result, error) {
-	res, err := u.upgradeImages()
+	res, err := u.upgradeSystemAMPRelease()
+	if err != nil {
+		return res, fmt.Errorf("Upgrade: remove system AMP_RELEASE error: %w", err)
+	}
+
+	res, err = u.upgradeImages()
 	if err != nil {
 		return res, fmt.Errorf("Upgrading images: %w", err)
 	}
 	if res.Requeue {
 		return res, nil
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) upgradeSystemAMPRelease() (reconcile.Result, error) {
+	system, err := System(u.apiManager, u.Client())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	res, err := u.deleteAMPReleaseSystemAppDC(system.AppDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	res, err = u.deleteAMPReleaseSystemSidekiqDC(system.SidekiqDeploymentConfig())
+	if res.Requeue || err != nil {
+		return res, err
+	}
+
+	return u.deleteAMPReleaseConfigMap(system.EnvironmentConfigMap())
+}
+
+func (u *UpgradeApiManager) deleteAMPReleaseSystemAppDC(desired *appsv1.DeploymentConfig) (reconcile.Result, error) {
+	existing := &appsv1.DeploymentConfig{}
+	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: u.apiManager.Namespace}, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(existing.Spec.Template.Spec.Containers) != 3 {
+		return reconcile.Result{}, fmt.Errorf("DeploymentConfig %s spec.template.spec.containers length is %d, should be 3",
+			existing.Name, len(existing.Spec.Template.Spec.Containers))
+	}
+
+	update := false
+
+	// regular pod containers
+	for idx := 0; idx < 3; idx++ {
+		container := &existing.Spec.Template.Spec.Containers[idx]
+		if envVarIdx := helper.FindEnvVar(container.Env, "AMP_RELEASE"); envVarIdx >= 0 {
+			// remove index
+			container.Env = append(container.Env[:envVarIdx], container.Env[envVarIdx+1:]...)
+			update = true
+		}
+	}
+
+	// Pre hook pod
+	// the ExecNewPod property is already a pointer
+	preHookPod := existing.Spec.Strategy.RollingParams.Pre.ExecNewPod
+	if envVarIdx := helper.FindEnvVar(preHookPod.Env, "AMP_RELEASE"); envVarIdx >= 0 {
+		// remove index
+		preHookPod.Env = append(preHookPod.Env[:envVarIdx], preHookPod.Env[envVarIdx+1:]...)
+		update = true
+	}
+
+	if update {
+		err = u.UpdateResource(existing)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) deleteAMPReleaseSystemSidekiqDC(desired *appsv1.DeploymentConfig) (reconcile.Result, error) {
+	existing := &appsv1.DeploymentConfig{}
+	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: u.apiManager.Namespace}, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	update := false
+
+	// regular pod containers
+	container := &existing.Spec.Template.Spec.Containers[0]
+	if envVarIdx := helper.FindEnvVar(container.Env, "AMP_RELEASE"); envVarIdx >= 0 {
+		// remove index
+		container.Env = append(container.Env[:envVarIdx], container.Env[envVarIdx+1:]...)
+		update = true
+	}
+
+	if update {
+		err = u.UpdateResource(existing)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (u *UpgradeApiManager) deleteAMPReleaseConfigMap(desired *v1.ConfigMap) (reconcile.Result, error) {
+	existing := &v1.ConfigMap{}
+	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: u.apiManager.Namespace}, existing)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	update := false
+
+	if _, ok := existing.Data["AMP_RELEASE"]; ok {
+		delete(existing.Data, "AMP_RELEASE")
+		update = true
+	}
+
+	if update {
+		err = u.UpdateResource(existing)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/3scale/amp/prometheusrules/system_app_rules.go
+++ b/pkg/3scale/amp/prometheusrules/system_app_rules.go
@@ -57,7 +57,6 @@ func systemOptions(ns string) (*component.SystemOptions, error) {
 	o.AdminAccessToken = "_"
 	o.AdminPassword = "_"
 	o.AdminUsername = "_"
-	o.AmpRelease = "_"
 	o.ImageTag = "_"
 	o.ApicastAccessToken = "_"
 	o.ApicastRegistryURL = "_"

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -214,7 +214,6 @@ func (s *System) options() (*component.SystemOptions, error) {
 	o.AdminEmail = &adminEmail
 	userSessionTTL := "${USER_SESSION_TTL}"
 	o.UserSessionTTL = &userSessionTTL
-	o.AmpRelease = "${AMP_RELEASE}"
 	o.ImageTag = "${AMP_RELEASE}"
 	o.ApicastAccessToken = "${APICAST_ACCESS_TOKEN}"
 	o.ApicastRegistryURL = "${APICAST_REGISTRY_URL}"


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-7427

Upgrade procedure implemented for deleting:
* `AMP_RELEASE` from `system-environment` config map
* `AMP_RELEASE` env var from pre-hook in `system-app` deployment config
* `AMP_RELEASE` env var from all containers in `system-app` deployment config
*  `AMP_RELEASE` env var from in `system-sidekiq` deployment config