### PR TITLE
tenant controller: secrets default namespace is the tenant's one

### DIFF
--- a/apis/capabilities/v1alpha1/tenant_types.go
+++ b/apis/capabilities/v1alpha1/tenant_types.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -77,6 +78,45 @@ func (t *Tenant) SetDefaults() bool {
 		changed = true
 	}
 	return changed
+}
+
+func (t *Tenant) MasterSecretKey() client.ObjectKey {
+	namespace := t.Spec.MasterCredentialsRef.Namespace
+
+	if namespace == "" {
+		namespace = t.Namespace
+	}
+
+	return client.ObjectKey{
+		Name:      t.Spec.MasterCredentialsRef.Name,
+		Namespace: namespace,
+	}
+}
+
+func (t *Tenant) AdminPassSecretKey() client.ObjectKey {
+	namespace := t.Spec.PasswordCredentialsRef.Namespace
+
+	if namespace == "" {
+		namespace = t.Namespace
+	}
+
+	return client.ObjectKey{
+		Name:      t.Spec.PasswordCredentialsRef.Name,
+		Namespace: namespace,
+	}
+}
+
+func (t *Tenant) TenantSecretKey() client.ObjectKey {
+	namespace := t.Spec.TenantSecretRef.Namespace
+
+	if namespace == "" {
+		namespace = t.Namespace
+	}
+
+	return client.ObjectKey{
+		Name:      t.Spec.TenantSecretRef.Name,
+		Namespace: namespace,
+	}
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
### what

The Tenant CRD has three fields of SecretReference type. If the `Namespace` is not set in the custom resource, the tenant controller should default that value to the custom resource's namespace.

### verification steps

Deploy 3scale with APIManager CR

```yaml
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: example.com
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
```

Then create one tenant with secret references without namespace

```yaml
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: ecorp-tenant
spec:
  username: admin
  systemMasterUrl: https://master.example.com
  email: admin@example.com
  organizationName: ECorp
  masterCredentialsRef:
    name: system-seed
  passwordCredentialsRef:
    name: ecorp-admin-secret
  tenantSecretRef:
    name: ecorp-tenant-secret
``` 

Without the fix, the controller would fail and tenant CR status would not have IDs from 3scale

If it works, the tenant status should look like this:

```yaml
k get tenants  ecorp-tenant -o jsonpath='{.status}' | yq e -P
adminId: 5
tenantId: 4
```

