### PR TITLE
Fix operator metrics servicemonitor

### DIFF
--- a/bundle/manifests/threescale-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/threescale-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,8 +6,12 @@ metadata:
   name: threescale-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
-  - path: /metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
     port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -11,6 +10,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/doc/monitoring-stack-deployment/README.md
+++ b/doc/monitoring-stack-deployment/README.md
@@ -34,6 +34,12 @@ oc apply -f prometheus.yaml
 oc expose service prometheus-operated --hostname prometheus.NAMESPACE_NAME.apps.CLUSTER_DOMAIN
 ```
 
+1. Grant operator metric reader permission (clusterrole `threescale-operator-metrics-reader`)
+
+```
+oc create clusterrolebinding prometheus-threescale-operator-metrics-reader --clusterrole=threescale-operator-metrics-reader --serviceaccount=NAMESPACE_NAME:prometheus-k8s
+```
+
 1. Deploy grafana datasource
 
 ```

--- a/doc/operator-monitoring-resources.md
+++ b/doc/operator-monitoring-resources.md
@@ -130,7 +130,10 @@ For instance, label the namespace where 3scale in installed with `MYLABELKEY=MYL
           - MYLABELVALUE
 ```
 
-Do not forget to provide required RBAC permissions. Check operator [doc](https://github.com/coreos/prometheus-operator/blob/v0.32.0/Documentation/api.md#prometheusspec) regarding this issue.
+**NOTE**: Prometheus instances may require extra permissions defined in the ClusterRole `threescale-operator-metrics-reader` to scrape 3scale operator metrics. 
+This clusterrole is created when the 3scale operator is deployed.
+
+Check out operator [spec doc](https://github.com/coreos/prometheus-operator/blob/v0.32.0/Documentation/api.md#prometheusspec) for all available options.
 
 **Kubernetes metrics: kube-state-metrics**
 


### PR DESCRIPTION
kube-rbac-proxy is used by default on operator-sdk to protect operator metrics path, in case you don't want anyone in the cluster but only k8s authenticated resources can access to them.

Currently, the service monitor is incorrectly configured and prometheus cannot scrape metrics. The service monitor needs to be fixed to specify:
* use HTTPS scheme 
* Use bearer token for authenticated calls (or kube-rbac-proxy will return 403 Forbidden)

Besides, the documentation has been enhanced to ensure prometheus instances have required RBAC permission to scrape operator metrics. 

Related issues:
* https://github.com/operator-framework/operator-sdk/issues/4764


**Warning**: with this fix, the prometheus instance from the openshift user-workload-monitoring stack does not scrape metrics from the operator. Apparently, a security policy configured for the user workload prometheus instance prevents from reading bearer token from  local file system. Thus, the service monitor is being discarded. The error shown in the prometheus operator:
```
level=warn ts=2021-11-21T14:41:30.167698607Z caller=operator.go:1753 component=prometheusoperator msg="skipping servicemonitor" error="it accesses file system via bearer token file which Prometheus specification prohibits" servicemonitor=eguzki/threescale-operator-controller-manager-metrics-monitor namespace=openshift-user-workload-monitoring prometheus=user-workload
```

