### PR TITLE
apimanager CRD: preserve unknown fields

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -139,7 +139,12 @@ type APIManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   APIManagerSpec   `json:"spec,omitempty"`
+	// XPreserveUnknownFields Does not work at type level. Tested on OCP 4.8
+
+	// +kubebuilder:validation:XPreserveUnknownFields
+	Spec APIManagerSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:validation:XPreserveUnknownFields
 	Status APIManagerStatus `json:"status,omitempty"`
 }
 

--- a/bundle/manifests/apps.3scale.net_apimanagers.yaml
+++ b/bundle/manifests/apps.3scale.net_apimanagers.yaml
@@ -6711,6 +6711,7 @@ spec:
             required:
             - wildcardDomain
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: APIManagerStatus defines the observed state of APIManager
             properties:
@@ -6759,6 +6760,7 @@ spec:
             required:
             - deployments
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/apps.3scale.net_apimanagers.yaml
+++ b/config/crd/bases/apps.3scale.net_apimanagers.yaml
@@ -12012,6 +12012,7 @@ spec:
             required:
             - wildcardDomain
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: APIManagerStatus defines the observed state of APIManager
             properties:
@@ -12079,6 +12080,7 @@ spec:
             required:
             - deployments
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true


### PR DESCRIPTION
apimanager CRD: add x-kubernetes-preserve-unknown-fields to disable pruning

Related issue: https://issues.redhat.com/browse/THREESCALE-8445

Ideally, unknown fields should be pruned and bump CRD version. Check comment: https://issues.redhat.com/browse/THREESCALE-8445?focusedCommentId=20369075&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-20369075

This PR prevents from issues as low effort good compromise