### PR TITLE
Update system-mysql internal DB from MySQL 5.7 to 8.0

### DIFF
--- a/doc/template-user-guide.md
+++ b/doc/template-user-guide.md
@@ -65,7 +65,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp.yml \
 | **ZYNC_DATABASE_IMAGE** | Zync's PostgreSQL image to use | centos/postgresql-10-centos7 |
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
-| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
+| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-80-centos7 |
 | **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
@@ -207,7 +207,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml \
 | **ZYNC_DATABASE_IMAGE** | Zync's PostgreSQL image to use | centos/postgresql-10-centos7 |
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
-| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
+| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-80-centos7 |
 | **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
@@ -359,7 +359,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml \
 | **ZYNC_DATABASE_IMAGE** | Zync's PostgreSQL image to use | centos/postgresql-10-centos7 |
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
-| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
+| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-80-centos7 |
 | **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |
@@ -427,7 +427,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
 | **ZYNC_DATABASE_IMAGE** | Zync's PostgreSQL image to use | centos/postgresql-10-centos7 |
 | **MEMCACHED_IMAGE** | Memcached image to use | memcached:1.5 |
 | **IMAGESTREAM_TAG_IMPORT_INSECURE** | the server may bypass certificate verification | false |
-| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-57-centos7 |
+| **SYSTEM_DATABASE_IMAGE** | System MySQL image URL | centos/mysql-80-centos7 |
 | **REDIS_IMAGE** | Redis image to use | centos/redis-5-centos7 |
 | **SYSTEM_DATABASE_USER** | System MySQL User | mysql |
 | **SYSTEM_DATABASE_PASSWORD** | System MySQL Password | random value |

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1217,7 +1217,8 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |
+    mysql-charset.cnf: |2
+
       [client]
       default-character-set = utf8
 
@@ -1227,6 +1228,10 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
+    mysql-default-authentication-plugin.cnf: |2
+
+      [mysqld]
+      default_authentication_plugin=mysql_native_password
   kind: ConfigMap
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1217,8 +1217,7 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |2
-
+    mysql-charset.cnf: |
       [client]
       default-character-set = utf8
 
@@ -1228,8 +1227,7 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
-    mysql-default-authentication-plugin.cnf: |2
-
+    mysql-default-authentication-plugin.cnf: |
       [mysqld]
       default_authentication_plugin=mysql_native_password
   kind: ConfigMap

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -4127,7 +4127,7 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: centos/mysql-57-centos7
+  value: centos/mysql-80-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1217,7 +1217,8 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |
+    mysql-charset.cnf: |2
+
       [client]
       default-character-set = utf8
 
@@ -1227,6 +1228,10 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
+    mysql-default-authentication-plugin.cnf: |2
+
+      [mysqld]
+      default_authentication_plugin=mysql_native_password
   kind: ConfigMap
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1217,8 +1217,7 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |2
-
+    mysql-charset.cnf: |
       [client]
       default-character-set = utf8
 
@@ -1228,8 +1227,7 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
-    mysql-default-authentication-plugin.cnf: |2
-
+    mysql-default-authentication-plugin.cnf: |
       [mysqld]
       default_authentication_plugin=mysql_native_password
   kind: ConfigMap

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3934,7 +3934,7 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: centos/mysql-57-centos7
+  value: centos/mysql-80-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1252,7 +1252,8 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |
+    mysql-charset.cnf: |2
+
       [client]
       default-character-set = utf8
 
@@ -1262,6 +1263,10 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
+    mysql-default-authentication-plugin.cnf: |2
+
+      [mysqld]
+      default_authentication_plugin=mysql_native_password
   kind: ConfigMap
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1252,8 +1252,7 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |2
-
+    mysql-charset.cnf: |
       [client]
       default-character-set = utf8
 
@@ -1263,8 +1262,7 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
-    mysql-default-authentication-plugin.cnf: |2
-
+    mysql-default-authentication-plugin.cnf: |
       [mysqld]
       default_authentication_plugin=mysql_native_password
   kind: ConfigMap

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -4228,7 +4228,7 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: centos/mysql-57-centos7
+  value: centos/mysql-80-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1252,7 +1252,8 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |
+    mysql-charset.cnf: |2
+
       [client]
       default-character-set = utf8
 
@@ -1262,6 +1263,10 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
+    mysql-default-authentication-plugin.cnf: |2
+
+      [mysqld]
+      default_authentication_plugin=mysql_native_password
   kind: ConfigMap
   metadata:
     creationTimestamp: null

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -4035,7 +4035,7 @@ parameters:
 - description: System MySQL image to use
   name: SYSTEM_DATABASE_IMAGE
   required: true
-  value: centos/mysql-57-centos7
+  value: centos/mysql-80-centos7
 - description: Redis image to use
   name: REDIS_IMAGE
   required: true

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1252,8 +1252,7 @@ objects:
     name: mysql-main-conf
 - apiVersion: v1
   data:
-    mysql-charset.cnf: |2
-
+    mysql-charset.cnf: |
       [client]
       default-character-set = utf8
 
@@ -1263,8 +1262,7 @@ objects:
       [mysqld]
       character-set-server = utf8
       collation-server = utf8_unicode_ci
-    mysql-default-authentication-plugin.cnf: |2
-
+    mysql-default-authentication-plugin.cnf: |
       [mysqld]
       default_authentication_plugin=mysql_native_password
   kind: ConfigMap

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -25,7 +25,7 @@ func SystemRedisImageURL() string {
 }
 
 func SystemMySQLImageURL() string {
-	return "centos/mysql-57-centos7"
+	return "centos/mysql-80-centos7"
 }
 
 func SystemPostgreSQLImageURL() string {

--- a/pkg/3scale/amp/component/system_mysql.go
+++ b/pkg/3scale/amp/component/system_mysql.go
@@ -70,8 +70,7 @@ func (mysql *SystemMysql) ExtraConfigConfigMap() *v1.ConfigMap {
 			Labels: mysql.Options.DeploymentLabels,
 		},
 		Data: map[string]string{
-			"mysql-charset.cnf": `
-[client]
+			"mysql-charset.cnf": `[client]
 default-character-set = utf8
 
 [mysql]
@@ -81,8 +80,7 @@ default-character-set = utf8
 character-set-server = utf8
 collation-server = utf8_unicode_ci
 `,
-			"mysql-default-authentication-plugin.cnf": `
-[mysqld]
+			"mysql-default-authentication-plugin.cnf": `[mysqld]
 default_authentication_plugin=mysql_native_password
 `,
 		},

--- a/pkg/3scale/amp/component/system_mysql.go
+++ b/pkg/3scale/amp/component/system_mysql.go
@@ -69,7 +69,24 @@ func (mysql *SystemMysql) ExtraConfigConfigMap() *v1.ConfigMap {
 			Name:   "mysql-extra-conf",
 			Labels: mysql.Options.DeploymentLabels,
 		},
-		Data: map[string]string{"mysql-charset.cnf": "[client]\ndefault-character-set = utf8\n\n[mysql]\ndefault-character-set = utf8\n\n[mysqld]\ncharacter-set-server = utf8\ncollation-server = utf8_unicode_ci\n"}}
+		Data: map[string]string{
+			"mysql-charset.cnf": `
+[client]
+default-character-set = utf8
+
+[mysql]
+default-character-set = utf8
+
+[mysqld]
+character-set-server = utf8
+collation-server = utf8_unicode_ci
+`,
+			"mysql-default-authentication-plugin.cnf": `
+[mysqld]
+default_authentication_plugin=mysql_native_password
+`,
+		},
+	}
 }
 
 func (mysql *SystemMysql) PersistentVolumeClaim() *v1.PersistentVolumeClaim {

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -904,8 +904,7 @@ func (u *UpgradeApiManager) upgradeMysqlConfigmap() (reconcile.Result, error) {
 	}
 
 	if _, ok := mysqlExtraConfigMap.Data["mysql-default-authentication-plugin.cnf"]; !ok {
-		mysqlExtraConfigMap.Data["mysql-default-authentication-plugin.cnf"] = `
-[mysqld]
+		mysqlExtraConfigMap.Data["mysql-default-authentication-plugin.cnf"] = `[mysqld]
 default_authentication_plugin=mysql_native_password
 `
 		err = u.UpdateResource(mysqlExtraConfigMap)

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -38,6 +38,11 @@ func (u *UpgradeApiManager) Upgrade() (reconcile.Result, error) {
 		return res, fmt.Errorf("Upgrade: remove system AMP_RELEASE error: %w", err)
 	}
 
+	res, err = u.upgradeMysqlConfigmap()
+	if err != nil {
+		return res, fmt.Errorf("Upgrade: update mysql configmap. error: %w", err)
+	}
+
 	res, err = u.upgradeImages()
 	if err != nil {
 		return res, fmt.Errorf("Upgrading images: %w", err)
@@ -880,6 +885,36 @@ func (u *UpgradeApiManager) ensurePodTemplateLabels(desired *appsv1.DeploymentCo
 	}
 
 	return updated, nil
+}
+
+func (u *UpgradeApiManager) upgradeMysqlConfigmap() (reconcile.Result, error) {
+	if u.apiManager.IsExternalDatabaseEnabled() {
+		return reconcile.Result{}, nil
+	}
+
+	if u.apiManager.Spec.System.DatabaseSpec != nil &&
+		u.apiManager.Spec.System.DatabaseSpec.PostgreSQL != nil {
+		return reconcile.Result{}, nil
+	}
+
+	mysqlExtraConfigMap := &v1.ConfigMap{}
+	err := u.Client().Get(context.TODO(), types.NamespacedName{Name: "mysql-extra-conf", Namespace: u.apiManager.Namespace}, mysqlExtraConfigMap)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if _, ok := mysqlExtraConfigMap.Data["mysql-default-authentication-plugin.cnf"]; !ok {
+		mysqlExtraConfigMap.Data["mysql-default-authentication-plugin.cnf"] = `
+[mysqld]
+default_authentication_plugin=mysql_native_password
+`
+		err = u.UpdateResource(mysqlExtraConfigMap)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
 }
 
 func (u *UpgradeApiManager) Logger() logr.Logger {


### PR DESCRIPTION
The change of image also implies an automated upgrade from
MySQL 5.7 to 8.0 when coming from an older 3scale installation
where 5.7 is used. There is no need for a custom upgrade procedure.

The data migration is performed automatically when changing the image.

On the product side, the image to be set will be:
`registry.redhat.io/rhscl/mysql-80-rhel7:8.0`

JIRA: https://issues.redhat.com/browse/THREESCALE-7786
which depends on https://issues.redhat.com/browse/THREESCALE-6825

### Verification steps

Deploy 3scale with the APIManager
```yaml
k apply -f - <<EOF
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager
spec:
  wildcardDomain: ns.apps.example.com
```

Wait for the deployment to be ready

```
oc wait --for=condition=available apimanager/apimanager --timeout=-1s
```
Check mysql 8 is running

```
oc exec -t dc/system-mysql -- /opt/rh/rh-mysql80/root/usr/libexec/mysqld --version
/opt/rh/rh-mysql80/root/usr/libexec/mysqld  Ver 8.0.21 for Linux on x86_64 (Source distribution)
```