### PR TITLE
[WIP] Mgdapi 3472 2

### DIFF
--- a/controllers/capabilities/backend_controller.go
+++ b/controllers/capabilities/backend_controller.go
@@ -21,18 +21,19 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
 	controllerhelper "github.com/3scale/3scale-operator/pkg/controller/helper"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	"github.com/3scale/3scale-operator/version"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+const backendFinalizer = "backendapi.3scale.net/finalizer"
 
 // BackendReconciler reconciles a Backend object
 type BackendReconciler struct {
@@ -74,9 +75,18 @@ func (r *BackendReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		reqLogger.V(1).Info(string(jsonData))
 	}
 
+	err = controllerhelper.ReconcileFinalizers(backend, r.Client(), backendFinalizer)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Ignore deleted Backends, this can happen when foregroundDeletion is enabled
 	// https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#foreground-cascading-deletion
 	if backend.DeletionTimestamp != nil {
+		err = r.removeBackend(backend)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -173,4 +183,31 @@ func (r *BackendReconciler) validateSpec(backendResource *capabilitiesv1beta1.Ba
 		ErrorType:      helper.InvalidError,
 		FieldErrorList: errors,
 	}
+}
+
+func (r *BackendReconciler) removeBackend(backendResource *capabilitiesv1beta1.Backend) error {
+	providerAccount, err := controllerhelper.LookupProviderAccount(r.Client(), backendResource.Namespace, backendResource.Spec.ProviderAccountRef, r.Logger())
+	if err != nil {
+		return err
+	}
+
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	if err != nil {
+		return err
+	}
+
+	err = threescaleAPIClient.DeleteBackendApi(*backendResource.Status.ID)
+	if err != nil {
+		return err
+	}
+
+	// confirm that backendAPI has been removed
+	backendAPIs, err := threescaleAPIClient.ListBackendApis()
+	for _, backendAPI := range backendAPIs.Backends {
+		if backendAPI.Element.ID == *backendResource.Status.ID {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/controllers/capabilities/tenant_internal_reconciler.go
+++ b/controllers/capabilities/tenant_internal_reconciler.go
@@ -116,7 +116,7 @@ func (r *TenantInternalReconciler) reconcileTenant() (*porta_client_pkg.Tenant, 
 	}
 
 	// create tenant if tenant is NOT found in 3scale and deletion timestamp is not present
-	if tenantDef == nil {
+	if tenantDef == nil && r.tenantR.Finalizers == nil {
 		tenantDef, err = r.createTenant()
 		if err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 	sigs.k8s.io/controller-runtime v0.6.3
 )
 

--- a/pkg/controller/helper/controllerUtil.go
+++ b/pkg/controller/helper/controllerUtil.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// AlreadyOwnedError is an error returned if the object you are trying to assign
+// a controller reference is already owned by another controller Object is the
+// subject and Owner is the reference for the current owner
+type AlreadyOwnedError struct {
+	Object metav1.Object
+	Owner  metav1.OwnerReference
+}
+
+func (e *AlreadyOwnedError) Error() string {
+	return fmt.Sprintf("Object %s/%s is already owned by another %s controller %s", e.Object.GetNamespace(), e.Object.GetName(), e.Owner.Kind, e.Owner.Name)
+}
+
+func newAlreadyOwnedError(Object metav1.Object, Owner metav1.OwnerReference) *AlreadyOwnedError {
+	return &AlreadyOwnedError{
+		Object: Object,
+		Owner:  Owner,
+	}
+}
+
+// SetControllerReference sets owner as a Controller OwnerReference on controlled.
+// This is used for garbage collection of the controlled object and for
+// reconciling the owner object on changes to controlled (with a Watch + EnqueueRequestForOwner).
+// Since only one OwnerReference can be a controller, it returns an error if
+// there is another OwnerReference with Controller flag set.
+func SetControllerReference(owner, controlled metav1.Object, scheme *runtime.Scheme) error {
+	// Validate the owner.
+	ro, ok := owner.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a runtime.Object, cannot call SetControllerReference", owner)
+	}
+	if err := validateOwner(owner, controlled); err != nil {
+		return err
+	}
+
+	// Create a new controller ref.
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return err
+	}
+	ref := metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               owner.GetName(),
+		UID:                owner.GetUID(),
+		BlockOwnerDeletion: pointer.BoolPtr(true),
+		Controller:         pointer.BoolPtr(true),
+	}
+
+	// Return early with an error if the object is already controlled.
+	if existing := metav1.GetControllerOf(controlled); existing != nil && !referSameObject(*existing, ref) {
+		return newAlreadyOwnedError(controlled, *existing)
+	}
+
+	// Update owner references and return.
+	upsertOwnerRef(ref, controlled)
+	return nil
+}
+
+// SetOwnerReference is a helper method to make sure the given object contains an object reference to the object provided.
+// This allows you to declare that owner has a dependency on the object without specifying it as a controller.
+// If a reference to the same object already exists, it'll be overwritten with the newly provided version.
+func SetOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) error {
+	// Validate the owner.
+	ro, ok := owner.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a runtime.Object, cannot call SetOwnerReference", owner)
+	}
+	if err := validateOwner(owner, object); err != nil {
+		return err
+	}
+
+	// Create a new owner ref.
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return err
+	}
+	ref := metav1.OwnerReference{
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
+		UID:        owner.GetUID(),
+		Name:       owner.GetName(),
+	}
+
+	// Update owner references and return.
+	upsertOwnerRef(ref, object)
+	return nil
+
+}
+
+func upsertOwnerRef(ref metav1.OwnerReference, object metav1.Object) {
+	owners := object.GetOwnerReferences()
+	idx := indexOwnerRef(owners, ref)
+	if idx == -1 {
+		owners = append(owners, ref)
+	} else {
+		owners[idx] = ref
+	}
+	object.SetOwnerReferences(owners)
+}
+
+// indexOwnerRef returns the index of the owner reference in the slice if found, or -1.
+func indexOwnerRef(ownerReferences []metav1.OwnerReference, ref metav1.OwnerReference) int {
+	for index, r := range ownerReferences {
+		if referSameObject(r, ref) {
+			return index
+		}
+	}
+	return -1
+}
+
+func validateOwner(owner, object metav1.Object) error {
+	ownerNs := owner.GetNamespace()
+	if ownerNs != "" {
+		objNs := object.GetNamespace()
+		if objNs == "" {
+			return fmt.Errorf("cluster-scoped resource must not have a namespace-scoped owner, owner's namespace %s", ownerNs)
+		}
+		if ownerNs != objNs {
+			return fmt.Errorf("cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", owner.GetNamespace(), object.GetNamespace())
+		}
+	}
+	return nil
+}
+
+// Returns true if a and b point to the same object
+func referSameObject(a, b metav1.OwnerReference) bool {
+	aGV, err := schema.ParseGroupVersion(a.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	bGV, err := schema.ParseGroupVersion(b.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
+}
+
+// OperationResult is the action result of a CreateOrUpdate call
+type OperationResult string
+
+const ( // They should complete the sentence "Deployment default/foo has been ..."
+	// OperationResultNone means that the resource has not been changed
+	OperationResultNone OperationResult = "unchanged"
+	// OperationResultCreated means that a new resource is created
+	OperationResultCreated OperationResult = "created"
+	// OperationResultUpdated means that an existing resource is updated
+	OperationResultUpdated OperationResult = "updated"
+)
+
+// CreateOrUpdate creates or updates the given object in the Kubernetes
+// cluster. The object's desired state must be reconciled with the existing
+// state inside the passed in callback MutateFn.
+//
+// The MutateFn is called regardless of creating or updating an object.
+//
+// It returns the executed operation and an error.
+func CreateOrUpdate(ctx context.Context, c client.Client, obj runtime.Object, f MutateFn) (OperationResult, error) {
+	key, err := client.ObjectKeyFromObject(obj)
+	if err != nil {
+		return OperationResultNone, err
+	}
+
+	if err := c.Get(ctx, key, obj); err != nil {
+		if !errors.IsNotFound(err) {
+			return OperationResultNone, err
+		}
+		if err := mutate(f, key, obj); err != nil {
+			return OperationResultNone, err
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return OperationResultNone, err
+		}
+		return OperationResultCreated, nil
+	}
+
+	existing := obj.DeepCopyObject()
+	if err := mutate(f, key, obj); err != nil {
+		return OperationResultNone, err
+	}
+
+	if equality.Semantic.DeepEqual(existing, obj) {
+		return OperationResultNone, nil
+	}
+
+	if err := c.Update(ctx, obj); err != nil {
+		return OperationResultNone, err
+	}
+	return OperationResultUpdated, nil
+}
+
+// mutate wraps a MutateFn and applies validation to its result
+func mutate(f MutateFn, key client.ObjectKey, obj runtime.Object) error {
+	if err := f(); err != nil {
+		return err
+	}
+	if newKey, err := client.ObjectKeyFromObject(obj); err != nil || key != newKey {
+		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
+	}
+	return nil
+}
+
+// MutateFn is a function which mutates the existing object into it's desired state.
+type MutateFn func() error
+
+// AddFinalizer accepts an Object and adds the provided finalizer if not present.
+func AddFinalizer(o Object, finalizer string) {
+	f := o.GetFinalizers()
+	for _, e := range f {
+		if e == finalizer {
+			return
+		}
+	}
+	o.SetFinalizers(append(f, finalizer))
+}
+
+// AddFinalizerWithError tries to convert a runtime object to a metav1 object and add the provided finalizer.
+// It returns an error if the provided object cannot provide an accessor.
+//
+// Deprecated: Use AddFinalizer instead. Check is performing on compile time.
+func AddFinalizerWithError(o runtime.Object, finalizer string) error {
+	m, err := meta.Accessor(o)
+	if err != nil {
+		return err
+	}
+	AddFinalizer(m.(Object), finalizer)
+	return nil
+}
+
+// RemoveFinalizer accepts an Object and removes the provided finalizer if present.
+func RemoveFinalizer(o Object, finalizer string) {
+	f := o.GetFinalizers()
+	for i := 0; i < len(f); i++ {
+		if f[i] == finalizer {
+			f = append(f[:i], f[i+1:]...)
+			i--
+		}
+	}
+	o.SetFinalizers(f)
+}
+
+// RemoveFinalizerWithError tries to convert a runtime object to a metav1 object and remove the provided finalizer.
+// It returns an error if the provided object cannot provide an accessor.
+//
+// Deprecated: Use RemoveFinalizer instead. Check is performing on compile time.
+func RemoveFinalizerWithError(o runtime.Object, finalizer string) error {
+	m, err := meta.Accessor(o)
+	if err != nil {
+		return err
+	}
+	RemoveFinalizer(m.(Object), finalizer)
+	return nil
+}
+
+// ContainsFinalizer checks an Object that the provided finalizer is present.
+func ContainsFinalizer(o Object, finalizer string) bool {
+	f := o.GetFinalizers()
+	for _, e := range f {
+		if e == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// Object allows functions to work indistinctly with any resource that
+// implements both Object interfaces.
+type Object interface {
+	metav1.Object
+	runtime.Object
+}

--- a/pkg/controller/helper/finalizers.go
+++ b/pkg/controller/helper/finalizers.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+This function reconciles the finalizers, it requires
+- object
+- k8client
+- finalizer
+If the deletion timestamp is found, the finalizer will be removed.
+If the deletion timestamp is not present, a finalizer will be reconciled
+*/
+func ReconcileFinalizers(object Object, client client.Client, finalizer string) error {
+	if object.GetDeletionTimestamp() == nil {
+		_, err := CreateOrUpdate(context.TODO(), client, object, func() error {
+			AddFinalizer(object, finalizer)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := CreateOrUpdate(context.TODO(), client, object, func() error {
+			RemoveFinalizer(object, finalizer)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
- adds support of deleting backend via CR
https://issues.redhat.com/browse/MGDAPI-3472

## Verification:
For RHOAM:
- install RHOAM locally from this branch: https://github.com/integr8ly/integreatly-operator/pull/2409 but replace the manifests/3scale/0.9.0 values for containerImage and image from `quay.io/austincunningham/3scale-operator:cluster-scoped` to `quay.io/mstoklus/3scale-operator:v0.21.0`
- wait for install to complete 
- create backend via CR
- confirm backend got created in 3scale 
- delete backend CR
- confirm backend has been deleted in 3scale

## NOTE
This PR can be reviewed but is more of a draft rather than final version, also, majority of the code is a re-use from this PR https://github.com/3scale/3scale-operator/pull/715 so it would have to be merged first. 
Main file to review here is the backend-controller, other files will be reviewed by review of tenant deletion.