### PR TITLE
THREESCALE-8476 fix domain resync command line

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -419,7 +419,7 @@ spec:
                 - name: RELATED_IMAGE_ZYNC_POSTGRESQL
                   value: centos/postgresql-10-centos7
                 - name: RELATED_IMAGE_OC_CLI
-                  value: quay.io/openshift/origin-cli:4.2
+                  value: quay.io/openshift/origin-cli:4.7
                 image: quay.io/3scale/3scale-operator:master
                 name: manager
                 ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,5 +70,5 @@ spec:
         - name: RELATED_IMAGE_ZYNC_POSTGRESQL
           value: "centos/postgresql-10-centos7"
         - name: RELATED_IMAGE_OC_CLI
-          value: "quay.io/openshift/origin-cli:4.2"
+          value: "quay.io/openshift/origin-cli:4.7"
       terminationGracePeriodSeconds: 10

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -41,5 +41,5 @@ func ZyncPostgreSQLImageURL() string {
 }
 
 func OCCLIImageURL() string {
-	return "quay.io/openshift/origin-cli:4.2"
+	return "quay.io/openshift/origin-cli:4.7"
 }

--- a/pkg/restore/apimanager_restore.go
+++ b/pkg/restore/apimanager_restore.go
@@ -402,7 +402,7 @@ func (b *APIManagerRestore) zyncResyncDomainsContainerArgs() string {
 		exit 1
 	fi
 	podname=$(echo -n $dcpods | awk '{print $1}')
-	oc exec ${podname} bash -- -c "bundle exec rake zync:resync:domains"
+	oc exec ${podname} -- bash -c "bundle exec rake zync:resync:domains"
 `
 }
 


### PR DESCRIPTION
### what

Fixes https://issues.redhat.com/browse/THREESCALE-8476

Downstream version of the operator is using `registry.redhat.io/openshift4/ose-cli:v4.7`. In this version, the command line `oc exec ${podname} bash -- -c "bundle exec rake zync:resync:domains"` fails. Indeed, the command line syntax is not correct. It has been working until now because the upstream version of the cli was `quay.io/openshift/origin-cli:4.2` shipping `oc` version 4.2. For this version, the above command line just **works**, But, it shouldn't. And it was fixed. In `oc` 4.7, as expected, it does not work. 

So this PR, fixes the command line and upgrades the image containing `oc` to 4.7

### Verification Steps

Those defined in https://github.com/3scale/3scale-operator/pull/758

