### PR TITLE
add secret_key_base to system sphinx

### DIFF
--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3207,6 +3207,8 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-database
+          - name: SECRET_KEY_BASE
+            value: rails/32947
           - name: THINKING_SPHINX_ADDRESS
             value: 0.0.0.0
           - name: THINKING_SPHINX_CONFIGURATION_FILE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval-s3.yml
@@ -3215,10 +3215,6 @@ objects:
             value: db/sphinx/production.conf
           - name: THINKING_SPHINX_PID_FILE
             value: db/sphinx/searchd.pid
-          - name: DELTA_INDEX_INTERVAL
-            value: "5"
-          - name: FULL_REINDEX_INTERVAL
-            value: "60"
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3025,6 +3025,8 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-database
+          - name: SECRET_KEY_BASE
+            value: rails/32947
           - name: THINKING_SPHINX_ADDRESS
             value: 0.0.0.0
           - name: THINKING_SPHINX_CONFIGURATION_FILE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
@@ -3033,10 +3033,6 @@ objects:
             value: db/sphinx/production.conf
           - name: THINKING_SPHINX_PID_FILE
             value: db/sphinx/searchd.pid
-          - name: DELTA_INDEX_INTERVAL
-            value: "5"
-          - name: FULL_REINDEX_INTERVAL
-            value: "60"
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2574,10 +2574,6 @@ objects:
             value: db/sphinx/production.conf
           - name: THINKING_SPHINX_PID_FILE
             value: db/sphinx/searchd.pid
-          - name: DELTA_INDEX_INTERVAL
-            value: "5"
-          - name: FULL_REINDEX_INTERVAL
-            value: "60"
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-ha.yml
@@ -2566,6 +2566,8 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-database
+          - name: SECRET_KEY_BASE
+            value: rails/32947
           - name: THINKING_SPHINX_ADDRESS
             value: 0.0.0.0
           - name: THINKING_SPHINX_CONFIGURATION_FILE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3046,10 +3046,6 @@ objects:
             value: db/sphinx/production.conf
           - name: THINKING_SPHINX_PID_FILE
             value: db/sphinx/searchd.pid
-          - name: DELTA_INDEX_INTERVAL
-            value: "5"
-          - name: FULL_REINDEX_INTERVAL
-            value: "60"
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml
@@ -3038,6 +3038,8 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-database
+          - name: SECRET_KEY_BASE
+            value: rails/32947
           - name: THINKING_SPHINX_ADDRESS
             value: 0.0.0.0
           - name: THINKING_SPHINX_CONFIGURATION_FILE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3280,10 +3280,6 @@ objects:
             value: db/sphinx/production.conf
           - name: THINKING_SPHINX_PID_FILE
             value: db/sphinx/searchd.pid
-          - name: DELTA_INDEX_INTERVAL
-            value: "5"
-          - name: FULL_REINDEX_INTERVAL
-            value: "60"
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp-s3.yml
@@ -3272,6 +3272,8 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-database
+          - name: SECRET_KEY_BASE
+            value: rails/32947
           - name: THINKING_SPHINX_ADDRESS
             value: 0.0.0.0
           - name: THINKING_SPHINX_CONFIGURATION_FILE

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3098,10 +3098,6 @@ objects:
             value: db/sphinx/production.conf
           - name: THINKING_SPHINX_PID_FILE
             value: db/sphinx/searchd.pid
-          - name: DELTA_INDEX_INTERVAL
-            value: "5"
-          - name: FULL_REINDEX_INTERVAL
-            value: "60"
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:

--- a/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
+++ b/pkg/3scale/amp/auto-generated-templates/amp/amp.yml
@@ -3090,6 +3090,8 @@ objects:
               secretKeyRef:
                 key: URL
                 name: system-database
+          - name: SECRET_KEY_BASE
+            value: rails/32947
           - name: THINKING_SPHINX_ADDRESS
             value: 0.0.0.0
           - name: THINKING_SPHINX_CONFIGURATION_FILE

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -162,6 +162,7 @@ func (system *System) buildSystemSphinxEnv() []v1.EnvVar {
 	result = append(result,
 		helper.EnvVarFromConfigMap("RAILS_ENV", "system-environment", "RAILS_ENV"),
 		helper.EnvVarFromSecret("DATABASE_URL", SystemSecretSystemDatabaseSecretName, SystemSecretSystemDatabaseURLFieldName),
+		helper.EnvVarFromValue("SECRET_KEY_BASE", "rails/32947"),
 		helper.EnvVarFromValue("THINKING_SPHINX_ADDRESS", "0.0.0.0"),
 		helper.EnvVarFromValue("THINKING_SPHINX_CONFIGURATION_FILE", "db/sphinx/production.conf"),
 		helper.EnvVarFromValue("THINKING_SPHINX_PID_FILE", "db/sphinx/searchd.pid"),

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -166,8 +166,6 @@ func (system *System) buildSystemSphinxEnv() []v1.EnvVar {
 		helper.EnvVarFromValue("THINKING_SPHINX_ADDRESS", "0.0.0.0"),
 		helper.EnvVarFromValue("THINKING_SPHINX_CONFIGURATION_FILE", "db/sphinx/production.conf"),
 		helper.EnvVarFromValue("THINKING_SPHINX_PID_FILE", "db/sphinx/searchd.pid"),
-		helper.EnvVarFromValue("DELTA_INDEX_INTERVAL", "5"),
-		helper.EnvVarFromValue("FULL_REINDEX_INTERVAL", "60"),
 	)
 	result = append(result, system.SystemRedisEnvVars()...)
 	return result


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/THREESCALE-8491

Rails 5.2 fails not only the web server but also other tasks
when secret_key_base is not present. Adding a dummy value here
to workaround that.

Also usage of DELTA_INDEX_INTERVAL and FULL_REINDEX_INTERVAL
was removed in 3scale/porta@4b01db2

See rails/rails#32947