### PR TITLE
bump version 2.13

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -381,7 +381,7 @@ spec:
                 com.company: Red_Hat
                 control-plane: controller-manager
                 rht.comp: 3scale
-                rht.comp_ver: master
+                rht.comp_ver: "2.13"
                 rht.prod_name: Red_Hat_Integration
                 rht.prod_ver: master
                 rht.subcomp: 3scale_operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
         rht.prod_name: Red_Hat_Integration
         rht.prod_ver: master
         rht.comp: 3scale
-        rht.comp_ver: master
+        rht.comp_ver: "2.13"
         rht.subcomp: 3scale_operator
         rht.subcomp_t: infrastructure
     spec:

--- a/pkg/3scale/amp/product/3scale_release.go
+++ b/pkg/3scale/amp/product/3scale_release.go
@@ -1,5 +1,5 @@
 package product
 
 var (
-	ThreescaleRelease = "master"
+	ThreescaleRelease = "2.13"
 )


### PR DESCRIPTION
Master will include target release version, like https://github.com/3scale/3scale-operator/blob/master/version/version.go