### PR TITLE
v0.0.0 in master

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.10.0"
+	Version = "0.0.0"
 )


### PR DESCRIPTION
`v0.0.0` in master

like in https://github.com/3scale/3scale-operator/blob/master/pkg/3scale/amp/product/3scale_release.go#L4

These fields are updated on release branch