### PR TITLE
THREESCALE-7055 - fix: add finalizer permissions for developer user and developer account

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -691,6 +691,18 @@ spec:
         - apiGroups:
           - capabilities.3scale.net
           resources:
+          - developeraccounts/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
           - developeraccounts/status
           verbs:
           - get
@@ -700,6 +712,18 @@ spec:
           - capabilities.3scale.net
           resources:
           - developerusers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - developerusers/finalizers
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -280,6 +280,18 @@ rules:
 - apiGroups:
   - capabilities.3scale.net
   resources:
+  - developeraccounts/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
   - developeraccounts/status
   verbs:
   - get
@@ -289,6 +301,18 @@ rules:
   - capabilities.3scale.net
   resources:
   - developerusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - capabilities.3scale.net
+  resources:
+  - developerusers/finalizers
   verbs:
   - create
   - delete

--- a/controllers/capabilities/developeraccount_controller.go
+++ b/controllers/capabilities/developeraccount_controller.go
@@ -52,6 +52,7 @@ var _ reconcile.Reconciler = &DeveloperAccountReconciler{}
 
 // +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developeraccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developeraccounts/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developeraccounts/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 func (r *DeveloperAccountReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/capabilities/developeruser_controller.go
+++ b/controllers/capabilities/developeruser_controller.go
@@ -53,6 +53,7 @@ var _ reconcile.Reconciler = &DeveloperUserReconciler{}
 
 // +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developerusers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developerusers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=capabilities.3scale.net,namespace=placeholder,resources=developerusers/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 func (r *DeveloperUserReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Logger().WithValues("developeruser", req.NamespacedName)


### PR DESCRIPTION
# Description
Missing finalizer permissions for developer user and developer account for an OLM install. 

The following developer user reconcile error happens due to missing permissions

```
{"level":"error","ts":1658829782.950092,"logger":"controller","msg":"Reconciler error","reconcilerGroup":"capabilities.3scale.net","reconcilerKind":"DeveloperUser","controller":"developeruser","name":"hsdg6wfltms","namespace":"3scale-alpha-190","error":"developerusers.capabilities.3scale.net \"hsdg6wfltms\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/remote-source/deps/gomod/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:246\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:218\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.3/pkg/internal/controller/controller.go:197\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90"}
```