### PR TITLE
grant clusterversions.config.openshift.io resource add and list verbs

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -769,6 +769,13 @@ spec:
           - patch
           - update
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        - apiGroups:
           - ""
           resources:
           - configmaps

--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -312,6 +312,13 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        - apiGroups:
           - console.openshift.io
           resources:
           - consolelinks
@@ -768,13 +775,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - clusterversions
-          verbs:
-          - get
-          - list
         - apiGroups:
           - ""
           resources:

--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -318,6 +318,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - console.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,6 +13,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - console.openshift.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -374,6 +374,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - console.openshift.io
   resources:
   - consolelinks
@@ -373,13 +380,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusterversions
-  verbs:
-  - get
-  - list
 - apiGroups:
   - ""
   resources:

--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -64,7 +64,7 @@ var _ reconcile.Reconciler = &APIManagerReconciler{}
 // +kubebuilder:rbac:groups=policy,namespace=placeholder,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace=placeholder,resources=podmonitors;servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=integreatly.org,namespace=placeholder,resources=grafanadashboards,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=config.openshift.io,namespace=placeholder,resources=clusterversions,verbs=get;list
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list
 
 func (r *APIManagerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -64,6 +64,7 @@ var _ reconcile.Reconciler = &APIManagerReconciler{}
 // +kubebuilder:rbac:groups=policy,namespace=placeholder,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace=placeholder,resources=podmonitors;servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=integreatly.org,namespace=placeholder,resources=grafanadashboards,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=config.openshift.io,namespace=placeholder,resources=clusterversions,verbs=get;list
 
 func (r *APIManagerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -64,7 +64,7 @@ var _ reconcile.Reconciler = &APIManagerReconciler{}
 // +kubebuilder:rbac:groups=policy,namespace=placeholder,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace=placeholder,resources=podmonitors;servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=integreatly.org,namespace=placeholder,resources=grafanadashboards,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 func (r *APIManagerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()


### PR DESCRIPTION
### what

The 3scale operator role assigned to the service account running the 3scale operator pod missed permission to `get`, `list` `clusterversions.config.openshift.io`. It was complaining with the following error:

```
E0505 12:54:28.484088       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to list *v1.ClusterVersion: clusterversions.config.openshift.io is forbidden: User "system:serviceaccount:eguzki:3scale-operator" cannot list resource "clusterversions" in API group "config.openshift.io" at the cluster scope
```

### Verification

Deploy the 3scale operator from OLM: follow our [user guide to deploy using OLM](https://github.com/3scale/3scale-operator/blob/master/doc/development.md#deploy-custom-3scale-operator-using-olm)

Create APIManager object, check all 3scale deployment objects are created. When the operator does not have permission to do something, it stops creating new deployment objects and retries.
