### PR TITLE
fix operator crash when creating activedoc with components section

### DIFF
--- a/controllers/capabilities/backend_controller.go
+++ b/controllers/capabilities/backend_controller.go
@@ -139,7 +139,7 @@ func (r *BackendReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		if updated {
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/controllers/capabilities/openapi_backend_reconciler.go
+++ b/controllers/capabilities/openapi_backend_reconciler.go
@@ -24,14 +24,14 @@ import (
 type OpenAPIBackendReconciler struct {
 	*reconcilers.BaseReconciler
 	openapiCR       *capabilitiesv1beta1.OpenAPI
-	openapiObj      *openapi3.Swagger
+	openapiObj      *openapi3.T
 	providerAccount *controllerhelper.ProviderAccount
 	logger          logr.Logger
 }
 
 func NewOpenAPIBackendReconciler(b *reconcilers.BaseReconciler,
 	openapiCR *capabilitiesv1beta1.OpenAPI,
-	openapiObj *openapi3.Swagger,
+	openapiObj *openapi3.T,
 	providerAccount *controllerhelper.ProviderAccount,
 	logger logr.Logger,
 ) *OpenAPIBackendReconciler {

--- a/controllers/capabilities/openapi_controller.go
+++ b/controllers/capabilities/openapi_controller.go
@@ -220,7 +220,7 @@ func (r *OpenAPIReconciler) checkProductSynced(resource *capabilitiesv1beta1.Ope
 	return product.Status.Conditions.IsTrueFor(capabilitiesv1beta1.ProductSyncedConditionType), nil
 }
 
-func (r *OpenAPIReconciler) readOpenAPI(resource *capabilitiesv1beta1.OpenAPI) (*openapi3.Swagger, error) {
+func (r *OpenAPIReconciler) readOpenAPI(resource *capabilitiesv1beta1.OpenAPI) (*openapi3.T, error) {
 	// OpenAPIRef is oneOf by CRD openapiV3 validation
 	if resource.Spec.OpenAPIRef.SecretRef != nil {
 		return r.readOpenAPISecret(resource)
@@ -230,7 +230,7 @@ func (r *OpenAPIReconciler) readOpenAPI(resource *capabilitiesv1beta1.OpenAPI) (
 	return r.readOpenAPIFromURL(resource)
 }
 
-func (r *OpenAPIReconciler) readOpenAPISecret(resource *capabilitiesv1beta1.OpenAPI) (*openapi3.Swagger, error) {
+func (r *OpenAPIReconciler) readOpenAPISecret(resource *capabilitiesv1beta1.OpenAPI) (*openapi3.T, error) {
 	fieldErrors := field.ErrorList{}
 	specFldPath := field.NewPath("spec")
 	openapiRefFldPath := specFldPath.Child("openapiRef")
@@ -269,7 +269,7 @@ func (r *OpenAPIReconciler) readOpenAPISecret(resource *capabilitiesv1beta1.Open
 		return nil
 	}(openapiSecretObj)
 
-	openapiObj, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData(dataByteArray)
+	openapiObj, err := openapi3.NewLoader().LoadFromData(dataByteArray)
 	if err != nil {
 		fieldErrors = append(fieldErrors, field.Invalid(secretRefFldPath, resource.Spec.OpenAPIRef.SecretRef, err.Error()))
 		return nil, &helper.SpecFieldError{
@@ -290,7 +290,7 @@ func (r *OpenAPIReconciler) readOpenAPISecret(resource *capabilitiesv1beta1.Open
 	return openapiObj, nil
 }
 
-func (r *OpenAPIReconciler) validateOpenAPIAs3scaleProduct(openapiCR *capabilitiesv1beta1.OpenAPI, openapiObj *openapi3.Swagger) error {
+func (r *OpenAPIReconciler) validateOpenAPIAs3scaleProduct(openapiCR *capabilitiesv1beta1.OpenAPI, openapiObj *openapi3.T) error {
 	fieldErrors := field.ErrorList{}
 	specFldPath := field.NewPath("spec")
 	openapiRefFldPath := specFldPath.Child("openapiRef")
@@ -322,7 +322,7 @@ func (r *OpenAPIReconciler) validateOpenAPIAs3scaleProduct(openapiCR *capabiliti
 	return nil
 }
 
-func (r *OpenAPIReconciler) readOpenAPIFromURL(resource *capabilitiesv1beta1.OpenAPI) (*openapi3.Swagger, error) {
+func (r *OpenAPIReconciler) readOpenAPIFromURL(resource *capabilitiesv1beta1.OpenAPI) (*openapi3.T, error) {
 	fieldErrors := field.ErrorList{}
 	specFldPath := field.NewPath("spec")
 	openapiRefFldPath := specFldPath.Child("openapiRef")
@@ -337,7 +337,7 @@ func (r *OpenAPIReconciler) readOpenAPIFromURL(resource *capabilitiesv1beta1.Ope
 		}
 	}
 
-	openapiObj, err := openapi3.NewSwaggerLoader().LoadSwaggerFromURI(openAPIURL)
+	openapiObj, err := openapi3.NewLoader().LoadFromURI(openAPIURL)
 	if err != nil {
 		fieldErrors = append(fieldErrors, field.Invalid(urlRefFldPath, resource.Spec.OpenAPIRef.URL, err.Error()))
 		return nil, &helper.SpecFieldError{

--- a/controllers/capabilities/openapi_product_reconciler.go
+++ b/controllers/capabilities/openapi_product_reconciler.go
@@ -30,14 +30,14 @@ var (
 type OpenAPIProductReconciler struct {
 	*reconcilers.BaseReconciler
 	openapiCR       *capabilitiesv1beta1.OpenAPI
-	openapiObj      *openapi3.Swagger
+	openapiObj      *openapi3.T
 	providerAccount *controllerhelper.ProviderAccount
 	logger          logr.Logger
 }
 
 func NewOpenAPIProductReconciler(b *reconcilers.BaseReconciler,
 	openapiCR *capabilitiesv1beta1.OpenAPI,
-	openapiObj *openapi3.Swagger,
+	openapiObj *openapi3.T,
 	providerAccount *controllerhelper.ProviderAccount,
 	logger logr.Logger,
 ) *OpenAPIProductReconciler {

--- a/doc/operator-application-capabilities.md
+++ b/doc/operator-application-capabilities.md
@@ -856,7 +856,7 @@ The operator will gather required credentials automatically for the default 3sca
 
 ### Features
 
-* [OpenAPI 3.0.2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md) specification
+* [OpenAPI 3.X](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md) specification
 * Accepted OpenAPI spec document formats are `json` and `yaml`.
 * OpenAPI spec document can be read from:
   * Secret

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/3scale/3scale-porta-go-client v0.6.0
 	github.com/RHsyseng/operator-utils v0.0.0-20200506183821-e3b4a2ba9c30
 	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
-	github.com/getkin/kin-openapi v0.22.1
+	github.com/getkin/kin-openapi v0.94.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-playground/validator/v10 v10.2.0

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/getkin/kin-openapi v0.22.1 h1:ODA1olTp175o//NfHko/uCAAhwUSfm5P4+K52XvTg4w=
-github.com/getkin/kin-openapi v0.22.1/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
+github.com/getkin/kin-openapi v0.94.0 h1:bAxg2vxgnHHHoeefVdmGbR+oxtJlcv5HsJJa3qmAHuo=
+github.com/getkin/kin-openapi v0.94.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -281,8 +281,9 @@ github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.17.2/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
-github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
+github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
+github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.17.2/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
@@ -468,6 +469,7 @@ github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=

--- a/pkg/controller/helper/shared.go
+++ b/pkg/controller/helper/shared.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	capabilitiesv1alpha1 "github.com/3scale/3scale-operator/apis/capabilities/v1alpha1"
-	
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 )
 
 /*
@@ -25,7 +25,7 @@ func RetrieveTenantCR(providerAccount *ProviderAccount, client k8sclient.Client,
 	opts := k8sclient.ListOptions{
 		Namespace: namespace,
 	}
-	
+
 	tenantList := &capabilitiesv1alpha1.TenantList{}
 	err := client.List(context.TODO(), tenantList, &opts)
 	if err != nil {

--- a/pkg/helper/openapi_utils.go
+++ b/pkg/helper/openapi_utils.go
@@ -22,19 +22,19 @@ var (
 	NonAlphanumRegexp = regexp.MustCompile(`[^0-9A-Za-z]`)
 )
 
-func SystemNameFromOpenAPITitle(obj *openapi3.Swagger) string {
+func SystemNameFromOpenAPITitle(obj *openapi3.T) string {
 	openapiTitle := obj.Info.Title
 	openapiTitleToLower := strings.ToLower(openapiTitle)
 	return NonWordCharRegexp.ReplaceAllString(openapiTitleToLower, "_")
 }
 
-func K8sNameFromOpenAPITitle(obj *openapi3.Swagger) string {
+func K8sNameFromOpenAPITitle(obj *openapi3.T) string {
 	openapiTitle := obj.Info.Title
 	openapiTitleToLower := strings.ToLower(openapiTitle)
 	return NonAlphanumRegexp.ReplaceAllString(openapiTitleToLower, "")
 }
 
-func FirstServerFromOpenAPI(obj *openapi3.Swagger) *openapi3.Server {
+func FirstServerFromOpenAPI(obj *openapi3.T) *openapi3.Server {
 	if obj == nil {
 		return nil
 	}
@@ -66,7 +66,7 @@ func RenderOpenAPIServerURLStr(server *openapi3.Server) (string, error) {
 	}
 
 	for variableName, variable := range server.Variables {
-		data.Data[variableName] = variable.Default.(string)
+		data.Data[variableName] = variable.Default
 	}
 
 	urlTemplate := TemplateRegexp.ReplaceAllString(server.URL, `{{ index .Data "$1" }}`)
@@ -112,7 +112,7 @@ func NewExtendedSecurityRequirement(secSchemeRef *openapi3.SecuritySchemeRef, sc
 	}
 }
 
-func OpenAPIGlobalSecurityRequirements(openapiObj *openapi3.Swagger) []*ExtendedSecurityRequirement {
+func OpenAPIGlobalSecurityRequirements(openapiObj *openapi3.T) []*ExtendedSecurityRequirement {
 	extendedSecRequirements := make([]*ExtendedSecurityRequirement, 0)
 
 	for _, secReq := range openapiObj.Security {
@@ -146,7 +146,7 @@ func MethodSystemNameFromOpenAPIOperation(path, opVerb string, op *openapi3.Oper
 	return NonWordCharRegexp.ReplaceAllString(nameToLower, "_")
 }
 
-func BaseURLFromOpenAPI(obj *openapi3.Swagger) (string, error) {
+func BaseURLFromOpenAPI(obj *openapi3.T) (string, error) {
 	server := FirstServerFromOpenAPI(obj)
 	serverURL, err := RenderOpenAPIServerURL(server)
 	if err != nil {
@@ -162,7 +162,7 @@ func BaseURLFromOpenAPI(obj *openapi3.Swagger) (string, error) {
 	return fmt.Sprintf("%s://%s", scheme, serverURL.Host), nil
 }
 
-func BasePathFromOpenAPI(obj *openapi3.Swagger) (string, error) {
+func BasePathFromOpenAPI(obj *openapi3.T) (string, error) {
 	server := FirstServerFromOpenAPI(obj)
 	serverURL, err := RenderOpenAPIServerURL(server)
 	if err != nil {


### PR DESCRIPTION
### What

Jira issue: https://issues.redhat.com/browse/THREESCALE-8287
The operator crashes when the activedoc's OpenAPI has `Components.Schemas[]` fields.

Internally, the operator tries to compare and the comparator library (`github.com/google/go-cmp/cmp`) was panic-ing  because it was trying to compare unexported field. 

The fix has been configure the comparator to ignore unexported fields from that structure.

Additionally, the openapi3 library has been upgraded from v0.22.0 -> v0.94.0

### verification steps

Create OpenAPI doc file (o.yaml):
```yaml
---
openapi: "3.0.0"
info:
  title: "some title"
  description: "some description"
  version: "1.0.0"
paths:
  /pet:
    get:
      operationId: "getPet"
      responses:
        405:
          description: "invalid input"
          content: {}
components:
  schemas:
    ApiResponse:
      type: object
      properties:
        code:
          type: integer
          format: int32
        type:
          type: string
        message:
          type: string
```

Create secret from the o.yaml file

```
k create secret generic myopenapi --from-file o.yaml
```

Create ActiveDoc CR

```yaml
k apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ActiveDoc
metadata:
  name: activedoc1
spec:
  name: "somename"
  activeDocOpenAPIRef:
    secretRef:
      name: myopenapi
EOF
```

Run the operator:

```
make run
```
The operator should not crash

The activedoc CR should be sync'ed

```yaml
k get activedoc activedoc1 -o yaml
apiVersion: capabilities.3scale.net/v1beta1
kind: ActiveDoc
metadata:
  name: activedoc1
spec:
  activeDocOpenAPIRef:
    secretRef:
      name: myopenapi
      namespace: 3scale
  name: somename
  systemName: somename
status:
  activeDocId: 195323
  conditions:
    - lastTransitionTime: "2022-04-05T13:38:01Z"
      status: "False"
      type: Failed
    - lastTransitionTime: "2022-04-05T13:38:01Z"
      status: "False"
      type: Invalid
    - lastTransitionTime: "2022-04-05T13:38:01Z"
      status: "False"
      type: Orphan
    - lastTransitionTime: "2022-04-05T13:38:01Z"
      status: "True"
      type: Ready
  observedGeneration: 2
  providerAccountHost: https://3scale-admin.example.com
```


