### PR TITLE
THREESCALE-7055 - feat: delete developer user

### DIFF
--- a/doc/developeruser-reference.md
+++ b/doc/developeruser-reference.md
@@ -8,6 +8,7 @@
       * [Provider Account Reference](#provider-account-reference)
    * [DeveloperUserStatus](#developeruserstatus)
       * [ConditionSpec](#conditionspec)
+* [Supported Actions](#Supported Actions)
 
 Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc)
 
@@ -132,3 +133,10 @@ Each element of the Condition array has the following fields:
 | Reason | `reason` | string | Condition state reason |
 | Message | `message` | string | Condition state description |
 | LastTransitionTime | `lastTransitionTime` | timestamp | Last transition timestap |
+
+
+## Supported Actions
+* Create - creating the CR will create the developer user in the associated account and tenant
+* Delete - deleting the CR will delete the developer user in the associated account and tenant
+  * Note: Due to a 3scale limitation, if the user is the last admin of the account, the CR will be prevented from 
+deleting successfully

--- a/pkg/controller/helper/shared.go
+++ b/pkg/controller/helper/shared.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"context"
-
 	capabilitiesv1alpha1 "github.com/3scale/3scale-operator/apis/capabilities/v1alpha1"
 
 	"github.com/go-logr/logr"
@@ -52,18 +51,29 @@ func RetrieveTenantCR(providerAccount *ProviderAccount, client k8sclient.Client,
 }
 
 /*
-SetOwnersReference sets ownersReference in given object
+SetOwnersReference sets ownersReference in given object for Tenant
 - object
 - k8client
 - tenantCR
 */
 func SetOwnersReference(object controllerutil.Object, client k8sclient.Client, tenantCR *capabilitiesv1alpha1.Tenant) (bool, error) {
+	return SetOwnersReferenceByObjectAndMeta(object, client, tenantCR.ObjectMeta, tenantCR.TypeMeta)
+}
+
+/*
+SetOwnersReferenceByObjectAndMeta sets ownersReference in given object using ObjectMeta and TypeMeta
+- object
+- k8client
+- objectMeta
+- typeMeta
+*/
+func SetOwnersReferenceByObjectAndMeta(object controllerutil.Object, client k8sclient.Client, objectMeta metav1.ObjectMeta, typeMeta metav1.TypeMeta) (bool, error) {
 	ownerReference := []metav1.OwnerReference{
 		{
-			APIVersion: tenantCR.APIVersion,
-			Kind:       tenantCR.Kind,
-			Name:       tenantCR.Name,
-			UID:        tenantCR.UID,
+			APIVersion: typeMeta.APIVersion,
+			Kind:       typeMeta.Kind,
+			Name:       objectMeta.Name,
+			UID:        objectMeta.UID,
 		},
 	}
 


### PR DESCRIPTION
## Description
Delete developer user when cr is deleted

## Verification
* Install CRDs and run 3scale operator
```
make install
oc new-project 3scale
make run
```
* Create S3 secret for APIManager
```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```
* Create `APIManager`
```
oc apply -f - <<EOF                                                             
---             
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: apps.some-valid-domain
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* Create secret for tenant admin
```
oc apply -f - <<EOF                                                             
---             
apiVersion: v1
kind: Secret
metadata:
  name: ecorp-admin-secret
type: Opaque
stringData:
  admin_password: password
EOF
```
* Create `Tenant`
```
oc apply -f - <<EOF                                                             
---             
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: tenant1
spec:
  email: test1@test.com
  masterCredentialsRef:
    name: system-seed
  organizationName: test1Org
  passwordCredentialsRef:
    name: ecorp-admin-secret
  systemMasterUrl: 'https://master.apps.some-valid-domain'
  tenantSecretRef:
    name: tenant-secret
  username: test1
EOF
```
* Create `DeveloperAccount` on the created tenant
```
oc apply -f - <<EOF                                                         
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperAccount
metadata:
  name: devaccount
  namespace: 3scale
spec:
  orgName: "devaccount"
  monthlyBillingEnabled: false
  monthlyChargingEnabled: false
  providerAccountRef:
    name: "tenant-secret"
EOF
```
* Create secret for `DeveleperUser`
```
oc apply -f - <<EOF                                                             
---             
apiVersion: v1
kind: Secret
metadata:
  name: my-user-password
type: Opaque
stringData:
  password: password
EOF
```
* Create `DeveloperUser` on the created tenant
```
oc apply -f - <<EOF                                                                       
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: devuser1
  namespace: 3scale
spec:
  username: devuser
  email: devuser@example.com
  passwordCredentialsRef:
    name: my-user-password
  developerAccountRef:
    name: devaccount
  providerAccountRef:
    name: "tenant-secret"
  role: admin
EOF
```
* Create second `DeveloperUser` on the created tenant
```
oc apply -f - <<EOF                                                                       
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: devuser2
  namespace: 3scale
spec:
  username: devuser2
  email: devuser2@example.com
  passwordCredentialsRef:
    name: my-user-password
  developerAccountRef:
    name: devaccount
  providerAccountRef:
    name: "tenant-secret"
  role: admin
EOF
```
* Sign into the created tenant and verify that `DeveloperUsers` is present
* Delete 1 `DeveloperUser` CR
```
oc delete developeruser devuser1
```
* Refresh the UI and verify developer user is deleted from the UI
* Delete last developer user 
```
oc delete developeruser devuser2
```
* Verify that last admin error is on the CR
```
oc delete developeraccount devaccount  devuser2 -o yaml
```
* Delete `DeveloperAccount`
```
oc delete developeraccount devaccount 
```
* Verify last developer account cr has been removed 
```
oc get developerusers
```
* Create a developer user and developer user again
* Delete tenant 
```
oc delete tenant tenant1
```
* Verify `DeveloperUser` and `DeveloperAccount` CR is removed along with the `Tenant` CR