### PR TITLE
fix tenant reconciliation

### DIFF
--- a/pkg/controller/helper/tenant.go
+++ b/pkg/controller/helper/tenant.go
@@ -1,6 +1,8 @@
 package helper
 
 import (
+	"fmt"
+
 	porta_client_pkg "github.com/3scale/3scale-porta-go-client/client"
 )
 
@@ -21,4 +23,69 @@ func FetchTenant(tenantID int64, portaClient *porta_client_pkg.ThreeScaleClient)
 		return nil, err
 	}
 	return tenantDef, nil
+}
+
+/*
+FindUser finds users by email and username
+- portaClient
+- tenantID
+- email
+- username
+*/
+func FindUser(portaClient *porta_client_pkg.ThreeScaleClient, tenantID int64, email, username string) (*porta_client_pkg.DeveloperUser, error) {
+	// Any state
+	// Any role (admin, member)
+	filterParams := porta_client_pkg.Params{}
+	// for the master account, the DeveloperUsers of one account are the users
+	// of the provider account associated the master account
+	userList, err := portaClient.ListDeveloperUsers(tenantID, filterParams)
+	if err != nil {
+		return nil, err
+	}
+
+	for idx, user := range userList.Items {
+		if user.Element.Email != nil && *user.Element.Email == email &&
+			user.Element.Username != nil && *user.Element.Username == username {
+			return &userList.Items[idx], nil
+		}
+	}
+
+	return nil, nil
+}
+
+/*
+CreateAdminUser creates and active admin user
+- portaClient
+- tenantID
+- email
+- username
+*/
+func CreateAdminUser(portaClient *porta_client_pkg.ThreeScaleClient, tenantID int64, email, username string) (*porta_client_pkg.DeveloperUser, error) {
+	desiredAdmin := &porta_client_pkg.DeveloperUser{
+		Element: porta_client_pkg.DeveloperUserItem{
+			Email:    &email,
+			Username: &username,
+		},
+	}
+
+	admin, err := portaClient.CreateDeveloperUser(tenantID, desiredAdmin)
+	if err != nil {
+		return nil, err
+	}
+
+	if admin.Element.ID == nil {
+		return nil, fmt.Errorf("admin returned nil ID for tenantID %d", tenantID)
+	}
+
+	admin, err = portaClient.ChangeRoleToAdminDeveloperUser(tenantID, *admin.Element.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	admin, err = portaClient.ActivateDeveloperUser(tenantID, *admin.Element.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return admin, nil
 }


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/THREESCALE-8301


### what

When a tenant is created declaratively, using the TenantCR, and afterwards it’s deleted from the 3scale admin portal UI, the operator starts creating tenants in an infinite loop.

### how

The issue was caused by a wrong reconciliation logic that did not take into account the NOT FOUND response when reading an admin user. That returned an error, which turned up into a new reconciliation loop before the tenantID and AdminID was stored in the status section. Every new reconciliation loop ended up creatiing a new tenant.

The reconciliation loop logic has been refactored. Basically:
* Read tenant from status.TenantId
* If not found, create it and store in status new tenant ID together with 0 in the status.AdminId
* Read tenant user list looking for one user with Email and Username as specified in the tenant's spec.
* If not found any, create one
* reconcile the admin user -> make admin role and activated state in 3scale

### Verification steps

Deploy 3scale with the APIManager

```yaml
k apply -f - <<EOF
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager
spec:
  wildcardDomain: example.com
EOF
```

Wait for the deployment to be ready

```
oc wait --for=condition=available apimanager/apimanager --timeout=-1s
```

Deploy new tenant CR

```yaml
k apply -f - <<EOF
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: ecorp-tenant
spec:
  username: admin
  systemMasterUrl: https://master.example.com
  email: admin@example.com
  organizationName: ECorp
  masterCredentialsRef:
    name: system-seed
  passwordCredentialsRef:
    name: ecorp-admin-secret
  tenantSecretRef:
    name: ecorp-tenant-secret
EOF
```

From the 3scale admin portal delete the tenant created (it will not be deleted, just scheduled for deletion)

Fully delete the tenant with the rails console:

open console
```
oc rsh -c system-master "$(oc get pods --selector deploymentconfig=system-app -o name)"
bundle exec rails console
```
delete with lines (takes few seconds)

```
tenant = Account.find(PROVIDER_ID)
# run several times
DeleteAccountHierarchyWorker.perform_later(tenant)
```

the tenant controller should not have notified the deletion of the tenant. We need to force tenant reconciliation for our tenant CR. Either stop and start the operator or update something in the TenantCR. I usually add harmless annotation

```
k annotate tenant ecorp-tenant newannotation=yes
```

The tenant controller should create (only) one new tenant with the CR spec.
