### PR TITLE
Fix recaptcha field name

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -635,7 +635,7 @@ The available configurable secrets are:
 | **Field** | **Description** | **Default value** |
 | --- | --- | --- |
 | PUBLIC_KEY | reCAPTCHA site key (used in spam protection) for System| `""` |
-| SECRET_KEY | reCAPTCHA secret key (used in spam protection) for System| `""` |
+| PRIVATE_KEY | reCAPTCHA secret key (used in spam protection) for System| `""` |
 
 ### system-redis
 


### PR DESCRIPTION
SECRET_KEY recaptcha field name is incorrect or outdated. The correct field name is PRIVATE _KEY.