### PR TITLE
THREESCALE-8467 (2): Make Redis ConfigMap common

### DIFF
--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -47,10 +47,11 @@ func (redis *Redis) buildDeploymentConfigObjectMeta() metav1.ObjectMeta {
 }
 
 const (
+	redisConfigVolumeName = "redis-config"
+
 	backendRedisObjectMetaName    = "backend-redis"
 	backendRedisDCSelectorName    = backendRedisObjectMetaName
 	backendRedisStorageVolumeName = "backend-redis-storage"
-	backendRedisConfigVolumeName  = "redis-config"
 	backendRedisConfigMapKey      = "redis.conf"
 	backendRedisContainerName     = "backend-redis"
 	backendRedisContainerCommand  = "/opt/rh/rh-redis5/root/usr/bin/redis-server"
@@ -130,11 +131,11 @@ func (redis *Redis) buildPodVolumes() []v1.Volume {
 			},
 		},
 		v1.Volume{
-			Name: backendRedisConfigVolumeName,
+			Name: redisConfigVolumeName,
 			VolumeSource: v1.VolumeSource{
 				ConfigMap: &v1.ConfigMapVolumeSource{
 					LocalObjectReference: v1.LocalObjectReference{ //The name of the ConfigMap
-						Name: backendRedisConfigVolumeName,
+						Name: redisConfigVolumeName,
 					},
 					Items: []v1.KeyToPath{
 						v1.KeyToPath{
@@ -219,7 +220,7 @@ func (redis *Redis) buildPodContainerVolumeMounts() []v1.VolumeMount {
 			MountPath: "/var/lib/redis/data",
 		},
 		v1.VolumeMount{
-			Name:      backendRedisConfigVolumeName,
+			Name:      redisConfigVolumeName,
 			MountPath: "/etc/redis.d/",
 		},
 	}
@@ -270,7 +271,7 @@ func (redis *Redis) buildServiceSelector() map[string]string {
 	}
 }
 
-func (redis *Redis) BackendConfigMap() *v1.ConfigMap {
+func (redis *Redis) ConfigMap() *v1.ConfigMap {
 	return &v1.ConfigMap{
 		ObjectMeta: redis.buildConfigMapObjectMeta(),
 		TypeMeta:   redis.buildConfigMapTypeMeta(),
@@ -280,7 +281,7 @@ func (redis *Redis) BackendConfigMap() *v1.ConfigMap {
 
 func (redis *Redis) buildConfigMapObjectMeta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:   backendRedisConfigVolumeName,
+		Name:   redisConfigVolumeName,
 		Labels: redis.Options.SystemRedisLabels,
 	}
 }

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -33,7 +33,7 @@ func NewSystemRedisDependencyReconciler(baseAPIManagerLogicReconciler *BaseAPIMa
 
 		DeploymentConfig:      (*component.Redis).SystemDeploymentConfig,
 		Service:               (*component.Redis).SystemService,
-		ConfigMap:             nil,
+		ConfigMap:             (*component.Redis).ConfigMap,
 		PersistentVolumeClaim: (*component.Redis).SystemPVC,
 		ImageStream:           (*component.Redis).SystemImageStream,
 		Secret:                (*component.Redis).SystemRedisSecret,
@@ -46,7 +46,7 @@ func NewBackendRedisDependencyReconciler(baseAPIManagerLogicReconciler *BaseAPIM
 
 		DeploymentConfig:      (*component.Redis).BackendDeploymentConfig,
 		Service:               (*component.Redis).BackendService,
-		ConfigMap:             (*component.Redis).BackendConfigMap,
+		ConfigMap:             (*component.Redis).ConfigMap,
 		PersistentVolumeClaim: (*component.Redis).BackendPVC,
 		ImageStream:           (*component.Redis).BackendImageStream,
 		Secret:                (*component.Redis).BackendRedisSecret,

--- a/pkg/3scale/amp/template/adapters/redis.go
+++ b/pkg/3scale/amp/template/adapters/redis.go
@@ -49,7 +49,7 @@ func (r *RedisAdapter) componentObjects(c *component.Redis) []common.KubernetesO
 func (r *RedisAdapter) backendRedisComponentObjects(c *component.Redis) []common.KubernetesObject {
 	dc := c.BackendDeploymentConfig()
 	bs := c.BackendService()
-	cm := c.BackendConfigMap()
+	cm := c.ConfigMap()
 	bpvc := c.BackendPVC()
 	bis := c.BackendImageStream()
 	backendRedisSecret := c.BackendRedisSecret()


### PR DESCRIPTION
Currently, the Backend Redis reconciler creates a `redis-config` ConfigMap that is used by the deployments, but the System Redis also depends on that ConfigMap. This results in the failure to deploy the System Redis when the Backend Redis is configured as external (which is now possible since making this configuration fine grained).


Fix this by making the ConfigMap reconciliation common among both Redis reconcilers, which will result in the ConfigMap being created regardless of what combination of internal/external Redis is configured.

Fixes https://issues.redhat.com/browse/THREESCALE-8467