### PR TITLE
fix system mysql pod label upgrade

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -1065,9 +1065,7 @@ func (apimanager *APIManager) IsSystemPostgreSQLEnabled() bool {
 }
 
 func (apimanager *APIManager) IsSystemMysqlEnabled() bool {
-	return !apimanager.IsExternal(SystemDatabase) &&
-		apimanager.Spec.System.DatabaseSpec != nil &&
-		apimanager.Spec.System.DatabaseSpec.MySQL != nil
+	return !apimanager.IsExternal(SystemDatabase) && !apimanager.IsSystemPostgreSQLEnabled()
 }
 
 func (apimanager *APIManager) IsMonitoringEnabled() bool {

--- a/pkg/3scale/amp/operator/upgrade.go
+++ b/pkg/3scale/amp/operator/upgrade.go
@@ -407,7 +407,7 @@ func (u *UpgradeApiManager) upgradeSystemRedisDeploymentConfig() (reconcile.Resu
 }
 
 func (u *UpgradeApiManager) upgradeSystemDatabaseDeploymentConfig() (reconcile.Result, error) {
-	if u.apiManager.Spec.System.DatabaseSpec != nil && u.apiManager.Spec.System.DatabaseSpec.PostgreSQL != nil {
+	if u.apiManager.IsSystemPostgreSQLEnabled() {
 		return u.upgradeSystemPostgreSQLDeploymentConfig()
 	}
 
@@ -900,12 +900,7 @@ func (u *UpgradeApiManager) ensurePodTemplateLabels(desired *appsv1.DeploymentCo
 }
 
 func (u *UpgradeApiManager) upgradeMysqlConfigmap() (reconcile.Result, error) {
-	if u.apiManager.IsExternal(appsv1alpha1.SystemDatabase) {
-		return reconcile.Result{}, nil
-	}
-
-	if u.apiManager.Spec.System.DatabaseSpec != nil &&
-		u.apiManager.Spec.System.DatabaseSpec.PostgreSQL != nil {
+	if !u.apiManager.IsSystemMysqlEnabled() {
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
### what

Fix `func (apimanager *APIManager) IsSystemMysqlEnabled() bool`. System mysql pod template labels were not upgraded

### verification steps

Deploy 3scale 2.11 with system mysql. System mysql pod labels are:
```yaml
$ oc get "$(oc get pods --selector deploymentconfig=system-mysql -o name)" -o jsonpath='{.metadata.labels}' | yq e -P
app: 3scale-api-management
com.redhat.component-name: system-mysql
com.redhat.component-type: application
com.redhat.component-version: "57"
com.redhat.product-name: 3scale
com.redhat.product-version: "2.11"
deployment: system-mysql-1
deploymentConfig: system-mysql
deploymentconfig: system-mysql
threescale_component: system
threescale_component_element: mysql
```

Run upgrade to 2.12 procedure. For this step, I just removed the operator and `make run` the version from this PR branch. Check system mysql pod labels:

```yaml
$ oc get "$(oc get pods --selector deploymentconfig=system-mysql -o name)" -o jsonpath='{.metadata.labels}' | yq e -P
app: 3scale-api-management
com.company: Red_Hat
deployment: system-mysql-2
deploymentConfig: system-mysql
deploymentconfig: system-mysql
rht.comp: 3scale
rht.comp_ver: master
rht.prod_name: Red_Hat_Integration
rht.prod_ver: master
rht.subcomp: system-mysql
rht.subcomp_t: application
threescale_component: system
threescale_component_element: mysql
```
Labels have been upgraded
