### PR TITLE
product status state empty

### DIFF
--- a/controllers/capabilities/product_status_reconciler.go
+++ b/controllers/capabilities/product_status_reconciler.go
@@ -76,8 +76,6 @@ func (s *ProductStatusReconciler) calculateStatus() *capabilitiesv1beta1.Product
 	if s.entity != nil {
 		tmpID := s.entity.ID()
 		newStatus.ID = &tmpID
-		tmpState := s.entity.State()
-		newStatus.State = &tmpState
 	}
 
 	newStatus.ProviderAccountHost = s.providerAccountHost


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/THREESCALE-8031

### what
The `Product.status.state` field **was** filled with 3scale Prooduct entity state which has 3scale domain `state` meaning. The Operator Hub reads `Product.status.state` and expects state info regarding sync state between desired and existing state. That led to confusion, hence the 3scale operator's product controllers will be enforcing this field to be empty (it will be unset instead of empty string)

### Verification Steps

It is required to deploy the 3scale operator within OperatorHub (or OLM), because the change is effective at the dashboard

Following [the steps to deploy the operator using OLM](https://github.com/3scale/3scale-operator/blob/2e9a06b154100d6ae8a100b6f96c056e46912507/doc/development.md#deploy-custom-3scale-operator-using-olm):
```
make docker-build-only IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator:myversiontag
make operator-image-push IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator:myversiontag

make bundle-custom-build IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator:myversiontag BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator-bundles:myversiontag
make bundle-image-push BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator-bundles:myversiontag
```

Deploy the operator in your currently configured and active cluster in $HOME/.kube/config

```
make bundle-run BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator-bundles:myversiontag
```

Create product

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: threescale-provider-account
type: Opaque
stringData:
  token: MY_TOKEN
  adminURL: https://3scale-admin.example.com
EOF
```

```yaml
k apply -f - <<EOF
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1
spec:
  name: "OperatedProduct 1"
EOF
```

The `Status` field in the dashboard should look like the attached image
![Screenshot 2022-03-30 at 11-55-01 dev1648633617-3scale-operator 0 0 1 · Details · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/881529/160811128-35125b21-d007-4ba5-b9ac-9798d58ad3f6.png)

And the product status should not show the `state` field
```yaml
$ k get product product1-sample -o jsonpath="{.status}" | yq e -P
conditions:
  - lastTransitionTime: "2022-03-30T09:51:00Z"
    status: "False"
    type: Failed
  - lastTransitionTime: "2022-03-30T09:51:00Z"
    status: "False"
    type: Invalid
  - lastTransitionTime: "2022-03-30T09:51:00Z"
    status: "False"
    type: Orphan
  - lastTransitionTime: "2022-03-30T09:51:00Z"
    status: "True"
    type: Synced
observedGeneration: 2
productId: 2555417951553
providerAccountHost: https://3scale-supertest-admin.3scale.net
```
