### PR TITLE
http client respects http proxy env vars

### DIFF
--- a/pkg/controller/helper/threescale_api.go
+++ b/pkg/controller/helper/threescale_api.go
@@ -42,6 +42,7 @@ func PortaClientFromURL(url *url.URL, token string) (*threescaleapi.ThreeScaleCl
 	// TODO By default should not skip verification
 	// Activated by some env var or Spec param
 	var transport http.RoundTripper = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 


### PR DESCRIPTION
Currently the http client used for application capabilities was not respecting the http proxy env variables. 

https://pkg.go.dev/net/http#ProxyFromEnvironment



