### PR TITLE
Rename APIcast openTracing.tracingConfigRef to tracingConfigSecretRef

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -593,11 +593,11 @@ type APIcastOpenTracingSpec struct {
 	// TracingLibrary controls which OpenTracing library is loaded. At the moment
 	// the only supported tracer is `jaeger`. If not set, `jaeger` will be used.
 	TracingLibrary *string `json:"tracingLibrary,omitempty"`
-	// TracingConfig contains a secret reference the OpenTracing configuration.
+	// TracingConfigSecretRef contains a secret reference the OpenTracing configuration.
 	// Each supported tracing library provides a default configuration file
 	// that is used if TracingConfig is not specified.
 	// +optional
-	TracingConfigSecretRef *v1.LocalObjectReference `json:"tracingConfigRef,omitempty"`
+	TracingConfigSecretRef *v1.LocalObjectReference `json:"tracingConfigSecretRef,omitempty"`
 }
 
 // SetDefaults sets the default values for the APIManager spec and returns true if the spec was changed

--- a/bundle/manifests/apps.3scale.net_apimanagers.yaml
+++ b/bundle/manifests/apps.3scale.net_apimanagers.yaml
@@ -456,8 +456,8 @@ spec:
                           enabled:
                             description: Enabled controls whether OpenTracing integration with APIcast is enabled. By default it is not enabled.
                             type: boolean
-                          tracingConfigRef:
-                            description: TracingConfig contains a secret reference the OpenTracing configuration. Each supported tracing library provides a default configuration file that is used if TracingConfig is not specified.
+                          tracingConfigSecretRef:
+                            description: TracingConfigSecretRef contains a secret reference the OpenTracing configuration. Each supported tracing library provides a default configuration file that is used if TracingConfig is not specified.
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -939,8 +939,8 @@ spec:
                           enabled:
                             description: Enabled controls whether OpenTracing integration with APIcast is enabled. By default it is not enabled.
                             type: boolean
-                          tracingConfigRef:
-                            description: TracingConfig contains a secret reference the OpenTracing configuration. Each supported tracing library provides a default configuration file that is used if TracingConfig is not specified.
+                          tracingConfigSecretRef:
+                            description: TracingConfigSecretRef contains a secret reference the OpenTracing configuration. Each supported tracing library provides a default configuration file that is used if TracingConfig is not specified.
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'

--- a/config/crd/bases/apps.3scale.net_apimanagers.yaml
+++ b/config/crd/bases/apps.3scale.net_apimanagers.yaml
@@ -783,11 +783,11 @@ spec:
                             description: Enabled controls whether OpenTracing integration
                               with APIcast is enabled. By default it is not enabled.
                             type: boolean
-                          tracingConfigRef:
-                            description: TracingConfig contains a secret reference
-                              the OpenTracing configuration. Each supported tracing
-                              library provides a default configuration file that is
-                              used if TracingConfig is not specified.
+                          tracingConfigSecretRef:
+                            description: TracingConfigSecretRef contains a secret
+                              reference the OpenTracing configuration. Each supported
+                              tracing library provides a default configuration file
+                              that is used if TracingConfig is not specified.
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -1621,11 +1621,11 @@ spec:
                             description: Enabled controls whether OpenTracing integration
                               with APIcast is enabled. By default it is not enabled.
                             type: boolean
-                          tracingConfigRef:
-                            description: TracingConfig contains a secret reference
-                              the OpenTracing configuration. Each supported tracing
-                              library provides a default configuration file that is
-                              used if TracingConfig is not specified.
+                          tracingConfigSecretRef:
+                            description: TracingConfigSecretRef contains a secret
+                              reference the OpenTracing configuration. Each supported
+                              tracing library provides a default configuration file
+                              that is used if TracingConfig is not specified.
                             properties:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -108,7 +108,7 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 | Workers | `workers` | integer | No | Automatically computed. Check [apicast doc](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_workers) for further info. | Defines the number of worker processes |
 | LogLevel | `logLevel` | string | No | N/A | Log level for the OpenResty logs  (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_log_level)) |
 | CustomPolicies | `customPolicies` | [][CustomPolicySpec](#CustomPolicySpec) | No | N/A | List of custom policies |
-| OpenTracing | `openTracing` | [OpenTracingSpec](#OpenTracingSpec) | No | N/A | contains the OpenTracing integration configuration |
+| OpenTracing | `openTracing` | [APIcastOpenTracingSpec](#APIcastOpenTracingSpec) | No | N/A | contains the OpenTracing integration configuration |
 | CustomEnvironments | `customEnvironments` | [][CustomEnvironmentSpec](#CustomEnvironmentSpec) | No | N/A | List of custom environments |
 | HTTPSPort | `httpsPort` | int | No | **8443** only when `httpsCertificateSecretRef` is provided | Controls on which port APIcast should start listening for HTTPS connections. Do not use `8080` as HTTPS port (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_https_port)) |
 | HTTPSVerifyDepth | `httpsVerifyDepth` | int | No | N/A | Defines the maximum length of the client certificate chain. (see [docs](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#apicast_https_verify_depth)) |
@@ -154,7 +154,7 @@ Some examples are available [here](/doc/adding-custom-policies.md)
 | --- | --- | --- | --- | --- | --- |
 | Enabled | `enabled` | bool | No | `false` | Controls whether OpenTracing integration with APIcast is enabled. By default it is not enabled |
 | TracingLibrary | `tracingLibrary` | string | No | `jaeger` | Controls which OpenTracing library is loaded. At the moment the supported values are: `jaeger`. If not set, `jaeger` will be used |
-| | TracingConfigRef | `tracingConfigRef` | LocalObjectReference | No | tracing library-specific default | Secret reference with the tracing library-specific configuration. Each supported tracing library provides a default configuration file which is used if `tracingConfigRef` is not specified. See [APIcastTracingConfigSecret](#APIcastTracingConfigSecret) for more information. |
+| TracingConfigSecretRef | `tracingConfigSecretRef` | LocalObjectReference | No | tracing library-specific default | Secret reference with the tracing library-specific configuration. Each supported tracing library provides a default configuration file which is used if `tracingConfigSecretRef` is not specified. See [APIcastTracingConfigSecret](#APIcastTracingConfigSecret) for more information. |
 
 ### APIcastTracingConfigSecret
 
@@ -168,7 +168,7 @@ However, apicast has the environment already loaded and it does not change the b
 
 If the custom environment content needs to be changed, there are two options:
 
-* [**recommended way**] Create another secret with a different name and update the APIcast custom resource field `spec.apicast.<apicast-environment>.openTracing.tracingConfigRef.name`. The operator will trigger a rolling update loading the new custom environment content.
+* [**recommended way**] Create another secret with a different name and update the APIcast custom resource field `spec.apicast.<apicast-environment>.openTracing.tracingConfigSecretRef.name`. The operator will trigger a rolling update loading the new custom environment content.
 * Update the existing secret content and redeploy apicast turning `spec.replicas` to 0 and then back to the previous value.
 
 #### CustomEnvironmentSpec


### PR DESCRIPTION
Rename .spec.openTracing.tracingConfigRef to .spec.openTracing.tracingConfigSecretRef to better indicate that the config to be provided is a K8s secret. Used in APIcast production and staging