### PR TITLE
[WIP] THREESCALE-8042: Add DEPLOY_INFO_RELEASE env var to System

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -1543,6 +1543,8 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
+            - name: DEPLOY_INFO_RELEASE
+              value: master
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1857,6 +1859,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2187,6 +2191,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2516,6 +2522,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2904,6 +2912,8 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -1559,6 +1559,8 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
+            - name: DEPLOY_INFO_RELEASE
+              value: master
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1832,6 +1834,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2121,6 +2125,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2409,6 +2415,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2760,6 +2768,8 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -1079,6 +1079,8 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
+            - name: DEPLOY_INFO_RELEASE
+              value: master
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1352,6 +1354,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -1647,6 +1651,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -1941,6 +1947,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2298,6 +2306,8 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -1551,6 +1551,8 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
+            - name: DEPLOY_INFO_RELEASE
+              value: master
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1824,6 +1826,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2119,6 +2123,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2413,6 +2419,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2770,6 +2778,8 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -1584,6 +1584,8 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
+            - name: DEPLOY_INFO_RELEASE
+              value: master
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1898,6 +1900,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2234,6 +2238,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2569,6 +2575,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2963,6 +2971,8 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -1600,6 +1600,8 @@ objects:
             - bundle exec rake boot openshift:deploy
             containerName: system-master
             env:
+            - name: DEPLOY_INFO_RELEASE
+              value: master
             - name: APICAST_REGISTRY_URL
               valueFrom:
                 configMapKeyRef:
@@ -1873,6 +1875,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2168,6 +2172,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2462,6 +2468,8 @@ objects:
           - -c
           - config/unicorn.rb
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:
@@ -2819,6 +2827,8 @@ objects:
           - sidekiq:worker
           - RAILS_MAX_THREADS=25
           env:
+          - name: DEPLOY_INFO_RELEASE
+            value: master
           - name: APICAST_REGISTRY_URL
             valueFrom:
               configMapKeyRef:

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/api/policy/v1beta1"
 
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -194,7 +195,9 @@ func (system *System) SystemRedisEnvVars() []v1.EnvVar {
 }
 
 func (system *System) buildSystemBaseEnv() []v1.EnvVar {
-	result := []v1.EnvVar{}
+	result := []v1.EnvVar{
+		helper.EnvVarFromValue("DEPLOY_INFO_RELEASE", product.ThreescaleRelease),
+	}
 
 	baseEnvConfigMapEnvs := system.getSystemBaseEnvsFromEnvConfigMap()
 	result = append(result, baseEnvConfigMapEnvs...)


### PR DESCRIPTION
> * Related JIRA: https://issues.redhat.com/browse/THREESCALE-8042
> * Related PR: https://github.com/3scale/porta/pull/2890
>
> Marked as work in progress as related PR hasn't been merged 

### Description

Include the `DEPLOY_INFO_RELEASE` environment variable in the `DeployConfigs` for System. Set the value from the `product.ThreescaleRelease` constant.

### Verification 

Run the operator and verify that the system Pods have the `DEPLOY_INFO_RELEASE` variable set.

