### PR TITLE
Remove usage of system redis messagebus from System

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -430,8 +430,8 @@ When HighAvailability is enabled the following secrets have to be pre-created by
 * [system-database](#system-database) with the `URL` field with the value
   pointing to the desired external database. The database should be configured
   in high-availability mode
-* [system-redis](#system-redis) with the `URL` and `MESSAGE_BUS_URL` fields
-  with the value pointing to the desired external databases. The databases
+* [system-redis](#system-redis) with the `URL` field
+  with the value pointing to the desired external database. The database
   should be configured in high-availability mode
 
 Additionally, when HighAvailability is enabled, if the `externalZyncDatabaseEnabled` field is
@@ -578,13 +578,9 @@ The available configurable secrets are:
 | **Field** | **Description** | **Default value** |
 | --- | --- | --- |
 | URL | System's Redis database URL | Mandatory when `.spec.highAvailability.enabled` is `true`. Otherwise the default value is: `redis://system-redis:6379/1` |
-| MESSAGE_BUS_URL | System's Message Bus Redis database URL | Mandatory when `.spec.highAvailability.enabled` is `true`. Otherwise the default value is: `redis://system-redis:6379/8` |
 | NAMESPACE | Define the namespace to be used by System's Redis Database. The empty value means not namespaced | `""` |
-| MESSAGE_BUS_NAMESPACE | Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced | `""` |
 | SENTINEL_HOSTS | System's Redis sentinel hosts. Used only when Redis sentinel is configured | `""` |
 | SENTINEL_ROLE | System's Redis sentinel role name. Used only when Redis sentinel is configured | `""` |
-| MESSAGE_BUS_SENTINEL_HOSTS | System's Message Bus Redis sentinel hosts. Used only when Redis sentinel is configured | `""` |
-| MESSAGE_BUS_SENTINEL_ROLE | System's Message Bus Redis sentinel role name. Used only when Redis sentinel is configured | `""` |
 
 ### system-seed
 

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -186,10 +186,6 @@ stringData:
   SENTINEL_HOSTS: "redis://sentinel-0.example.com:26379,redis://sentinel-1.example.com:26379, redis://sentinel-2.example.com:26379"
   SENTINEL_ROLE: "master"
   NAMESPACE: ""
-  MESSAGE_BUS_URL: "redis://system-redis-messagebus"
-  MESSAGE_BUS_SENTINEL_HOSTS: "redis://sentinel-0.example.com:26379,redis://sentinel-1.example.com:26379, redis://sentinel-2.example.com:26379"
-  MESSAGE_BUS_SENTINEL_ROLE: "master"
-  MESSAGE_BUS_NAMESPACE: ""
 type: Opaque
 ```
 

--- a/doc/template-user-guide.md
+++ b/doc/template-user-guide.md
@@ -86,9 +86,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp.yml \
 | **RECAPTCHA_PUBLIC_KEY** | reCAPTCHA site key (used in spam protection) | - |
 | **RECAPTCHA_PRIVATE_KEY** | reCAPTCHA secret key (used in spam protection) | - |
 | **SYSTEM_REDIS_URL** | Define the external system-redis to connect to | redis://system-redis:6379/1 |
-| **SYSTEM_MESSAGE_BUS_REDIS_URL** | Define the external system-redis message bus to connect to | see note<sup>[1](#note1)</sup> |
 | **SYSTEM_REDIS_NAMESPACE** | namespace to be used by System's Redis Database | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE** | namespace to be used by System's Message Bus Redis Database | none |
 | **ZYNC_DATABASE_PASSWORD** | Zync Database PostgreSQL Connection Password | random value |
 | **ZYNC_SECRET_KEY_BASE** | Zync application secret key base | random value |
 | **ZYNC_AUTHENTICATION_TOKEN** | Zync application authentication token | random value |
@@ -155,9 +153,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml \
 | **RECAPTCHA_PUBLIC_KEY** | reCAPTCHA site key (used in spam protection) | - |
 | **RECAPTCHA_PRIVATE_KEY** | reCAPTCHA secret key (used in spam protection) | - |
 | **SYSTEM_REDIS_URL** | Define the external system-redis to connect to | redis://system-redis:6379/1 |
-| **SYSTEM_MESSAGE_BUS_REDIS_URL** | Define the external system-redis message bus to connect to | see note<sup>[1](#note1)</sup> |
 | **SYSTEM_REDIS_NAMESPACE** | namespace to be used by System's Redis Database | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE** | namespace to be used by System's Message Bus Redis Database | none |
 | **ZYNC_DATABASE_PASSWORD** | Zync Database PostgreSQL Connection Password | random value |
 | **ZYNC_SECRET_KEY_BASE** | Zync application secret key base | random value |
 | **ZYNC_AUTHENTICATION_TOKEN** | Zync application authentication token | random value |
@@ -232,9 +228,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml \
 | **RECAPTCHA_PUBLIC_KEY** | reCAPTCHA site key (used in spam protection) | - |
 | **RECAPTCHA_PRIVATE_KEY** | reCAPTCHA secret key (used in spam protection) | - |
 | **SYSTEM_REDIS_URL** | Define the external system-redis to connect to | redis://system-redis:6379/1 |
-| **SYSTEM_MESSAGE_BUS_REDIS_URL** | Define the external system-redis message bus to connect to | see note<sup>[1](#note1)</sup> |
 | **SYSTEM_REDIS_NAMESPACE** | namespace to be used by System's Redis Database | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE** | namespace to be used by System's Message Bus Redis Database | none |
 | **ZYNC_DATABASE_PASSWORD** | Zync Database PostgreSQL Connection Password | random value |
 | **ZYNC_SECRET_KEY_BASE** | Zync application secret key base | random value |
 | **ZYNC_AUTHENTICATION_TOKEN** | Zync application authentication token | random value |
@@ -263,7 +257,6 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml \
            --param BACKEND_REDIS_QUEUES_ENDPOINT=redis://backend-redis:6379/1 \
            --param SYSTEM_DATABASE_URL=mysql2://root:password1@system-mysql/system \
            --param SYSTEM_REDIS_URL=redis://system-redis:6379/0 \
-           --param SYSTEM_MESSAGE_BUS_REDIS_URL=redis://system-redis:6379/1 \
            --param WILDCARD_DOMAIN=lvh.me
 ```
 
@@ -271,7 +264,6 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml \
 | Parameter Name | Description | Example |
 | :--- | :---| :--- |
 | **SYSTEM_REDIS_URL** | Define the external system-redis to connect to | redis://system-redis:6379/0 |
-| **SYSTEM_MESSAGE_BUS_REDIS_URL** | Define the external system-redis message bus to connect to | redis://system-redis:6379/1 |
 | **SYSTEM_DATABASE_URL** | Define the external system-mysql to connect to | mysql2://root:password1@system-mysql/system |
 | **BACKEND_REDIS_STORAGE_ENDPOINT** | Define the external backend-redis storage endpoint to connect to | redis://backend-redis:6379/0 |
 | **BACKEND_REDIS_QUEUES_ENDPOINT** | Define the external backend-redis queues endpoint to connect to | redis://backend-redis:6379/1 |
@@ -307,7 +299,6 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml \
 | **RECAPTCHA_PUBLIC_KEY** | reCAPTCHA site key (used in spam protection) | - |
 | **RECAPTCHA_PRIVATE_KEY** | reCAPTCHA secret key (used in spam protection) | - |
 | **SYSTEM_REDIS_NAMESPACE** | namespace to be used by System's Redis Database | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE** | namespace to be used by System's Message Bus Redis Database | none |
 | **ZYNC_DATABASE_PASSWORD** | Zync Database PostgreSQL Connection Password | random value |
 | **ZYNC_SECRET_KEY_BASE** | Zync application secret key base | random value |
 | **ZYNC_AUTHENTICATION_TOKEN** | Zync application authentication token | random value |
@@ -316,8 +307,6 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml \
 | **APICAST_OPENSSL_VERIFY** | OpenSSL peer verification when downloading the configuration | false |
 | **APICAST_RESPONSE_CODES** | Enable logging response codes in APIcast | true |
 | **APICAST_REGISTRY_URL** | The URL to point to APIcast policies registry management | http://apicast-staging:8090/policies |
-| **SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS** | Define the external system message bus sentinel hosts | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE** | Define the external system message bus sentinel role | none |
 | **SYSTEM_REDIS_SENTINEL_HOSTS** | Define the external system redis sentinel hosts | none |
 | **SYSTEM_REDIS_SENTINEL_ROLE** | Define the external system redis sentinel role | none |
 | **BACKEND_REDIS_QUEUE_SENTINEL_HOSTS** | Define the external backend redis queue sentinel hosts | none |
@@ -391,9 +380,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml \
 | **RECAPTCHA_PUBLIC_KEY** | reCAPTCHA site key (used in spam protection) | - |
 | **RECAPTCHA_PRIVATE_KEY** | reCAPTCHA secret key (used in spam protection) | - |
 | **SYSTEM_REDIS_URL** | Define the external system-redis to connect to | redis://system-redis:6379/1 |
-| **SYSTEM_MESSAGE_BUS_REDIS_URL** | Define the external system-redis message bus to connect to | see note<sup>[1](#note1)</sup> |
 | **SYSTEM_REDIS_NAMESPACE** | namespace to be used by System's Redis Database | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE** | namespace to be used by System's Message Bus Redis Database | none |
 | **ZYNC_DATABASE_PASSWORD** | Zync Database PostgreSQL Connection Password | random value |
 | **ZYNC_SECRET_KEY_BASE** | Zync application secret key base | random value |
 | **ZYNC_AUTHENTICATION_TOKEN** | Zync application authentication token | random value |
@@ -461,9 +448,7 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
 | **RECAPTCHA_PUBLIC_KEY** | reCAPTCHA site key (used in spam protection) | - |
 | **RECAPTCHA_PRIVATE_KEY** | reCAPTCHA secret key (used in spam protection) | - |
 | **SYSTEM_REDIS_URL** | Define the external system-redis to connect to | redis://system-redis:6379/1 |
-| **SYSTEM_MESSAGE_BUS_REDIS_URL** | Define the external system-redis message bus to connect to | see note<sup>[1](#note1)</sup> |
 | **SYSTEM_REDIS_NAMESPACE** | namespace to be used by System's Redis Database | none |
-| **SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE** | namespace to be used by System's Message Bus Redis Database | none |
 | **ZYNC_DATABASE_PASSWORD** | Zync Database PostgreSQL Connection Password | random value |
 | **ZYNC_SECRET_KEY_BASE** | Zync application secret key base | random value |
 | **ZYNC_AUTHENTICATION_TOKEN** | Zync application authentication token | random value |
@@ -473,5 +458,3 @@ oc new-app --file pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
 | **APICAST_RESPONSE_CODES** | Enable logging response codes in APIcast | true |
 | **APICAST_REGISTRY_URL** | The URL to point to APIcast policies registry management | http://apicast-staging:8090/policies |
 
-## Notes
-<a name="note1">1</a>: *SYSTEM_MESSAGE_BUS_REDIS_URL* by default is the same value as *SYSTEM_REDIS_URL* but with the logical database incremented by 1 and the result applied mod 16

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -434,10 +434,6 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
     NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     SENTINEL_HOSTS: ""
     SENTINEL_ROLE: ""
@@ -1672,20 +1668,10 @@ objects:
                 secretKeyRef:
                   key: URL
                   name: system-redis
-            - name: MESSAGE_BUS_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_URL
-                  name: system-redis
             - name: REDIS_NAMESPACE
               valueFrom:
                 secretKeyRef:
                   key: NAMESPACE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_NAMESPACE
                   name: system-redis
             - name: REDIS_SENTINEL_HOSTS
               valueFrom:
@@ -1696,16 +1682,6 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: SENTINEL_ROLE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_HOSTS
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_ROLE
                   name: system-redis
             - name: BACKEND_REDIS_URL
               valueFrom:
@@ -1986,20 +1962,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2010,16 +1976,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2316,20 +2272,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2340,16 +2286,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2645,20 +2581,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2669,16 +2595,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3033,20 +2949,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3057,16 +2963,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3208,20 +3104,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3232,16 +3118,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: SLEEP_SECONDS
             value: "1"
@@ -3343,20 +3219,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3367,16 +3233,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
@@ -4356,12 +4212,8 @@ parameters:
   name: SYSTEM_REDIS_URL
   required: true
   value: redis://system-redis:6379/1
-- description: Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16
-  name: SYSTEM_MESSAGE_BUS_REDIS_URL
 - description: Define the namespace to be used by System's Redis Database. The empty value means not namespaced
   name: SYSTEM_REDIS_NAMESPACE
-- description: Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced
-  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -434,10 +434,6 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
     NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     SENTINEL_HOSTS: ""
     SENTINEL_ROLE: ""
@@ -1688,20 +1684,10 @@ objects:
                 secretKeyRef:
                   key: URL
                   name: system-redis
-            - name: MESSAGE_BUS_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_URL
-                  name: system-redis
             - name: REDIS_NAMESPACE
               valueFrom:
                 secretKeyRef:
                   key: NAMESPACE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_NAMESPACE
                   name: system-redis
             - name: REDIS_SENTINEL_HOSTS
               valueFrom:
@@ -1712,16 +1698,6 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: SENTINEL_ROLE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_HOSTS
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_ROLE
                   name: system-redis
             - name: BACKEND_REDIS_URL
               valueFrom:
@@ -1961,20 +1937,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -1985,16 +1951,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2250,20 +2206,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2274,16 +2220,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2538,20 +2474,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2562,16 +2488,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2889,20 +2805,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2913,16 +2819,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3023,20 +2919,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3047,16 +2933,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: SLEEP_SECONDS
             value: "1"
@@ -3161,20 +3037,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3185,16 +3051,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
@@ -4163,12 +4019,8 @@ parameters:
   name: SYSTEM_REDIS_URL
   required: true
   value: redis://system-redis:6379/1
-- description: Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16
-  name: SYSTEM_MESSAGE_BUS_REDIS_URL
 - description: Define the namespace to be used by System's Redis Database. The empty value means not namespaced
   name: SYSTEM_REDIS_NAMESPACE
-- description: Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced
-  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -205,10 +205,6 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS}
-    MESSAGE_BUS_SENTINEL_ROLE: ${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE}
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
     NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     SENTINEL_HOSTS: ${SYSTEM_REDIS_SENTINEL_HOSTS}
     SENTINEL_ROLE: ${SYSTEM_REDIS_SENTINEL_ROLE}
@@ -1208,20 +1204,10 @@ objects:
                 secretKeyRef:
                   key: URL
                   name: system-redis
-            - name: MESSAGE_BUS_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_URL
-                  name: system-redis
             - name: REDIS_NAMESPACE
               valueFrom:
                 secretKeyRef:
                   key: NAMESPACE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_NAMESPACE
                   name: system-redis
             - name: REDIS_SENTINEL_HOSTS
               valueFrom:
@@ -1232,16 +1218,6 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: SENTINEL_ROLE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_HOSTS
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_ROLE
                   name: system-redis
             - name: BACKEND_REDIS_URL
               valueFrom:
@@ -1481,20 +1457,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -1505,16 +1471,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -1776,20 +1732,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -1800,16 +1746,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2070,20 +2006,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2094,16 +2020,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2427,20 +2343,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2451,16 +2357,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2567,20 +2463,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2591,16 +2477,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: SLEEP_SECONDS
             value: "1"
@@ -2705,20 +2581,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2729,16 +2595,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
@@ -3835,12 +3691,8 @@ parameters:
 - description: Define the external system-redis to connect to
   name: SYSTEM_REDIS_URL
   required: true
-- description: Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16
-  name: SYSTEM_MESSAGE_BUS_REDIS_URL
 - description: Define the namespace to be used by System's Redis Database. The empty value means not namespaced
   name: SYSTEM_REDIS_NAMESPACE
-- description: Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced
-  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'
@@ -3882,10 +3734,6 @@ parameters:
 - description: Define the external system-mysql to connect to
   name: SYSTEM_DATABASE_URL
   required: true
-- description: Define the external system message bus sentinel hosts
-  name: SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-- description: Define the external system message bus sentinel role
-  name: SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE
 - description: Define the external system redis sentinel hosts
   name: SYSTEM_REDIS_SENTINEL_HOSTS
 - description: Define the external system redis sentinel role

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -440,10 +440,6 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
     NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     SENTINEL_HOSTS: ""
     SENTINEL_ROLE: ""
@@ -1680,20 +1676,10 @@ objects:
                 secretKeyRef:
                   key: URL
                   name: system-redis
-            - name: MESSAGE_BUS_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_URL
-                  name: system-redis
             - name: REDIS_NAMESPACE
               valueFrom:
                 secretKeyRef:
                   key: NAMESPACE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_NAMESPACE
                   name: system-redis
             - name: REDIS_SENTINEL_HOSTS
               valueFrom:
@@ -1704,16 +1690,6 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: SENTINEL_ROLE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_HOSTS
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_ROLE
                   name: system-redis
             - name: BACKEND_REDIS_URL
               valueFrom:
@@ -1953,20 +1929,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -1977,16 +1943,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2248,20 +2204,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2272,16 +2218,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2542,20 +2478,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2566,16 +2492,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2899,20 +2815,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2923,16 +2829,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3039,20 +2935,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3063,16 +2949,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: SLEEP_SECONDS
             value: "1"
@@ -3177,20 +3053,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3201,16 +3067,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
@@ -4209,12 +4065,8 @@ parameters:
   name: SYSTEM_REDIS_URL
   required: true
   value: redis://system-redis:6379/1
-- description: Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16
-  name: SYSTEM_MESSAGE_BUS_REDIS_URL
 - description: Define the namespace to be used by System's Redis Database. The empty value means not namespaced
   name: SYSTEM_REDIS_NAMESPACE
-- description: Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced
-  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -440,10 +440,6 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
     NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     SENTINEL_HOSTS: ""
     SENTINEL_ROLE: ""
@@ -1713,20 +1709,10 @@ objects:
                 secretKeyRef:
                   key: URL
                   name: system-redis
-            - name: MESSAGE_BUS_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_URL
-                  name: system-redis
             - name: REDIS_NAMESPACE
               valueFrom:
                 secretKeyRef:
                   key: NAMESPACE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_NAMESPACE
                   name: system-redis
             - name: REDIS_SENTINEL_HOSTS
               valueFrom:
@@ -1737,16 +1723,6 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: SENTINEL_ROLE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_HOSTS
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_ROLE
                   name: system-redis
             - name: BACKEND_REDIS_URL
               valueFrom:
@@ -2027,20 +2003,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2051,16 +2017,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2363,20 +2319,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2387,16 +2333,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2698,20 +2634,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2722,16 +2648,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3092,20 +3008,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3116,16 +3022,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3273,20 +3169,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3297,16 +3183,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: SLEEP_SECONDS
             value: "1"
@@ -3408,20 +3284,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3432,16 +3298,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
@@ -4457,12 +4313,8 @@ parameters:
   name: SYSTEM_REDIS_URL
   required: true
   value: redis://system-redis:6379/1
-- description: Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16
-  name: SYSTEM_MESSAGE_BUS_REDIS_URL
 - description: Define the namespace to be used by System's Redis Database. The empty value means not namespaced
   name: SYSTEM_REDIS_NAMESPACE
-- description: Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced
-  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -440,10 +440,6 @@ objects:
       threescale_component: system
     name: system-redis
   stringData:
-    MESSAGE_BUS_NAMESPACE: ${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}
-    MESSAGE_BUS_SENTINEL_HOSTS: ""
-    MESSAGE_BUS_SENTINEL_ROLE: ""
-    MESSAGE_BUS_URL: ${SYSTEM_MESSAGE_BUS_REDIS_URL}
     NAMESPACE: ${SYSTEM_REDIS_NAMESPACE}
     SENTINEL_HOSTS: ""
     SENTINEL_ROLE: ""
@@ -1729,20 +1725,10 @@ objects:
                 secretKeyRef:
                   key: URL
                   name: system-redis
-            - name: MESSAGE_BUS_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_URL
-                  name: system-redis
             - name: REDIS_NAMESPACE
               valueFrom:
                 secretKeyRef:
                   key: NAMESPACE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_NAMESPACE
                   name: system-redis
             - name: REDIS_SENTINEL_HOSTS
               valueFrom:
@@ -1753,16 +1739,6 @@ objects:
               valueFrom:
                 secretKeyRef:
                   key: SENTINEL_ROLE
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_HOSTS
-                  name: system-redis
-            - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-              valueFrom:
-                secretKeyRef:
-                  key: MESSAGE_BUS_SENTINEL_ROLE
                   name: system-redis
             - name: BACKEND_REDIS_URL
               valueFrom:
@@ -2002,20 +1978,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2026,16 +1992,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2297,20 +2253,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2321,16 +2267,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2591,20 +2527,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2615,16 +2541,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -2948,20 +2864,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -2972,16 +2878,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: BACKEND_REDIS_URL
             valueFrom:
@@ -3088,20 +2984,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3112,16 +2998,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           - name: SLEEP_SECONDS
             value: "1"
@@ -3226,20 +3102,10 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-redis
-          - name: MESSAGE_BUS_REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_URL
-                name: system-redis
           - name: REDIS_NAMESPACE
             valueFrom:
               secretKeyRef:
                 key: NAMESPACE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_NAMESPACE
                 name: system-redis
           - name: REDIS_SENTINEL_HOSTS
             valueFrom:
@@ -3250,16 +3116,6 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: SENTINEL_ROLE
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_HOSTS
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_HOSTS
-                name: system-redis
-          - name: MESSAGE_BUS_REDIS_SENTINEL_ROLE
-            valueFrom:
-              secretKeyRef:
-                key: MESSAGE_BUS_SENTINEL_ROLE
                 name: system-redis
           image: amp-system:latest
           imagePullPolicy: IfNotPresent
@@ -4264,12 +4120,8 @@ parameters:
   name: SYSTEM_REDIS_URL
   required: true
   value: redis://system-redis:6379/1
-- description: Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16
-  name: SYSTEM_MESSAGE_BUS_REDIS_URL
 - description: Define the namespace to be used by System's Redis Database. The empty value means not namespaced
   name: SYSTEM_REDIS_NAMESPACE
-- description: Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced
-  name: SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE
 - description: Password for the Zync Database PostgreSQL connection user.
   displayName: Zync Database PostgreSQL Connection Password
   from: '[a-zA-Z0-9]{16}'

--- a/pkg/3scale/amp/component/highavailability.go
+++ b/pkg/3scale/amp/component/highavailability.go
@@ -69,14 +69,10 @@ func (ha *HighAvailability) SystemRedisSecret() *v1.Secret {
 			Labels: ha.Options.SystemRedisLabels,
 		},
 		StringData: map[string]string{
-			SystemSecretSystemRedisURLFieldName:                ha.Options.SystemRedisURL,
-			SystemSecretSystemRedisSentinelHosts:               ha.Options.SystemRedisSentinelsHosts,
-			SystemSecretSystemRedisSentinelRole:                ha.Options.SystemRedisSentinelsRole,
-			SystemSecretSystemRedisMessageBusRedisURLFieldName: ha.Options.SystemMessageBusRedisURL,
-			SystemSecretSystemRedisMessageBusSentinelHosts:     ha.Options.SystemMessageBusRedisSentinelsHosts,
-			SystemSecretSystemRedisMessageBusSentinelRole:      ha.Options.SystemMessageBusRedisSentinelsRole,
-			SystemSecretSystemRedisNamespace:                   ha.Options.SystemRedisNamespace,
-			SystemSecretSystemRedisMessageBusRedisNamespace:    ha.Options.SystemMessageBusRedisNamespace,
+			SystemSecretSystemRedisURLFieldName:  ha.Options.SystemRedisURL,
+			SystemSecretSystemRedisSentinelHosts: ha.Options.SystemRedisSentinelsHosts,
+			SystemSecretSystemRedisSentinelRole:  ha.Options.SystemRedisSentinelsRole,
+			SystemSecretSystemRedisNamespace:     ha.Options.SystemRedisNamespace,
 		},
 		Type: v1.SecretTypeOpaque,
 	}

--- a/pkg/3scale/amp/component/highavailability_options.go
+++ b/pkg/3scale/amp/component/highavailability_options.go
@@ -3,21 +3,17 @@ package component
 import "github.com/go-playground/validator/v10"
 
 type HighAvailabilityOptions struct {
-	BackendRedisQueuesEndpoint          string `validate:"required"`
-	BackendRedisQueuesSentinelHosts     string
-	BackendRedisQueuesSentinelRole      string
-	BackendRedisStorageEndpoint         string `validate:"required"`
-	BackendRedisStorageSentinelHosts    string
-	BackendRedisStorageSentinelRole     string
-	SystemDatabaseURL                   string `validate:"required"`
-	SystemRedisURL                      string `validate:"required"`
-	SystemRedisSentinelsHosts           string
-	SystemRedisSentinelsRole            string
-	SystemRedisNamespace                string
-	SystemMessageBusRedisURL            string `validate:"required"`
-	SystemMessageBusRedisSentinelsHosts string
-	SystemMessageBusRedisSentinelsRole  string
-	SystemMessageBusRedisNamespace      string
+	BackendRedisQueuesEndpoint       string `validate:"required"`
+	BackendRedisQueuesSentinelHosts  string
+	BackendRedisQueuesSentinelRole   string
+	BackendRedisStorageEndpoint      string `validate:"required"`
+	BackendRedisStorageSentinelHosts string
+	BackendRedisStorageSentinelRole  string
+	SystemDatabaseURL                string `validate:"required"`
+	SystemRedisURL                   string `validate:"required"`
+	SystemRedisSentinelsHosts        string
+	SystemRedisSentinelsRole         string
+	SystemRedisNamespace             string
 
 	BackendRedisLabels   map[string]string `validate:"required"`
 	SystemRedisLabels    map[string]string `validate:"required"`

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -633,14 +633,10 @@ func (redis *Redis) SystemRedisSecret() *v1.Secret {
 			Labels: redis.Options.SystemCommonLabels,
 		},
 		StringData: map[string]string{
-			SystemSecretSystemRedisURLFieldName:                redis.Options.SystemRedisURL,
-			SystemSecretSystemRedisSentinelHosts:               redis.Options.SystemRedisSentinelsHosts,
-			SystemSecretSystemRedisSentinelRole:                redis.Options.SystemRedisSentinelsRole,
-			SystemSecretSystemRedisMessageBusRedisURLFieldName: redis.Options.SystemRedisMessageBusURL,
-			SystemSecretSystemRedisMessageBusSentinelHosts:     redis.Options.SystemMessageBusRedisSentinelsHosts,
-			SystemSecretSystemRedisMessageBusSentinelRole:      redis.Options.SystemMessageBusRedisSentinelsRole,
-			SystemSecretSystemRedisNamespace:                   redis.Options.SystemRedisNamespace,
-			SystemSecretSystemRedisMessageBusRedisNamespace:    redis.Options.SystemMessageBusRedisNamespace,
+			SystemSecretSystemRedisURLFieldName:  redis.Options.SystemRedisURL,
+			SystemSecretSystemRedisSentinelHosts: redis.Options.SystemRedisSentinelsHosts,
+			SystemSecretSystemRedisSentinelRole:  redis.Options.SystemRedisSentinelsRole,
+			SystemSecretSystemRedisNamespace:     redis.Options.SystemRedisNamespace,
 		},
 		Type: v1.SecretTypeOpaque,
 	}

--- a/pkg/3scale/amp/component/redis_options.go
+++ b/pkg/3scale/amp/component/redis_options.go
@@ -31,20 +31,16 @@ type RedisOptions struct {
 	BackendRedisPodTemplateLabels map[string]string `validate:"required"`
 
 	// secrets
-	BackendStorageURL                   string `validate:"required"`
-	BackendQueuesURL                    string `validate:"required"`
-	BackendRedisQueuesSentinelHosts     string
-	BackendRedisQueuesSentinelRole      string
-	BackendRedisStorageSentinelHosts    string
-	BackendRedisStorageSentinelRole     string
-	SystemRedisURL                      string `validate:"required"`
-	SystemRedisMessageBusURL            string
-	SystemRedisSentinelsHosts           string
-	SystemRedisSentinelsRole            string
-	SystemRedisNamespace                string
-	SystemMessageBusRedisSentinelsHosts string
-	SystemMessageBusRedisSentinelsRole  string
-	SystemMessageBusRedisNamespace      string
+	BackendStorageURL                string `validate:"required"`
+	BackendQueuesURL                 string `validate:"required"`
+	BackendRedisQueuesSentinelHosts  string
+	BackendRedisQueuesSentinelRole   string
+	BackendRedisStorageSentinelHosts string
+	BackendRedisStorageSentinelRole  string
+	SystemRedisURL                   string `validate:"required"`
+	SystemRedisSentinelsHosts        string
+	SystemRedisSentinelsRole         string
+	SystemRedisNamespace             string
 }
 
 func NewRedisOptions() *RedisOptions {
@@ -94,10 +90,6 @@ func DefaultSystemRedisURL() string {
 	return "redis://system-redis:6379/1"
 }
 
-func DefaultSystemRedisMessageBusURL() string {
-	return ""
-}
-
 func DefaultSystemRedisSentinelHosts() string {
 	return ""
 }
@@ -106,19 +98,7 @@ func DefaultSystemRedisSentinelRole() string {
 	return ""
 }
 
-func DefaultSystemMessageBusRedisSentinelHosts() string {
-	return ""
-}
-
-func DefaultSystemMessageBusRedisSentinelRole() string {
-	return ""
-}
-
 func DefaultSystemRedisNamespace() string {
-	return ""
-}
-
-func DefaultSystemMessageBusRedisNamespace() string {
 	return ""
 }
 

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -41,15 +41,11 @@ const (
 )
 
 const (
-	SystemSecretSystemRedisSecretName                  = "system-redis"
-	SystemSecretSystemRedisURLFieldName                = "URL"
-	SystemSecretSystemRedisMessageBusRedisURLFieldName = "MESSAGE_BUS_URL"
-	SystemSecretSystemRedisNamespace                   = "NAMESPACE"
-	SystemSecretSystemRedisMessageBusRedisNamespace    = "MESSAGE_BUS_NAMESPACE"
-	SystemSecretSystemRedisSentinelHosts               = "SENTINEL_HOSTS"
-	SystemSecretSystemRedisSentinelRole                = "SENTINEL_ROLE"
-	SystemSecretSystemRedisMessageBusSentinelHosts     = "MESSAGE_BUS_SENTINEL_HOSTS"
-	SystemSecretSystemRedisMessageBusSentinelRole      = "MESSAGE_BUS_SENTINEL_ROLE"
+	SystemSecretSystemRedisSecretName    = "system-redis"
+	SystemSecretSystemRedisURLFieldName  = "URL"
+	SystemSecretSystemRedisNamespace     = "NAMESPACE"
+	SystemSecretSystemRedisSentinelHosts = "SENTINEL_HOSTS"
+	SystemSecretSystemRedisSentinelRole  = "SENTINEL_ROLE"
 )
 
 const (
@@ -181,13 +177,9 @@ func (system *System) SystemRedisEnvVars() []v1.EnvVar {
 
 	result = append(result,
 		helper.EnvVarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
-		helper.EnvVarFromSecret("MESSAGE_BUS_REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisURLFieldName),
 		helper.EnvVarFromSecret("REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisNamespace),
-		helper.EnvVarFromSecret("MESSAGE_BUS_REDIS_NAMESPACE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusRedisNamespace),
 		helper.EnvVarFromSecret("REDIS_SENTINEL_HOSTS", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisSentinelHosts),
 		helper.EnvVarFromSecret("REDIS_SENTINEL_ROLE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisSentinelRole),
-		helper.EnvVarFromSecret("MESSAGE_BUS_REDIS_SENTINEL_HOSTS", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusSentinelHosts),
-		helper.EnvVarFromSecret("MESSAGE_BUS_REDIS_SENTINEL_ROLE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisMessageBusSentinelRole),
 	)
 
 	return result

--- a/pkg/3scale/amp/operator/highavailability_options_provider.go
+++ b/pkg/3scale/amp/operator/highavailability_options_provider.go
@@ -129,11 +129,6 @@ func (h *HighAvailabilityOptionsProvider) setSystemRedisOptions() error {
 			component.SystemSecretSystemRedisSecretName,
 			component.SystemSecretSystemRedisURLFieldName,
 		},
-		{
-			&h.options.SystemMessageBusRedisURL,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusRedisURLFieldName,
-		},
 	}
 
 	for _, option := range cases {
@@ -164,28 +159,10 @@ func (h *HighAvailabilityOptionsProvider) setSystemRedisOptions() error {
 			component.DefaultSystemRedisSentinelRole(),
 		},
 		{
-			&h.options.SystemMessageBusRedisSentinelsHosts,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusSentinelHosts,
-			component.DefaultSystemMessageBusRedisSentinelHosts(),
-		},
-		{
-			&h.options.SystemMessageBusRedisSentinelsRole,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusSentinelRole,
-			component.DefaultSystemMessageBusRedisSentinelRole(),
-		},
-		{
 			&h.options.SystemRedisNamespace,
 			component.SystemSecretSystemRedisSecretName,
 			component.SystemSecretSystemRedisNamespace,
 			component.DefaultSystemRedisNamespace(),
-		},
-		{
-			&h.options.SystemMessageBusRedisNamespace,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusRedisNamespace,
-			component.DefaultSystemMessageBusRedisNamespace(),
 		},
 	}
 

--- a/pkg/3scale/amp/operator/highavailability_options_provider_test.go
+++ b/pkg/3scale/amp/operator/highavailability_options_provider_test.go
@@ -16,31 +16,20 @@ import (
 )
 
 const (
-	backendStorageURL   = "redis://storage.redis.example.com"
-	backendQueueURL     = "redis://queue.redis.example.com"
-	systemRedisURL      = "redis://system.redis.example.com"
-	systemMessageBusURL = "redis://messagebus.redis.example.com"
-	systemDatabaseURL   = "mysql://mysql.example.com"
+	backendStorageURL = "redis://storage.redis.example.com"
+	backendQueueURL   = "redis://queue.redis.example.com"
+	systemRedisURL    = "redis://system.redis.example.com"
+	systemDatabaseURL = "mysql://mysql.example.com"
 )
 
 func getSystemRedisSecretMissingRedisURL() *v1.Secret {
-	data := map[string]string{
-		component.SystemSecretSystemRedisMessageBusRedisURLFieldName: systemMessageBusURL,
-	}
-	return GetTestSecret(namespace, component.SystemSecretSystemRedisSecretName, data)
-}
-
-func getSystemRedisSecretMissingMessageBusRedisURL() *v1.Secret {
-	data := map[string]string{
-		component.SystemSecretSystemRedisURLFieldName: systemRedisURL,
-	}
+	data := map[string]string{}
 	return GetTestSecret(namespace, component.SystemSecretSystemRedisSecretName, data)
 }
 
 func getSystemRedisSecretForHighAvailabilityTest() *v1.Secret {
 	data := map[string]string{
-		component.SystemSecretSystemRedisURLFieldName:                systemRedisURL,
-		component.SystemSecretSystemRedisMessageBusRedisURLFieldName: systemMessageBusURL,
+		component.SystemSecretSystemRedisURLFieldName: systemRedisURL,
 	}
 	return GetTestSecret(namespace, component.SystemSecretSystemRedisSecretName, data)
 }
@@ -96,22 +85,19 @@ func TestGetHighAvailabilityOptionsProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedOptions := &component.HighAvailabilityOptions{
-		BackendRedisLabels:                  testBackendCommonLabels(),
-		SystemRedisLabels:                   testSystemCommonLabels(),
-		SystemDatabaseLabels:                testSystemCommonLabels(),
-		BackendRedisQueuesEndpoint:          backendQueueURL,
-		BackendRedisQueuesSentinelHosts:     "",
-		BackendRedisQueuesSentinelRole:      "",
-		BackendRedisStorageEndpoint:         backendStorageURL,
-		BackendRedisStorageSentinelHosts:    "",
-		BackendRedisStorageSentinelRole:     "",
-		SystemRedisURL:                      systemRedisURL,
-		SystemRedisSentinelsHosts:           "",
-		SystemRedisSentinelsRole:            "",
-		SystemMessageBusRedisURL:            systemMessageBusURL,
-		SystemMessageBusRedisSentinelsHosts: "",
-		SystemMessageBusRedisSentinelsRole:  "",
-		SystemDatabaseURL:                   systemDatabaseURL,
+		BackendRedisLabels:               testBackendCommonLabels(),
+		SystemRedisLabels:                testSystemCommonLabels(),
+		SystemDatabaseLabels:             testSystemCommonLabels(),
+		BackendRedisQueuesEndpoint:       backendQueueURL,
+		BackendRedisQueuesSentinelHosts:  "",
+		BackendRedisQueuesSentinelRole:   "",
+		BackendRedisStorageEndpoint:      backendStorageURL,
+		BackendRedisStorageSentinelHosts: "",
+		BackendRedisStorageSentinelRole:  "",
+		SystemRedisURL:                   systemRedisURL,
+		SystemRedisSentinelsHosts:        "",
+		SystemRedisSentinelsRole:         "",
+		SystemDatabaseURL:                systemDatabaseURL,
 	}
 
 	if !reflect.DeepEqual(expectedOptions, opts) {
@@ -168,13 +154,6 @@ func TestGetHighAvailabilityOptionsInvalid(t *testing.T) {
 			getSystemRedisSecretMissingRedisURL(),
 			getSystemDatabaseSecret(),
 			component.SystemSecretSystemRedisURLFieldName,
-		},
-		{
-			"SystemRedisMessagebusURLMissing",
-			getBackendRedisSecret(),
-			getSystemRedisSecretMissingMessageBusRedisURL(),
-			getSystemDatabaseSecret(),
-			component.SystemSecretSystemRedisMessageBusRedisURLFieldName,
 		},
 		{
 			"SystemDatabaseURLMissing",

--- a/pkg/3scale/amp/operator/redis_options_provider.go
+++ b/pkg/3scale/amp/operator/redis_options_provider.go
@@ -125,12 +125,6 @@ func (r *RedisOptionsProvider) setSecretBasedOptions() error {
 			component.DefaultSystemRedisURL(),
 		},
 		{
-			&r.options.SystemRedisMessageBusURL,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusRedisURLFieldName,
-			component.DefaultSystemRedisMessageBusURL(),
-		},
-		{
 			&r.options.SystemRedisSentinelsHosts,
 			component.SystemSecretSystemRedisSecretName,
 			component.SystemSecretSystemRedisSentinelHosts,
@@ -143,28 +137,10 @@ func (r *RedisOptionsProvider) setSecretBasedOptions() error {
 			component.DefaultSystemRedisSentinelRole(),
 		},
 		{
-			&r.options.SystemMessageBusRedisSentinelsHosts,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusSentinelHosts,
-			component.DefaultSystemMessageBusRedisSentinelHosts(),
-		},
-		{
-			&r.options.SystemMessageBusRedisSentinelsRole,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusSentinelRole,
-			component.DefaultSystemMessageBusRedisSentinelRole(),
-		},
-		{
 			&r.options.SystemRedisNamespace,
 			component.SystemSecretSystemRedisSecretName,
 			component.SystemSecretSystemRedisNamespace,
 			component.DefaultSystemRedisNamespace(),
-		},
-		{
-			&r.options.SystemMessageBusRedisNamespace,
-			component.SystemSecretSystemRedisSecretName,
-			component.SystemSecretSystemRedisMessageBusRedisNamespace,
-			component.DefaultSystemMessageBusRedisNamespace(),
 		},
 	}
 

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -131,14 +131,10 @@ func testBackendRedisSecret() *v1.Secret {
 
 func testSystemRedisSecret() *v1.Secret {
 	data := map[string]string{
-		component.SystemSecretSystemRedisNamespace:                   "systemRedis",
-		component.SystemSecretSystemRedisURLFieldName:                "redis://system1:6379",
-		component.SystemSecretSystemRedisSentinelHosts:               "someHosts1",
-		component.SystemSecretSystemRedisSentinelRole:                "someRole1",
-		component.SystemSecretSystemRedisMessageBusRedisNamespace:    "mbus",
-		component.SystemSecretSystemRedisMessageBusSentinelHosts:     "someHosts2",
-		component.SystemSecretSystemRedisMessageBusSentinelRole:      "someRole2",
-		component.SystemSecretSystemRedisMessageBusRedisURLFieldName: "redis://system2:6379",
+		component.SystemSecretSystemRedisNamespace:     "systemRedis",
+		component.SystemSecretSystemRedisURLFieldName:  "redis://system1:6379",
+		component.SystemSecretSystemRedisSentinelHosts: "someHosts1",
+		component.SystemSecretSystemRedisSentinelRole:  "someRole1",
 	}
 	return GetTestSecret(namespace, component.SystemSecretSystemRedisSecretName, data)
 }
@@ -167,12 +163,8 @@ func defaultRedisOptions() *component.RedisOptions {
 		BackendRedisQueuesSentinelHosts:           component.DefaultBackendQueuesSentinelHosts(),
 		BackendRedisQueuesSentinelRole:            component.DefaultBackendQueuesSentinelRole(),
 		SystemRedisURL:                            component.DefaultSystemRedisURL(),
-		SystemRedisMessageBusURL:                  component.DefaultSystemRedisMessageBusURL(),
 		SystemRedisSentinelsHosts:                 component.DefaultSystemRedisSentinelHosts(),
 		SystemRedisSentinelsRole:                  component.DefaultSystemRedisSentinelRole(),
-		SystemMessageBusRedisSentinelsHosts:       component.DefaultSystemMessageBusRedisSentinelHosts(),
-		SystemMessageBusRedisSentinelsRole:        component.DefaultSystemMessageBusRedisSentinelRole(),
-		SystemMessageBusRedisNamespace:            component.DefaultSystemMessageBusRedisNamespace(),
 		SystemRedisNamespace:                      component.DefaultSystemRedisNamespace(),
 	}
 }
@@ -391,11 +383,7 @@ func TestGetRedisOptionsProvider(t *testing.T) {
 				opts.SystemRedisURL = "redis://system1:6379"
 				opts.SystemRedisSentinelsHosts = "someHosts1"
 				opts.SystemRedisSentinelsRole = "someRole1"
-				opts.SystemRedisMessageBusURL = "redis://system2:6379"
-				opts.SystemMessageBusRedisSentinelsHosts = "someHosts2"
-				opts.SystemMessageBusRedisSentinelsRole = "someRole2"
 				opts.SystemRedisNamespace = "systemRedis"
-				opts.SystemMessageBusRedisNamespace = "mbus"
 				return opts
 			},
 		},

--- a/pkg/3scale/amp/template/adapters/ha.go
+++ b/pkg/3scale/amp/template/adapters/ha.go
@@ -125,11 +125,8 @@ func (h *HAAdapter) updateDatabasesURLS(c *component.HighAvailability, objects [
 			switch secret.Name {
 			case "system-redis":
 				secret.StringData["URL"] = c.Options.SystemRedisURL
-				secret.StringData["MESSAGE_BUS_URL"] = c.Options.SystemMessageBusRedisURL
 				secret.StringData[component.SystemSecretSystemRedisSentinelHosts] = c.Options.SystemRedisSentinelsHosts
 				secret.StringData[component.SystemSecretSystemRedisSentinelRole] = c.Options.SystemRedisSentinelsRole
-				secret.StringData[component.SystemSecretSystemRedisMessageBusSentinelHosts] = c.Options.SystemMessageBusRedisSentinelsHosts
-				secret.StringData[component.SystemSecretSystemRedisMessageBusSentinelRole] = c.Options.SystemMessageBusRedisSentinelsRole
 			case "backend-redis":
 				secret.StringData["REDIS_STORAGE_URL"] = c.Options.BackendRedisStorageEndpoint
 				secret.StringData["REDIS_QUEUES_URL"] = c.Options.BackendRedisQueuesEndpoint
@@ -165,8 +162,7 @@ func (h *HAAdapter) deleteDBRelatedParameters(template *templatev1.Template) {
 
 func (h *HAAdapter) unsetSystemRedisDBDefaultValues(template *templatev1.Template) {
 	dbParamsToUpdate := map[string]bool{
-		"SYSTEM_REDIS_URL":             true,
-		"SYSTEM_MESSAGE_BUS_REDIS_URL": true,
+		"SYSTEM_REDIS_URL": true,
 	}
 
 	for paramIdx := range template.Parameters {
@@ -197,9 +193,6 @@ func (h *HAAdapter) options() (*component.HighAvailabilityOptions, error) {
 	o.SystemRedisURL = "${SYSTEM_REDIS_URL}"
 	o.SystemRedisSentinelsHosts = "${SYSTEM_REDIS_SENTINEL_HOSTS}"
 	o.SystemRedisSentinelsRole = "${SYSTEM_REDIS_SENTINEL_ROLE}"
-	o.SystemMessageBusRedisSentinelsHosts = "${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS}"
-	o.SystemMessageBusRedisSentinelsRole = "${SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE}"
-	o.SystemMessageBusRedisURL = "${SYSTEM_MESSAGE_BUS_REDIS_URL}"
 	o.SystemRedisLabels = h.systemRedisLabels()
 
 	err := o.Validate()
@@ -223,14 +216,7 @@ func (h *HAAdapter) parameters() []templatev1.Parameter {
 			Description: "Define the external system-mysql to connect to",
 			Required:    true,
 		},
-		templatev1.Parameter{
-			Name:        "SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_HOSTS",
-			Description: "Define the external system message bus sentinel hosts",
-		},
-		templatev1.Parameter{
-			Name:        "SYSTEM_MESSAGE_BUS_REDIS_SENTINEL_ROLE",
-			Description: "Define the external system message bus sentinel role",
-		},
+
 		templatev1.Parameter{
 			Name:        "SYSTEM_REDIS_SENTINEL_HOSTS",
 			Description: "Define the external system redis sentinel hosts",

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -106,10 +106,6 @@ func (r *RedisAdapter) options() (*component.RedisOptions, error) {
 	ro.SystemRedisSentinelsHosts = component.DefaultSystemRedisSentinelHosts()
 	ro.SystemRedisSentinelsRole = component.DefaultSystemRedisSentinelRole()
 	ro.SystemRedisNamespace = "${SYSTEM_REDIS_NAMESPACE}"
-	ro.SystemRedisMessageBusURL = "${SYSTEM_MESSAGE_BUS_REDIS_URL}"
-	ro.SystemMessageBusRedisSentinelsHosts = component.DefaultSystemMessageBusRedisSentinelHosts()
-	ro.SystemMessageBusRedisSentinelsRole = component.DefaultSystemMessageBusRedisSentinelRole()
-	ro.SystemMessageBusRedisNamespace = "${SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE}"
 
 	ro.BackendStorageURL = component.DefaultBackendRedisStorageURL()
 	ro.BackendQueuesURL = component.DefaultBackendRedisQueuesURL()

--- a/pkg/3scale/amp/template/adapters/system.go
+++ b/pkg/3scale/amp/template/adapters/system.go
@@ -116,16 +116,8 @@ func (s *System) Parameters() []templatev1.Parameter {
 			Value:       "redis://system-redis:6379/1",
 		},
 		templatev1.Parameter{
-			Name:        "SYSTEM_MESSAGE_BUS_REDIS_URL",
-			Description: "Define the external system-redis message bus to connect to. By default the same value as SYSTEM_REDIS_URL but with the logical database incremented by 1 and the result applied mod 16",
-		},
-		templatev1.Parameter{
 			Name:        "SYSTEM_REDIS_NAMESPACE",
 			Description: "Define the namespace to be used by System's Redis Database. The empty value means not namespaced",
-		},
-		templatev1.Parameter{
-			Name:        "SYSTEM_MESSAGE_BUS_REDIS_NAMESPACE",
-			Description: "Define the namespace to be used by System's Message Bus Redis Database. The empty value means not namespaced",
 		},
 	}
 }


### PR DESCRIPTION
This PR removes the usage of System's Redis message bus database from System DCs (DeploymentConfigs).

* Removes all redis message-bus related environment variable references from the following DCs:
  * system-app
  * system-sidekiq
  * system-sphinx
* In case databases deployment mode is internal it removes message-bus related attributes from the system-redis K8s Secret. In case databases deployment mode is external then this attributes remain unchanged.
* Implements an upgrade procedure that performs the previously explained changes

This is done for both operator and templates.

Templates will need an upgrade procedure for this change.