### PR TITLE
THREESCALE-8467 (1): Granular options provider logic

### DIFF
--- a/pkg/3scale/amp/component/highavailability_options.go
+++ b/pkg/3scale/amp/component/highavailability_options.go
@@ -3,14 +3,14 @@ package component
 import "github.com/go-playground/validator/v10"
 
 type HighAvailabilityOptions struct {
-	BackendRedisQueuesEndpoint       string `validate:"required"`
+	BackendRedisQueuesEndpoint       string
 	BackendRedisQueuesSentinelHosts  string
 	BackendRedisQueuesSentinelRole   string
-	BackendRedisStorageEndpoint      string `validate:"required"`
+	BackendRedisStorageEndpoint      string
 	BackendRedisStorageSentinelHosts string
 	BackendRedisStorageSentinelRole  string
-	SystemDatabaseURL                string `validate:"required"`
-	SystemRedisURL                   string `validate:"required"`
+	SystemDatabaseURL                string
+	SystemRedisURL                   string
 	SystemRedisSentinelsHosts        string
 	SystemRedisSentinelsRole         string
 	SystemRedisNamespace             string


### PR DESCRIPTION
The `GetHighAvailabilityOptions` method that is used by all external component reconcilers has logic that expects the secrets for all the components being external. This means that even when a dependency is configured as internal, as long as another dependency is configured external this logic will try to retrieve the secret for the internal dependency, failing the reconciliation.

Fix this by making the logic only populate the options for the dependencies configured as external.

Fixes https://issues.redhat.com/browse/THREESCALE-8467