### PR TITLE
disable openapi schema format validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/getkin/kin-openapi/openapi3"
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -56,6 +57,12 @@ var (
 )
 
 func init() {
+	// Avoid OpenAPI schema formatvalidation
+	// invalid components: unsupported 'format' value "uuid"
+	// https://github.com/getkin/kin-openapi/issues/442
+	// https://pkg.go.dev/github.com/getkin/kin-openapi@v0.80.0/openapi3#SchemaFormatValidationDisabled
+	openapi3.SchemaFormatValidationDisabled = true
+
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))


### PR DESCRIPTION
As per the OAS: https://spec.openapis.org/oas/v3.0.0#data-types

```
the format property is an open string-valued property, and can have any value. Formats such as "email", "uuid", and so on, MAY be used even though undefined by this specification.
```

The following openapi Doc schema is not successfully validated:
```yaml
parameters:
   - name: customer_uuid
          in: query
          description: Unique customer identifier to be used for experience customization.
          schema:
            type: string
            format: uuid
```

The error from the operator:
```
spec.openapiRef.secretRef: Invalid value: v1.ObjectReference{Kind:"",
        Namespace:"3scale-cand-3", Name:"uberoas3", UID:"", APIVersion:"",
        ResourceVersion:"", FieldPath:""}: invalid paths: parameter
        "customer_uuid" schema is invalid: Unsupported 'format' value 'uuid'
```

Issue: https://issues.redhat.com/browse/THREESCALE-7642