### PR TITLE
THREESCALE-8491 upgrade system sphinx secret key env var

### DIFF
--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -5,6 +5,7 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/upgrade"
 	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
@@ -118,6 +119,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigAffinityMutator,
 		reconcilers.DeploymentConfigTolerationsMutator,
 		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
+		upgrade.SphinxSecretKeyEnvVarMutator,
 	)
 	err = r.ReconcileDeploymentConfig(system.SphinxDeploymentConfig(), sphinxDCmutator)
 	if err != nil {

--- a/pkg/3scale/amp/upgrade/sphinx-deployment-secret-key-base.go
+++ b/pkg/3scale/amp/upgrade/sphinx-deployment-secret-key-base.go
@@ -1,0 +1,18 @@
+package upgrade
+
+import (
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+func SphinxSecretKeyEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	//  SECRET_KEY_BASE added
+	updated := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "SECRET_KEY_BASE")
+	// DELTA_INDEX_INTERVAL removed
+	tmp := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "DELTA_INDEX_INTERVAL")
+	updated = updated || tmp
+	// FULL_REINDEX_INTERVAL removed
+	tmp = reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "FULL_REINDEX_INTERVAL")
+	updated = updated || tmp
+	return updated, nil
+}


### PR DESCRIPTION
### what

Completes https://issues.redhat.com/browse/THREESCALE-8491 after #762 

### how

Adding env var mutator to the sphinx deployment resource to 
* SECRET_KEY_BASE added 
* DELTA_INDEX_INTERVAL removed
* FULL_REINDEX_INTERVAL removed

### verification steps

Deploy 2.12

```
git checkout 3scale-2.12.0-GA
```
```
make run
```

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: eguzki.apps.dev-eng-ocp4-operator.dev.3sca.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
Check sphinx deployment config does not have the  `SECRET_KEY_BASE` env var
```
k get dc system-sphinx -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SECRET_KEY_BASE")].value}'
```
Check sphinx deployment config has the  `DELTA_INDEX_INTERVAL` env var
```
k get dc system-sphinx -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="DELTA_INDEX_INTERVAL")].value}'
5
```
Check sphinx deployment config has the  `FULL_REINDEX_INTERVAL` env var
```
k get dc system-sphinx -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="FULL_REINDEX_INTERVAL")].value}'
60
```
Kill 2.12 operator with `CTRL+c` and move git workspace to `upgrade-system-sphinx-secret-key` branch

```
git checkout upgrade-system-sphinx-secret-key
```

Run the controller to perform upgrade

```
make run
```
wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
Check sphinx deployment config has the  `SECRET_KEY_BASE` env var
```
k get dc system-sphinx -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SECRET_KEY_BASE")].value}'
rails/32947
```
Check sphinx deployment config does not have the  `DELTA_INDEX_INTERVAL` env var
```
k get dc system-sphinx -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="DELTA_INDEX_INTERVAL")].value}'
```
Check sphinx deployment config does not have the  `FULL_REINDEX_INTERVAL` env var
```
k get dc system-sphinx -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="FULL_REINDEX_INTERVAL")].value}'
```
