### PR TITLE
Update the ProxyConfigPromote status when the product not found

### DIFF
--- a/controllers/capabilities/proxyconfigpromote_controller.go
+++ b/controllers/capabilities/proxyconfigpromote_controller.go
@@ -76,7 +76,9 @@ func (r *ProxyConfigPromoteReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 	err = r.Client().Get(r.Context(), projectMeta, product)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Info("resource not found. Ignoring since object must have been deleted")
+			statusReconciler := NewProxyConfigPromoteStatusReconciler(r.BaseReconciler, proxyConfigPromote, "Failed", "product not found", 0, 0, err)
+			statusReconciler.Reconcile()
+			reqLogger.Info("product not found. Ignoring since object must have been deleted")
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, err
@@ -100,10 +102,10 @@ func (r *ProxyConfigPromoteReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		statusResult, statusUpdateErr := statusReconciler.Reconcile()
 		if statusUpdateErr != nil {
 			if reconcileErr != nil {
-				return ctrl.Result{}, fmt.Errorf("Failed to reconcile activedoc: %v. Failed to update activedoc status: %w", reconcileErr, statusUpdateErr)
+				return ctrl.Result{}, fmt.Errorf("Failed to reconcile proxyConfigPromote: %v. Failed to update proxyConfigPromote status: %w", reconcileErr, statusUpdateErr)
 			}
 
-			return ctrl.Result{}, fmt.Errorf("Failed to update activedoc status: %w", statusUpdateErr)
+			return ctrl.Result{}, fmt.Errorf("Failed to update proxyConfigPromote status: %w", statusUpdateErr)
 		}
 
 		if statusResult.Requeue {


### PR DESCRIPTION
## WHAT
update the status in ProxyConfigPromote if the Product is not found

## Verification
1. Deploy 3scale-operator locally
2. Create dummy smtp secret
```bash
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
3.Create apimanager resource
```bash
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata: 
  name: apimanager-sample
  namespace: 3scale-test
spec: 
  system: 
    fileStorage: 
      simpleStorageService: 
        configurationSecretRef: 
          name: s3-credentials
  wildcardDomain: <cluster_domain>
EOF
```
4. As no products exist create proxyconfigpromote resource to promote  non existing product to staging.
```bash
kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product1-v1-staging
  namespace: 3scale-test
spec:
  productCRName: product1-cr-wrong-name
EOF
```
5. Confirm that the status updates as follows e.g.
```yaml
status:
  conditions:
    - lastTransitionTime: '2022-08-05T10:58:44Z'
      status: 'False'
      type: Ready
  productId: product not found
```

