### PR TITLE
fix: Make sure zync-database DeploymentConfig is only upgraded when deployed internally

### DIFF
--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -297,9 +297,11 @@ func (u *UpgradeApiManager) upgradeZyncDeploymentConfigs() (reconcile.Result, er
 		return res, err
 	}
 
-	res, err = u.upgradeDeploymentConfigImageChangeTrigger(zync.DatabaseDeploymentConfig())
-	if res.Requeue || err != nil {
-		return res, err
+	if !u.apiManager.IsZyncExternalDatabaseEnabled() {
+		res, err = u.upgradeDeploymentConfigImageChangeTrigger(zync.DatabaseDeploymentConfig())
+		if res.Requeue || err != nil {
+			return res, err
+		}
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Uprading 3scale-operator fails to upgrade from 2.10 to 2.11 is enabled when external databases are enabled and the setting to enable zync external database is enabled too:

```
  highAvailability:
    enabled: true
    externalZyncDatabaseEnabled: true
```

The following operator error logs in a loop can be observed when the upgrade process is triggered:

```
2021-09-03T17:40:32.193+0200	ERROR	controllers.APIManager	Error upgrading APIManager	{"apimanager": "msoriano-test/example-apimanager", "error": "Upgrading images: DeploymentConfig.apps.openshift.io \"zync-database\" not found"}
github.com/go-logr/zapr.(*zapLogger).Error
	/home/msoriano/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
github.com/3scale/3scale-operator/controllers/apps.(*APIManagerReconciler).Reconcile
	/home/msoriano/go/src/github.com/3scale/3scale-operator/controllers/apps/apimanager_controller.go:106
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/msoriano/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:244
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/msoriano/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:218
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/home/msoriano/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:197
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90
2021-09-03T17:40:32.193+0200	ERROR	controller	Reconciler error	{"reconcilerGroup": "apps.3scale.net", "reconcilerKind": "APIManager", "controller": "apimanager", "name": "example-apimanager", "namespace": "msoriano-test", "error": "Upgrading images: DeploymentConfig.apps.openshift.io \"zync-database\" not found"}
github.com/go-logr/zapr.(*zapLogger).Error
	/home/msoriano/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/msoriano/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:246
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/msoriano/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:218
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/home/msoriano/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:197
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/home/msoriano/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90
2021-09-03T17:40:33.193+0200	INFO	controllers.APIManager	ReconcileAPIManager	{"apimanager": "msoriano-test/example-apimanager", "Operator version": "0.9.0", "3scale release": "master"}
```