### PR TITLE
update the grafana-datasource secret name

### DIFF
--- a/doc/monitoring-stack-deployment/README.md
+++ b/doc/monitoring-stack-deployment/README.md
@@ -4,7 +4,7 @@
 
 1. Create additional-scrape-configs secret with 3scale scrape config
 
-Get basic auth password `basicAuthPassword` from `ns/openshift-monitoring/secrets/grafana-datasources/prometheus.yaml` and update `3scale-scrape-configs.yaml` basic auth field.
+Get basic auth password `basicAuthPassword` from `ns/openshift-monitoring/secrets/grafana-datasources-v2/prometheus.yaml` and update `3scale-scrape-configs.yaml` basic auth field.
 
 Then create secret:
 


### PR DESCRIPTION
# What 
grafana-datasources secret change to grafana-datasources-v2 from Openshift 4.10

![image](https://user-images.githubusercontent.com/16667688/168089198-463f71bb-419b-4242-a934-9849f43b4c20.png)

Updating the monitoring doc