### PR TITLE
migrate circleci ubuntu to ubuntu-2004:202201-02

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ jobs:
 
   tag-operator-image-master:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -390,7 +390,7 @@ jobs:
 
   tag-operator-image-release:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -410,7 +410,7 @@ jobs:
 
   deploy_templates:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     resource_class: large
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ _output
 
 # controller-runtime testenv binaries
 testbin/*
+
+3scale-operator


### PR DESCRIPTION
Ubuntu 16.04-based image used in circleCI is deprecated and near EOL. Migrating to ubuntu-2004:202201-02

https://circleci.com/blog/ubuntu-14-16-image-deprecation/?mkt_tok=NDg1LVpNSC02MjYAAAGCndaS4T7Scgi7c4rB8r6g0bSsqoPY_E5GHWHcYzyRMlDS4oeY1FBTMWliNblf0MAFDvP7ae5x3Qms-6fj3_3WMthRMTB2AJHtYJnSZeld5tQ