### PR TITLE
Fix product delete

### DIFF
--- a/controllers/capabilities/backend_controller.go
+++ b/controllers/capabilities/backend_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -265,7 +266,7 @@ func (r *BackendReconciler) removeBackend(providerAccountRef *corev1.LocalObject
 
 	// Attempt to remove backendAPI - expect error on first attempt as the backendUsage has not been removed yet from 3scale
 	err = threescaleAPIClient.DeleteBackendApi(backendID)
-	if err != nil {
+	if err != nil && !threescaleapi.IsNotFound(err) {
 		return false, err
 	}
 

--- a/controllers/capabilities/product_controller.go
+++ b/controllers/capabilities/product_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -374,7 +375,7 @@ func (r *ProductReconciler) removeProduct(productResource *capabilitiesv1beta1.P
 	}
 
 	err = threescaleAPIClient.DeleteProduct(*productResource.Status.ID)
-	if err != nil {
+	if err != nil && !threescaleapi.IsNotFound(err) {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/3scale/3scale-operator
 go 1.13
 
 require (
-	github.com/3scale/3scale-porta-go-client v0.5.0
+	github.com/3scale/3scale-porta-go-client v0.6.0
 	github.com/RHsyseng/operator-utils v0.0.0-20200506183821-e3b4a2ba9c30
 	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
 	github.com/getkin/kin-openapi v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.3.0/go.mod h1:9IAwXhoyBJ7z9LcAwkj0/7NnPzYaPeZxxVp3zm+5IqA=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/3scale/3scale-porta-go-client v0.5.0 h1:lCxPKRYeHwXnIVnJSaQF0NkSWkFPisjTeh5vYMZUOwo=
-github.com/3scale/3scale-porta-go-client v0.5.0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
+github.com/3scale/3scale-porta-go-client v0.6.0 h1:RYIBxx57WNTfJ746IIqq40xASHKT2+vhG++59nDQbkQ=
+github.com/3scale/3scale-porta-go-client v0.6.0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=


### PR DESCRIPTION
### What 

The product deletion was broken. When deleting a product CR, the operator started retrying repeatedly without removing the finalizers.

### How

Two issues were involved.
* The  `github.com/3scale/3scale-porta-go-client/client` v0.5.0 had a bug and returned error on product deletion command even if the 3scale API returned `200 OK`.
* After first error, the operator tried to delete some non existing product, so the 3scale API returned `404 Not Found`. This error was not handled correctly by the product controller resulting in repeated retries. 

Both issues have been fixed

### Verification Steps

Run the operator

```
make run
```
Create a product

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: threescale-provider-account
type: Opaque
stringData:
  token: MY_TOKEN
  adminURL: https://3scale-admin.example.com
EOF
```

```yaml
k apply -f - <<EOF
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1
spec:
  name: "OperatedProduct 1"
EOF
```

Delete the product should return "quickly", meaning that the finalizer has been correctly deleted

```
$ k delete product product1
product.capabilities.3scale.net "product1" deleted
```

Checking the 3scale tenant, there should not be any product called `OperatedProduct 1`
