### PR TITLE
THREESCALE-7052 - feat: delete developer account

### DIFF
--- a/doc/developeraccount-reference.md
+++ b/doc/developeraccount-reference.md
@@ -7,6 +7,7 @@
       * [Provider Account Reference](#provider-account-reference)
    * [DeveloperAccountStatus](#developeraccountstatus)
       * [ConditionSpec](#conditionspec)
+* [Supported Actions](#Supported Actions)
 
 Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc)
 
@@ -108,3 +109,7 @@ Each element of the Condition array has the following fields:
 | Reason | `reason` | string | Condition state reason |
 | Message | `message` | string | Condition state description |
 | LastTransitionTime | `lastTransitionTime` | timestamp | Last transition timestap |
+
+## Supported Actions
+* Create - creating the CR will create the developer account in the associated tenant
+* Delete - deleting the CR will delete the developer account in the associated tenant


### PR DESCRIPTION
## Description
Delete developer account when cr is deleted

## Verification
* Install CRDs and run 3scale operator
```
make install
oc new-project 3scale
make run
```
* Create S3 secret for APIManager
```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```
* Create `APIManager`
```
oc apply -f - <<EOF                                                             
---             
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: apps.some-valid-domain
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* Create secret for tenant admin
```
oc apply -f - <<EOF                                                             
---             
apiVersion: v1
kind: Secret
metadata:
  name: ecorp-admin-secret
type: Opaque
stringData:
  admin_password: password
EOF
```
* Create `Tenant`
```
oc apply -f - <<EOF                                                             
---             
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: tenant1
spec:
  email: test1@test.com
  masterCredentialsRef:
    name: system-seed
  organizationName: test1Org
  passwordCredentialsRef:
    name: ecorp-admin-secret
  systemMasterUrl: 'https://master. apps.some-valid-domain'
  tenantSecretRef:
    name: tenant-secret
  username: test1
EOF
```
* Create secret for `DeveleperUser`
```
oc apply -f - <<EOF                                                             
---             
apiVersion: v1
kind: Secret
metadata:
  name: my-user-password
type: Opaque
stringData:
  password: password
EOF
```
* Create `DeveloperUser` on the created tenant
```
oc apply -f - <<EOF                                                             
---             
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: devuser1
  namespace: 3scale
spec: 
  username: test1
  email: test1@example.com
  passwordCredentialsRef: 
    name: my-user-password
  developerAccountRef: 
    name: devaccount1
  providerAccountRef: 
    name: "tenant-secret"
  role: admin
EOF
```
* Create `DeveloperAccount` on the created tenant
```
oc apply -f - <<EOF                                                             
---             
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperAccount
metadata:
  name: devaccount1
  namespace: 3scale
spec: 
  orgName: "test1"
  monthlyBillingEnabled: false
  monthlyChargingEnabled: false
  providerAccountRef: 
    name: "tenant-secret"
EOF
```
* Sign into the created tenant and verify that DeveloperAccount is present
* Delete `DeveloperAccount` CR
```
oc delete developeraccount devaccount1
```
* Refresh the UI and verify developer account is deleted from the UI
* Create developer account again 
* Delete tenant 
```
oc delete tenant tenant1
```
* Verify `DeveloperAccount` CR is removed along with the `Tenant` CR