### PR TITLE
Reconcile apicast environment

### DIFF
--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -112,6 +112,8 @@ type ApicastOptions struct {
 	StagingHTTPProxy     *string
 	StagingHTTPSProxy    *string
 	StagingNoProxy       *string
+
+	AdditionalPodAnnotations map[string]string `validate:"required"`
 }
 
 func NewApicastOptions() *ApicastOptions {

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -156,6 +156,7 @@ func defaultApicastOptions() *component.ApicastOptions {
 		Namespace:                      namespace,
 		ProductionTracingConfig:        &component.APIcastTracingConfig{TracingLibrary: component.APIcastDefaultTracingLibrary},
 		StagingTracingConfig:           &component.APIcastTracingConfig{TracingLibrary: component.APIcastDefaultTracingLibrary},
+		AdditionalPodAnnotations:       map[string]string{APIcastEnvironmentCMAnnotation: "788712912"},
 	}
 }
 

--- a/pkg/3scale/amp/prometheusrules/apicast_rules.go
+++ b/pkg/3scale/amp/prometheusrules/apicast_rules.go
@@ -52,6 +52,8 @@ func apicastOptions(ns string) (*component.ApicastOptions, error) {
 	o.StagingTracingConfig = &component.APIcastTracingConfig{TracingLibrary: component.APIcastDefaultTracingLibrary}
 	o.ProductionTracingConfig = &component.APIcastTracingConfig{TracingLibrary: component.APIcastDefaultTracingLibrary}
 
+	o.AdditionalPodAnnotations = map[string]string{}
+
 	return o, o.Validate()
 }
 

--- a/pkg/3scale/amp/template/adapters/apicast.go
+++ b/pkg/3scale/amp/template/adapters/apicast.go
@@ -123,6 +123,7 @@ func (a *Apicast) options() (*component.ApicastOptions, error) {
 
 	// Currently, only used for monitoring resources. Thus, it does not apply to templates.
 	ao.Namespace = "${NAMESPACE}"
+	ao.AdditionalPodAnnotations = map[string]string{}
 
 	err := ao.Validate()
 	return ao, err


### PR DESCRIPTION
### what

The following APIManager fields are not reconciled. 
* `spec.apicast.managementAPI`
* `spec.apicast.openSSLVerify`
* `spec.apicast.responseCodes`

The root reason is that those fields in the APIMamanger CR are reconciled in the `apicast-environment` config map. Then the apicast production and staging deploymentconfigs have env vars as references to fields from that config map. When the APIManager CR fields are changed, the config map is changed, but the apicast deployments are not rolled out, so changes do not take effect. 

This PR makes apicast deployments being rolled out when those APIManager CR fields change their value.

### how

The ideal fix would be to simplify the deployment. The env var defined in the deploymentconfig object should be set with the value of the APIManager CR. This fix makes the rolling out of the deployment when the CR values changes automatically. However, this solution implies removing the configmap `apicast-environment`. This removal would imply upgrade procedures in the operator based deployments and template based deployments. In order to avoid upgrade procedures, the fix is otherwise. The apicast pods will have one annotation with a hash value computed from the content of the configmap. If the fields of the APIManager CR change, the hash will change and the deployment will rollout. 

### Verification Steps

```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  resourceRequirementsEnabled: false
  wildcardDomain: example.com
EOF
```
Wait for deployment to be available

```
$ oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```

Patch apicast field

```
k patch apimanager apimanager1 --type='merge' -p '{"spec":{"apicast":{"managementAPI": "debug"}}}'
```

Apicast deployments should be rolling out

```
$ k get pods
NAME                          READY   STATUS              RESTARTS      AGE
apicast-production-8-5zj92    1/1     Running             0             5m18s
apicast-production-9-deploy   0/1     ContainerCreating   0             2s
apicast-staging-8-vpjcs       1/1     Running             0             5m19s
apicast-staging-9-deploy      0/1     ContainerCreating   0             3s
```