### PR TITLE
Apimanager 2.11: add preserve unknown fields

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -136,7 +136,12 @@ type APIManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   APIManagerSpec   `json:"spec,omitempty"`
+	// XPreserveUnknownFields Does not work at type level. Tested on OCP 4.8
+
+	// +kubebuilder:validation:XPreserveUnknownFields
+	Spec APIManagerSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:validation:XPreserveUnknownFields
 	Status APIManagerStatus `json:"status,omitempty"`
 }
 

--- a/bundle/manifests/apps.3scale.net_apimanagers.yaml
+++ b/bundle/manifests/apps.3scale.net_apimanagers.yaml
@@ -6691,6 +6691,7 @@ spec:
             required:
             - wildcardDomain
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: APIManagerStatus defines the observed state of APIManager
             properties:
@@ -6739,6 +6740,7 @@ spec:
             required:
             - deployments
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/apps.3scale.net_apimanagers.yaml
+++ b/config/crd/bases/apps.3scale.net_apimanagers.yaml
@@ -11992,6 +11992,7 @@ spec:
             required:
             - wildcardDomain
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: APIManagerStatus defines the observed state of APIManager
             properties:
@@ -12059,6 +12060,7 @@ spec:
             required:
             - deployments
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true


### PR DESCRIPTION
### What
Fixes: https://issues.redhat.com/browse/THREESCALE-8445

In summary, installing one old version (2.11) operator makes OLM to replace CRD to the old version. This scenario only applies to namespaced operators. In cluster wide operators cannot happen because the OLM upgrade path does not allow. It would be necessary to uninstall and install again.  

This is mainly because the CRD of APIManager keeps the same version even if there are new fields.

The fix is about making the CRD 2.11 to preserve unknown fields, so even 2.11 CRD is installed, already stored fields from 2.12 will be available.

### Steps to reproduce
* Install CRD from 2.12 
```
git checkout 3scale-2.12-stable
k apply -f bundle/manifests/apps.3scale.net_apimanagers.yaml
``` 
* Create APImanager 2.12 with `spec.externalComponents`

```yaml
k apply -f - <<EOF
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: example-apimanager
spec:
  wildcardDomain: lvh.me
  externalComponents:
    backend:
      redis: true
    system:
      database: false
      redis: true
    zync:
      database: false
EOF
```
*  Install CRD from 2.11
```
git checkout 3scale-2.11-stable
k apply -f bundle/manifests/apps.3scale.net_apimanagers.yaml
``` 
* Fetch the apimanager CR, check that the `spec.externalComponents` is gone. This causes the operator to update the deployment from external to internal, and since the secrets have already being creatred, the deployment breaks.
```yaml
k get apimanager  example-apimanager -n 3scale212 -o yaml | yq_k8s_clean 
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"annotations":{},"name":"example-apimanager","namespace":"3scale212"},"spec":{"externalComponents":{"backend":{"redis":true},"system":{"database":false,"redis":true},"zync":{"database":false}},"wildcardDomain":"lvh.me"}}
  creationTimestamp: "2022-06-01T16:31:40Z"
  generation: 2
  name: example-apimanager
  namespace: 3scale212
  resourceVersion: "363928247"
  uid: 4d81993c-cee0-4a57-bb0f-5d7afff8ad2c
spec:
  wildcardDomain: lvh.me
```

It can be quickly fix if CRD from 2.12 is installed, as the content is there back again. It has not been changed in the etcd persistence

```yaml
git checkout 3scale-2.12-stable
k apply -f bundle/manifests/apps.3scale.net_apimanagers.yaml


k get apimanager  example-apimanager -n 3scale212 -o yaml | yq_k8s_clean
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"annotations":{},"name":"example-apimanager","namespace":"3scale212"},"spec":{"externalComponents":{"backend":{"redis":true},"system":{"database":false,"redis":true},"zync":{"database":false}},"wildcardDomain":"lvh.me"}}
  creationTimestamp: "2022-06-01T17:29:52Z"
  generation: 1
  name: example-apimanager
  namespace: 3scale212
  resourceVersion: "363966992"
  uid: e37ebdcc-3cbf-4f68-9cb9-a4b5a9ef1efd
spec:
  externalComponents:
    backend:
      redis: true
    system:
      database: false
      redis: true
    zync:
      database: false
  wildcardDomain: lvh.me
```

### Verification steps

It is basically the same as the "steps to reproduce" guide, but when CRD2.11 is installed, the APIManager CR should still have the `spec.externalComponents` fields

* Install CRD from 2.12 
```
git checkout 3scale-2.12-stable
k apply -f bundle/manifests/apps.3scale.net_apimanagers.yaml
``` 
* Create APImanager 2.12 with `spec.externalComponents`

```yaml
k apply -f - <<EOF
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: example-apimanager
  namespace: A
spec:
  wildcardDomain: lvh.me
  externalComponents:
    backend:
      redis: true
    system:
      database: false
      redis: true
    zync:
      database: false
EOF
```
*  Install CRD from 2.11 *FROM THIS BRANCH* with the patch
```
git checkout apimanager-add-preserve-unknown-fields
k apply -f bundle/manifests/apps.3scale.net_apimanagers.yaml
``` 
* check that the preserve unknown fields is present:
```
❯ k get crds  apimanagers.apps.3scale.net -o yaml | grep x-kubernetes-preserve-unknown-fields
            x-kubernetes-preserve-unknown-fields: true
            x-kubernetes-preserve-unknown-fields: true
```

* Fetch the apimanager CR, check that the `spec.externalComponents` is still there. 

```yaml
k get apimanager  example-apimanager -n 3scale212 -o yaml | yq_k8s_clean 
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"annotations":{},"name":"example-apimanager","namespace":"3scale212"},"spec":{"externalComponents":{"backend":{"redis":true},"system":{"database":false,"redis":true},"zync":{"database":false}},"wildcardDomain":"lvh.me"}}
  creationTimestamp: "2022-06-01T16:31:40Z"
  generation: 2
  name: example-apimanager
  namespace: 3scale212
  resourceVersion: "363928247"
  uid: 4d81993c-cee0-4a57-bb0f-5d7afff8ad2c
spec:
  externalComponents:
    backend:
      redis: true
    system:
      database: false
      redis: true
    zync:
      database: false
  wildcardDomain: lvh.me
```