### PR TITLE
Adressing proxy promotion issues

### DIFF
--- a/controllers/capabilities/proxyconfigpromote_controller.go
+++ b/controllers/capabilities/proxyconfigpromote_controller.go
@@ -189,6 +189,8 @@ func (r *ProxyConfigPromoteReconciler) proxyConfigPromoteReconciler(proxyConfigP
 			if err != nil {
 				statusReconciler := NewProxyConfigPromoteStatusReconciler(r.BaseReconciler, proxyConfigPromote, "Failed", productIDStr, latestProductionVersion, latestStagingVersion, err)
 				return statusReconciler, err
+			} else {
+				latestProductionVersion = latestStagingVersion
 			}
 
 		}

--- a/doc/proxyConfigPromote-reference.md
+++ b/doc/proxyConfigPromote-reference.md
@@ -2,30 +2,30 @@
 
 ## Table of Contents
 
-* [ProxyConfigPromote CRD Reference](#proxyconfigpromote-crd-reference)
-    * [ProxyConfigPromote](#proxyconfigpromote)
-        * [ProxyConfigPromoteSpec](#proxyconfigpromotespec)
-            * [Provider Account Reference](#provider-account-reference)
-        * [ProxyConfigPromoteStatus](#proxyconfigpromotestatus)
-            * [ConditionSpec](#conditionspec)
+* [ProxyConfigPromote](#proxyconfigpromote)
+    * [ProxyConfigPromoteSpec](#proxyconfigpromotespec)
+        * [Provider Account Reference](#provider-account-reference)
+    * [ProxyConfigPromoteStatus](#proxyconfigpromotestatus)
+        * [ConditionSpec](#conditionspec)
 
 
 Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc)
 
 ## ProxyConfigPromote
 
-| **Field** | **json field**| **Type**                                          | **Info** |
-| --- | --- |---------------------------------------------------| --- |
+| **Field** | **json field**| **Type** | **Info** |
+| --- | --- | --- | --- |
 | Spec | `spec` | [ProxyConfigPromoteSpec](#ProxyConfigPromoteSpec) | The specfication for the custom resource |
-| Status | `status` | [ProxyConfigPromoteStatus](#ProxyConfigPromoteStatus)        | The status for the custom resource |
+| Status | `status` | [ProxyConfigPromoteStatus](#ProxyConfigPromoteStatus) | The status for the custom resource |
 
 ### ProxyConfigPromoteSpec
 
-| **Field**                  | **json field**       | **Type** | **Info**                                                                                                                                                   | **Required** |
-|----------------------------|----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
-| ProductCRName              | `productCRName`      | string   | Name of product Cr                                                                                                                                         | Yes          |
-| Production                 | `production`         | bool     | If true promotes to production, if false promotes to staging                                                                                               | No           |
-| DeleteCR                   | `deleteCR`           | bool     | If true deletes the resource after a succesfull promotion                                                                                                  | No           |                                                                            | No |
+| **Field** | **json field**| **Type** | **Info** | **Required** |
+| --- | --- | --- | --- | --- |
+| ProductCRName | `productCRName` | string | Name of product Cr| Yes |
+| Production | `production` | bool | If true promotes to production, if false promotes to staging | No |
+| DeleteCR | `deleteCR` | bool | If true deletes the resource after a succesfull promotion | No |
+| Provider Account Reference | `providerAccountRef` | object | [Provider account credentials secret reference](#provider-account-reference) | No |
 
 #### Provider Account Reference
 
@@ -54,11 +54,11 @@ stringData:
 
 ### ProxyConfigPromoteStatus
 
-| **Field**           | **json field**       | **Type** | **Info**                                                                    |
-|---------------------|----------------------| --- |-----------------------------------------------------------------------------|
-| ProductId          | `productId`          | string | Internal ID of promted product                                              |
-| LatestProductionVersion | `latestProductionVersion` | string | int with the current version in the production environment      |
-| LatestStagingVersion | `latestStagingVersion` | string | int with the current version in the staging environment      |
+| **Field** | **json field** | **Type** | **Info** |
+| --- | --- | --- | --- |
+| ProductId | `productId` | string | Internal ID of promted product |
+| LatestProductionVersion | `latestProductionVersion` | string | int with the current version in the production environment |
+| LatestStagingVersion | `latestStagingVersion` | string | int with the current version in the staging environment |
 | Conditions | `conditions` | array of [conditions](#ConditionSpec) | resource conditions |
 
 For example:

--- a/doc/proxyConfigPromote-reference.md
+++ b/doc/proxyConfigPromote-reference.md
@@ -2,10 +2,13 @@
 
 ## Table of Contents
 
-* [ProxyConfigPromote](#proxyconfigpromote)
-    * [ProxyConfigPromoteSpec](#proxyconfigpromotespec)
-        * [Provider Account Reference](#provider-account-reference)
-    * [ProxyConfigPromoteStatus](#proxyconfigpromotestatus)
+* [ProxyConfigPromote CRD Reference](#proxyconfigpromote-crd-reference)
+    * [ProxyConfigPromote](#proxyconfigpromote)
+        * [ProxyConfigPromoteSpec](#proxyconfigpromotespec)
+            * [Provider Account Reference](#provider-account-reference)
+        * [ProxyConfigPromoteStatus](#proxyconfigpromotestatus)
+            * [ConditionSpec](#conditionspec)
+
 
 Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdown-toc)
 
@@ -24,6 +27,30 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 | Production                 | `production`         | bool     | If true promotes to production, if false promotes to staging                                                                                               | No           |
 | DeleteCR                   | `deleteCR`           | bool     | If true deletes the resource after a succesfull promotion                                                                                                  | No           |                                                                            | No |
 
+#### Provider Account Reference
+
+Provider account credentials secret referenced by a [v1.LocalObjectReference](https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#localobjectreference-v1-core) type object.
+
+The secret must have `adminURL` and `token` fields with tenant credentials.
+Tenant controller will fetch the secret and read the following fields:
+
+| **Field** | **Description** | **Required** |
+| --- | --- | --- |
+| *token* | Provider account access token with *Account Management API* scope and *Read & Write* permission | Yes |
+| *adminURL* | Provider account's domain URL | Yes |
+
+For example:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mytenant
+type: Opaque
+stringData:
+  adminURL: https://my3scale-admin.example.com:443
+  token: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+```
 
 ### ProxyConfigPromoteStatus
 


### PR DESCRIPTION
# What 

Addressing issues raised in this [comment ](https://issues.redhat.com/browse/THREESCALE-7135)

# Verification 

1. Deploy 3scale-operator locally 

2.Create dummy smtp secret
```sh
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```

3.Create apimanager resource
```sh
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata: 
  name: apimanager-sample
  namespace: 3scale-test
spec: 
  system: 
    fileStorage: 
      simpleStorageService: 
        configurationSecretRef: 
          name: s3-credentials
  wildcardDomain: <cluster_domain>
EOF
```
cluster domain example : `apps.pstefans.uq32.s1.devshift.org`


4. Create Backend resource
```sh
kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend1-cr
  namespace: 3scale-test
spec:
  mappingRules:
    - httpMethod: GET
      increment: 1
      last: true
      metricMethodRef: hits
      pattern: /
  name: backend1
  privateBaseURL: 'https://api.example.com'
  systemName: backend1
EOF
```

5. Create product resources with the backend referenced
```sh
kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1-cr
  namespace: 3scale-test
spec:
  name: product1
  backendUsages:
    backend1:
      path: /
EOF
```

6. Create proxyconfigpromote resources  to promote product to staging.
```sh
kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product1-v1-staging
  namespace: 3scale-test
spec:
  productCRName: product1-cr
 production: true
EOF
```

7. In 3scale UI check that product1 configuration was promoted to staging and that the CR now correctly reflects the staging and production versions.


