### PR TITLE
fix docker image version parser

### DIFF
--- a/pkg/helper/labels.go
+++ b/pkg/helper/labels.go
@@ -22,7 +22,7 @@ func MeteringLabels(componentName, componentVersion string, componentType Compon
 		"com.redhat.component-version": componentVersion,
 	}
 
-	if len(componentVersion) > validation.LabelValueMaxLength {
+	if len(validation.IsValidLabelValue(componentVersion)) > 0 {
 		labels["com.redhat.component-version"] = ""
 	}
 

--- a/pkg/helper/version_parser.go
+++ b/pkg/helper/version_parser.go
@@ -22,10 +22,14 @@ var (
 	reg1digitRawParser versionParser = func(text string) string { return regexp.MustCompile(`\d+`).FindString(text) }
 )
 
-func normalizeDockerImage(image string) string {
+func normalizeDockerURL(image string) string {
+	// Only for version parsing purposes, Host and scheme is added to have the URL being parsed correctly
+	// normalizeDockerURL tries to build a URL string that can be parsed by net/url library
+	// docker image URLS can be tricky sometimes.
+	// o := url.Parse("registry.redhat.io:443/rhel8/redis-5:1") -> o.Path is empty
 	newImage := image
 
-	if strings.Index(image, "/") < 0 {
+	if !strings.Contains(image, "/") {
 		newImage = fmt.Sprintf("docker.io/%s", newImage)
 	}
 
@@ -33,21 +37,22 @@ func normalizeDockerImage(image string) string {
 		newImage = fmt.Sprintf("http://%s", newImage)
 	}
 
-	return newImage
+	u, err := url.Parse(newImage)
+	if err != nil {
+		// silently discard the error and return empty
+		return ""
+	}
+
+	return u.Path
 }
 
 func ParseVersion(image string) string {
 	regExpsFuncs := []versionParser{reg3digitRawParser, reg2digitRawParser, regColonRawParser, reg1digitRawParser}
 
-	nImage := normalizeDockerImage(image)
-
-	u, err := url.Parse(nImage)
-	if err != nil {
-		return "unknown"
-	}
+	nImage := normalizeDockerURL(image)
 
 	for _, regExpRawFunc := range regExpsFuncs {
-		version := regExpRawFunc(u.Path)
+		version := regExpRawFunc(nImage)
 		if len(version) > 0 {
 			return version
 		}

--- a/pkg/helper/version_parser_test.go
+++ b/pkg/helper/version_parser_test.go
@@ -15,6 +15,8 @@ func TestParseVersion(t *testing.T) {
 		{"test03", "memcached:1.5", "1.5"},
 		{"test04", "redis-32-rhel7", "32"},
 		{"test05", "quay.io/3scale/apisonator:latest", "latest"},
+		{"test06", "quay.io/3scale/apisonator@sha256:353e979109b7db05813068e503dc95e8c3308f5a2210c40644e01d7f634e66e7", "353e979109b7db05813068e503dc95e8c3308f5a2210c40644e01d7f634e66e7"},
+		{"test07", "registry.redhat.io:443/rhel8/redis-5:1", "1"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
* Keep backward compat. New unittests added, not updated any existing unittests.
* Full check for valid label value, not only length.

