### PR TITLE
fix circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,7 @@ jobs:
   unit-tests-coverage:
     docker:
       - image: circleci/golang:1.13.7
+    resource_class: large
     steps:
       - unit-tests
       - run:


### PR DESCRIPTION
Unittest memory footpring increased up to 7.5 GB and requires large resource class. 

https://github.com/3scale/3scale-operator/pull/742#issuecomment-1160226259

Opened issue to try to fix the memory footpring: https://issues.redhat.com/browse/THREESCALE-8493