### PR TITLE
THREESCALE-8754 Enhance replica reconciliation

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -763,11 +763,6 @@ func (apimanager *APIManager) setApicastSpecDefaults() bool {
 	return changed
 }
 
-func (apimanager *APIManager) defaultReplicas() *int64 {
-	var defaultReplicas int64 = 1
-	return &defaultReplicas
-}
-
 func (apimanager *APIManager) setBackendSpecDefaults() bool {
 	changed := false
 	spec := &apimanager.Spec
@@ -919,16 +914,6 @@ func (apimanager *APIManager) setZyncDefaults() bool {
 
 	if spec.Zync.QueSpec == nil {
 		spec.Zync.QueSpec = &ZyncQueSpec{}
-		changed = true
-	}
-
-	if spec.Zync.AppSpec.Replicas == nil {
-		spec.Zync.AppSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
-	if spec.Zync.QueSpec.Replicas == nil {
-		spec.Zync.QueSpec.Replicas = apimanager.defaultReplicas()
 		changed = true
 	}
 

--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -760,16 +760,6 @@ func (apimanager *APIManager) setApicastSpecDefaults() bool {
 		changed = true
 	}
 
-	if spec.Apicast.StagingSpec.Replicas == nil {
-		spec.Apicast.StagingSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
-	if spec.Apicast.ProductionSpec.Replicas == nil {
-		spec.Apicast.ProductionSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
 	return changed
 }
 

--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -866,16 +866,6 @@ func (apimanager *APIManager) setSystemSpecDefaults() (bool, error) {
 		changed = true
 	}
 
-	if spec.System.AppSpec.Replicas == nil {
-		spec.System.AppSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
-	if spec.System.SidekiqSpec.Replicas == nil {
-		spec.System.SidekiqSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
 	return changed, nil
 }
 

--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -802,21 +802,6 @@ func (apimanager *APIManager) setBackendSpecDefaults() bool {
 		changed = true
 	}
 
-	if spec.Backend.ListenerSpec.Replicas == nil {
-		spec.Backend.ListenerSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
-	if spec.Backend.CronSpec.Replicas == nil {
-		spec.Backend.CronSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
-	if spec.Backend.WorkerSpec.Replicas == nil {
-		spec.Backend.WorkerSpec.Replicas = apimanager.defaultReplicas()
-		changed = true
-	}
-
 	return changed
 }
 

--- a/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/apis/apps/v1alpha1/apimanager_types_test.go
@@ -45,12 +45,8 @@ func TestSetDefaults(t *testing.T) {
 				ApicastManagementAPI: &tmpDefaultApicastManagementAPI,
 				OpenSSLVerify:        &tmpDefaultApicastOpenSSLVerify,
 				RegistryURL:          &tmpDefaultApicastRegistryURL,
-				ProductionSpec: &ApicastProductionSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
-				StagingSpec: &ApicastStagingSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
+				ProductionSpec:       &ApicastProductionSpec{},
+				StagingSpec:          &ApicastStagingSpec{},
 			},
 			Backend: &BackendSpec{
 				ListenerSpec: &BackendListenerSpec{},

--- a/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/apis/apps/v1alpha1/apimanager_types_test.go
@@ -53,15 +53,9 @@ func TestSetDefaults(t *testing.T) {
 				},
 			},
 			Backend: &BackendSpec{
-				ListenerSpec: &BackendListenerSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
-				WorkerSpec: &BackendWorkerSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
-				CronSpec: &BackendCronSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
+				ListenerSpec: &BackendListenerSpec{},
+				WorkerSpec:   &BackendWorkerSpec{},
+				CronSpec:     &BackendCronSpec{},
 			},
 			System: &SystemSpec{
 				AppSpec: &SystemAppSpec{

--- a/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/apis/apps/v1alpha1/apimanager_types_test.go
@@ -21,8 +21,6 @@ func TestSetDefaults(t *testing.T) {
 	tmpDefaultApicastResponseCodes := defaultApicastResponseCodes
 	tmpDefaultApicastRegistryURL := defaultApicastRegistryURL
 
-	var tmpDefaultReplicas int64 = 1
-
 	inputAPIManager := minimumAPIManagerTest()
 
 	expectedAPIManager := APIManager{
@@ -59,12 +57,8 @@ func TestSetDefaults(t *testing.T) {
 				SphinxSpec:  &SystemSphinxSpec{},
 			},
 			Zync: &ZyncSpec{
-				AppSpec: &ZyncAppSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
-				QueSpec: &ZyncQueSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
+				AppSpec: &ZyncAppSpec{},
+				QueSpec: &ZyncQueSpec{},
 			},
 			PodDisruptionBudget: nil,
 		},

--- a/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/apis/apps/v1alpha1/apimanager_types_test.go
@@ -54,13 +54,9 @@ func TestSetDefaults(t *testing.T) {
 				CronSpec:     &BackendCronSpec{},
 			},
 			System: &SystemSpec{
-				AppSpec: &SystemAppSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
-				SidekiqSpec: &SystemSidekiqSpec{
-					Replicas: &tmpDefaultReplicas,
-				},
-				SphinxSpec: &SystemSphinxSpec{},
+				AppSpec:     &SystemAppSpec{},
+				SidekiqSpec: &SystemSidekiqSpec{},
+				SphinxSpec:  &SystemSphinxSpec{},
 			},
 			Zync: &ZyncSpec{
 				AppSpec: &ZyncAppSpec{

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -93,11 +93,6 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 | **Annotations**  | **Name** | **Default value** | **Description** |
 | --- | --- | --- | --- |
 | `apps.3scale.net/disable-apicast-service-reconciler` | disableApicastPortReconcile | `false` | Can be `true` or `false` - will disable apicast service port reconcile when true |
-| `apps.3scale.net/disable-apicast-production-replica-reconciler` | disableApicastProductionReplicaReconciler | `false` | Can be `true` or `false` - will disable apicast production replicas reconcile when true |
-| `apps.3scale.net/disable-apicast-staging-replica-reconciler` | disableApicastStagingReplicaReconciler | `false` | Can be `true` or `false` - will disable apicast staging replicas reconcile when true |
-| `apps.3scale.net/disable-backend-listener-replica-reconciler` | disableBackendListenerReplicasReconciler | `false` | Can be `true` or `false` - will disable backend listener replicas reconcile when true |
-| `apps.3scale.net/disable-backend-worker-replica-reconciler` | disableBackendWorkerReplicasReconciler | `false` | Can be `true` or `false` - will disable backend worker replicas reconcile when true |
-| `apps.3scale.net/disable-cron-replica-reconciler` | disableCronReplicasReconciler | `false` | Can be `true` or `false` - will disable backend cron replicas reconcile when true |
 
 ### ApicastSpec
 

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -572,7 +572,7 @@ func (system *System) AppDeploymentConfig() *appsv1.DeploymentConfig {
 							Kind: "ImageStreamTag",
 							Name: fmt.Sprintf("amp-system:%s", system.Options.ImageTag)}}},
 			},
-			Replicas: *system.Options.AppReplicas,
+			Replicas: system.Options.AppReplicas,
 			Selector: map[string]string{"deploymentConfig": SystemAppDeploymentName},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -807,7 +807,7 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 							Kind: "ImageStreamTag",
 							Name: fmt.Sprintf("amp-system:%s", system.Options.ImageTag)}}},
 			},
-			Replicas: *system.Options.SidekiqReplicas,
+			Replicas: system.Options.SidekiqReplicas,
 			Selector: map[string]string{"deploymentConfig": SystemSidekiqName},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -48,8 +48,8 @@ type SystemOptions struct {
 	S3FileStorageOptions  *S3FileStorageOptions  `validate:"required_without=PvcFileStorageOptions"`
 	PvcFileStorageOptions *PVCFileStorageOptions `validate:"required_without=S3FileStorageOptions"`
 
-	AppReplicas     *int32 `validate:"required"`
-	SidekiqReplicas *int32 `validate:"required"`
+	AppReplicas     int32
+	SidekiqReplicas int32
 
 	AdminAccessToken    string  `validate:"required"`
 	AdminPassword       string  `validate:"required"`

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -140,8 +140,15 @@ func (a *ApicastOptionsProvider) setNodeAffinityAndTolerationsOptions() {
 }
 
 func (a *ApicastOptionsProvider) setReplicas() {
-	a.apicastOptions.ProductionReplicas = int32(*a.apimanager.Spec.Apicast.ProductionSpec.Replicas)
-	a.apicastOptions.StagingReplicas = int32(*a.apimanager.Spec.Apicast.StagingSpec.Replicas)
+	a.apicastOptions.ProductionReplicas = 1
+	if a.apimanager.Spec.Apicast.ProductionSpec.Replicas != nil {
+		a.apicastOptions.ProductionReplicas = int32(*a.apimanager.Spec.Apicast.ProductionSpec.Replicas)
+	}
+
+	a.apicastOptions.StagingReplicas = 1
+	if a.apimanager.Spec.Apicast.StagingSpec.Replicas != nil {
+		a.apicastOptions.StagingReplicas = int32(*a.apimanager.Spec.Apicast.StagingSpec.Replicas)
+	}
 }
 
 func (a *ApicastOptionsProvider) commonLabels() map[string]string {

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -17,11 +17,6 @@ import (
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 )
 
-const (
-	disableApicastProductionReplicaReconciler = "apps.3scale.net/disable-apicast-production-replica-reconciler"
-	disableApicastStagingReplicaReconciler    = "apps.3scale.net/disable-apicast-staging-replica-reconciler"
-)
-
 func ApicastEnvCMMutator(existingObj, desiredObj common.KubernetesObject) (bool, error) {
 	existing, ok := existingObj.(*v1.ConfigMap)
 	if !ok {
@@ -85,7 +80,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		apicastPodTemplateEnvConfigMapAnnotationsMutator,
 	}
 
-	if value, found := r.apiManager.ObjectMeta.Annotations[disableApicastStagingReplicaReconciler]; !found || value != "true" {
+	if r.apiManager.Spec.Apicast.StagingSpec.Replicas != nil {
 		stagingMutators = append(stagingMutators, reconcilers.DeploymentConfigReplicasMutator)
 	}
 
@@ -117,7 +112,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		apicastPodTemplateEnvConfigMapAnnotationsMutator,
 	}
 
-	if value, found := r.apiManager.ObjectMeta.Annotations[disableApicastProductionReplicaReconciler]; !found || value != "true" {
+	if r.apiManager.Spec.Apicast.ProductionSpec.Replicas != nil {
 		productionMutators = append(productionMutators, reconcilers.DeploymentConfigReplicasMutator)
 	}
 

--- a/pkg/3scale/amp/operator/apicast_reconciler_test.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler_test.go
@@ -799,11 +799,11 @@ func TestReplicaApicastReconciler(t *testing.T) {
 		apimanager               *appsv1alpha1.APIManager
 		expectedAmountOfReplicas int32
 	}{
-		{"apicast-staging replicas set", "apicast-staging", apiManagerCreator(&oneValue64, nil), oneValue},
-		{"apicast-staging replicas not set", "apicast-staging", apiManagerCreator(nil, nil), twoValue},
+		{"apicast-staging replicas set", "apicast-staging", testApicastAPIManagerCreator(&oneValue64, nil), oneValue},
+		{"apicast-staging replicas not set", "apicast-staging", testApicastAPIManagerCreator(nil, nil), twoValue},
 
-		{"apicast-production replicas set", "apicast-production", apiManagerCreator(nil, &oneValue64), oneValue},
-		{"apicast-production replicas not set", "apicast-production", apiManagerCreator(nil, nil), twoValue},
+		{"apicast-production replicas set", "apicast-production", testApicastAPIManagerCreator(nil, &oneValue64), oneValue},
+		{"apicast-production replicas not set", "apicast-production", testApicastAPIManagerCreator(nil, nil), twoValue},
 	}
 
 	for _, tc := range cases {
@@ -859,7 +859,7 @@ func TestReplicaApicastReconciler(t *testing.T) {
 	}
 }
 
-func apiManagerCreator(stagingReplicas, productionReplicas *int64) *appsv1alpha1.APIManager {
+func testApicastAPIManagerCreator(stagingReplicas, productionReplicas *int64) *appsv1alpha1.APIManager {
 	var (
 		name                 = "example-apimanager"
 		namespace            = "operator-unittest"

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -142,9 +142,20 @@ func (o *OperatorBackendOptionsProvider) setNodeAffinityAndTolerationsOptions() 
 }
 
 func (o *OperatorBackendOptionsProvider) setReplicas() {
-	o.backendOptions.ListenerReplicas = int32(*o.apimanager.Spec.Backend.ListenerSpec.Replicas)
-	o.backendOptions.WorkerReplicas = int32(*o.apimanager.Spec.Backend.WorkerSpec.Replicas)
-	o.backendOptions.CronReplicas = int32(*o.apimanager.Spec.Backend.CronSpec.Replicas)
+	o.backendOptions.ListenerReplicas = 1
+	if o.apimanager.Spec.Backend.ListenerSpec.Replicas != nil {
+		o.backendOptions.ListenerReplicas = int32(*o.apimanager.Spec.Backend.ListenerSpec.Replicas)
+	}
+
+	o.backendOptions.WorkerReplicas = 1
+	if o.apimanager.Spec.Backend.WorkerSpec.Replicas != nil {
+		o.backendOptions.WorkerReplicas = int32(*o.apimanager.Spec.Backend.WorkerSpec.Replicas)
+	}
+
+	o.backendOptions.CronReplicas = 1
+	if o.apimanager.Spec.Backend.CronSpec.Replicas != nil {
+		o.backendOptions.CronReplicas = int32(*o.apimanager.Spec.Backend.CronSpec.Replicas)
+	}
 }
 
 func (o *OperatorBackendOptionsProvider) commonLabels() map[string]string {

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -34,8 +34,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Cron DC
 	cronConfigMutator := reconcilers.GenericBackendMutators()
-
-	if value, found := r.apiManager.ObjectMeta.Annotations[disableCronReplicasReconciler]; !found || value != "true" {
+	if r.apiManager.Spec.Backend.CronSpec.Replicas != nil {
 		cronConfigMutator = append(cronConfigMutator, reconcilers.DeploymentConfigReplicasMutator)
 	}
 
@@ -46,8 +45,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Listener DC
 	listenerConfigMutator := reconcilers.GenericBackendMutators()
-
-	if value, found := r.apiManager.ObjectMeta.Annotations[disableBackendListenerReplicasReconciler]; !found || value != "true" {
+	if r.apiManager.Spec.Backend.ListenerSpec.Replicas != nil {
 		listenerConfigMutator = append(listenerConfigMutator, reconcilers.DeploymentConfigReplicasMutator)
 	}
 
@@ -70,8 +68,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Worker DC
 	workerConfigMutator := reconcilers.GenericBackendMutators()
-
-	if value, found := r.apiManager.ObjectMeta.Annotations[disableBackendWorkerReplicasReconciler]; !found || value != "true" {
+	if r.apiManager.Spec.Backend.WorkerSpec.Replicas != nil {
 		workerConfigMutator = append(workerConfigMutator, reconcilers.DeploymentConfigReplicasMutator)
 	}
 

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -14,12 +14,6 @@ type BackendReconciler struct {
 	*BaseAPIManagerLogicReconciler
 }
 
-const (
-	disableBackendListenerReplicasReconciler = "apps.3scale.net/disable-backend-listener-replica-reconciler"
-	disableBackendWorkerReplicasReconciler   = "apps.3scale.net/disable-backend-worker-replica-reconciler"
-	disableCronReplicasReconciler            = "apps.3scale.net/disable-cron-replica-reconciler"
-)
-
 func NewBackendReconciler(baseAPIManagerLogicReconciler *BaseAPIManagerLogicReconciler) *BackendReconciler {
 	return &BackendReconciler{
 		BaseAPIManagerLogicReconciler: baseAPIManagerLogicReconciler,

--- a/pkg/3scale/amp/operator/backend_reconciler_test.go
+++ b/pkg/3scale/amp/operator/backend_reconciler_test.go
@@ -251,23 +251,3 @@ func backendApiManagerCreator(listenerReplicas, cronReplicas, workerReplicas *in
 		},
 	}
 }
-
-func confirmReplicasWhenAnnotationIsNotPresent(apiManager *appsv1alpha1.APIManager, dc *appsv1.DeploymentConfig, annotation string, annotationValue string, expectedValue int32) bool {
-	if !metav1.HasAnnotation(apiManager.ObjectMeta, annotation) {
-		if dc.Spec.Replicas != expectedValue {
-			return false
-		}
-	}
-
-	return true
-}
-
-func confirmReplicasWhenAnnotationPresent(apiManager *appsv1alpha1.APIManager, dc *appsv1.DeploymentConfig, annotation string, annotationValue string, expectedValue int32) bool {
-	if metav1.HasAnnotation(apiManager.ObjectMeta, annotation) && apiManager.Annotations[annotation] == annotationValue {
-		if dc.Spec.Replicas != expectedValue {
-			return false
-		}
-	}
-
-	return true
-}

--- a/pkg/3scale/amp/operator/backend_reconciler_test.go
+++ b/pkg/3scale/amp/operator/backend_reconciler_test.go
@@ -161,11 +161,11 @@ func TestReplicaBackendReconciler(t *testing.T) {
 		{"cron replicas set", "backend-cron", backendApiManagerCreator(nil, &oneValue64, nil), oneValue},
 		{"cron replicas not set", "backend-cron", backendApiManagerCreator(nil, nil, nil), twoValue},
 
-		//{"listener replicas set", "backend-listener", &appsv1.DeploymentConfig{}, backendApiManagerCreator("someAnnotation", "false"), disableBackendListenerReplicasReconciler, "dummy", int32(1), confirmReplicasWhenAnnotationIsNotPresent},
-		//{"listener replicas not set", "backend-listener", &appsv1.DeploymentConfig{}, backendApiManagerCreator(disableBackendListenerReplicasReconciler, "false"), disableBackendListenerReplicasReconciler, "false", int32(1), confirmReplicasWhenAnnotationPresent},
+		{"listener replicas set", "backend-listener", backendApiManagerCreator(&oneValue64, nil, nil), oneValue},
+		{"listener replicas not set", "backend-listener", backendApiManagerCreator(nil, nil, nil), twoValue},
 
-		//{"worker replicas set", "backend-worker", &appsv1.DeploymentConfig{}, backendApiManagerCreator("someAnnotation", "false"), disableBackendWorkerReplicasReconciler, "dummy", int32(1), confirmReplicasWhenAnnotationIsNotPresent},
-		//{"worker replicas not set", "backend-worker", &appsv1.DeploymentConfig{}, backendApiManagerCreator(disableBackendWorkerReplicasReconciler, "false"), disableBackendWorkerReplicasReconciler, "false", int32(1), confirmReplicasWhenAnnotationPresent},
+		{"worker replicas set", "backend-worker", backendApiManagerCreator(nil, nil, &oneValue64), oneValue},
+		{"worker replicas not set", "backend-worker", backendApiManagerCreator(nil, nil, nil), twoValue},
 	}
 
 	for _, tc := range cases {

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -458,10 +458,15 @@ func (s *SystemOptionsProvider) setFileStorageOptions() {
 }
 
 func (s *SystemOptionsProvider) setReplicas() {
-	appSecReplicas := int32(*s.apimanager.Spec.System.AppSpec.Replicas)
-	s.options.AppReplicas = &appSecReplicas
-	sidekiqReplicas := int32(*s.apimanager.Spec.System.SidekiqSpec.Replicas)
-	s.options.SidekiqReplicas = &sidekiqReplicas
+	s.options.AppReplicas = 1
+	if s.apimanager.Spec.System.AppSpec.Replicas != nil {
+		s.options.AppReplicas = int32(*s.apimanager.Spec.System.AppSpec.Replicas)
+	}
+
+	s.options.SidekiqReplicas = 1
+	if s.apimanager.Spec.System.SidekiqSpec.Replicas != nil {
+		s.options.SidekiqReplicas = int32(*s.apimanager.Spec.System.SidekiqSpec.Replicas)
+	}
 }
 
 func (s *SystemOptionsProvider) commonLabels() map[string]string {

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -19,9 +19,7 @@ import (
 )
 
 const (
-	systemAppReplicas     int64 = 3
-	systemSidekiqReplicas int64 = 4
-	apicastRegistryURL          = "http://otherapicast:8090/policies"
+	apicastRegistryURL = "http://otherapicast:8090/policies"
 )
 
 func testSystemCommonLabels() map[string]string {
@@ -221,16 +219,14 @@ func testSystemSphinxCustomResourceRequirements() *v1.ResourceRequirements {
 }
 
 func basicApimanagerSpecTestSystemOptions() *appsv1alpha1.APIManager {
-	tmpSystemAppReplicas := systemAppReplicas
-	tmpSystemSideKiqReplicas := systemSidekiqReplicas
 	tmpApicastRegistryURL := apicastRegistryURL
 
 	apimanager := basicApimanager()
 	apimanager.Spec.Apicast = &appsv1alpha1.ApicastSpec{RegistryURL: &tmpApicastRegistryURL}
 	apimanager.Spec.System = &appsv1alpha1.SystemSpec{
 		FileStorageSpec: &appsv1alpha1.SystemFileStorageSpec{},
-		AppSpec:         &appsv1alpha1.SystemAppSpec{Replicas: &tmpSystemAppReplicas},
-		SidekiqSpec:     &appsv1alpha1.SystemSidekiqSpec{Replicas: &tmpSystemSideKiqReplicas},
+		AppSpec:         &appsv1alpha1.SystemAppSpec{},
+		SidekiqSpec:     &appsv1alpha1.SystemSidekiqSpec{},
 		SphinxSpec:      &appsv1alpha1.SystemSphinxSpec{},
 	}
 	apimanager.Spec.PodDisruptionBudget = &appsv1alpha1.PodDisruptionBudgetSpec{Enabled: true}
@@ -299,8 +295,6 @@ func getSystemMasterApicastSecret() *v1.Secret {
 func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOptions {
 	recaptchaPublicKey := component.DefaultRecaptchaPublickey()
 	recaptchaPrivateKey := component.DefaultRecaptchaPrivatekey()
-	tmpSystemAppReplicas := int32(systemAppReplicas)
-	tmpSystemSideKiqReplicas := int32(systemSidekiqReplicas)
 	tmpSystemAdminEmail := component.DefaultSystemAdminEmail()
 	tmpSystemUserSessionTTL := component.DefaultUserSessionTTL()
 	tmpSMTPAddress := component.DefaultSystemSMTPAddress()
@@ -337,8 +331,8 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		AdminAccessToken:                          opts.AdminAccessToken,
 		MasterAccessToken:                         opts.MasterAccessToken,
 		ApicastAccessToken:                        opts.ApicastAccessToken,
-		AppReplicas:                               &tmpSystemAppReplicas,
-		SidekiqReplicas:                           &tmpSystemSideKiqReplicas,
+		AppReplicas:                               1,
+		SidekiqReplicas:                           1,
 		AdminEmail:                                &tmpSystemAdminEmail,
 		UserSessionTTL:                            &tmpSystemUserSessionTTL,
 		PvcFileStorageOptions: &component.PVCFileStorageOptions{

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -197,8 +197,15 @@ func (z *ZyncOptionsProvider) setNodeAffinityAndTolerationsOptions() {
 }
 
 func (z *ZyncOptionsProvider) setReplicas() {
-	z.zyncOptions.ZyncReplicas = int32(*z.apimanager.Spec.Zync.AppSpec.Replicas)
-	z.zyncOptions.ZyncQueReplicas = int32(*z.apimanager.Spec.Zync.QueSpec.Replicas)
+	z.zyncOptions.ZyncReplicas = 1
+	if z.apimanager.Spec.Zync.AppSpec.Replicas != nil {
+		z.zyncOptions.ZyncReplicas = int32(*z.apimanager.Spec.Zync.AppSpec.Replicas)
+	}
+
+	z.zyncOptions.ZyncQueReplicas = 1
+	if z.apimanager.Spec.Zync.QueSpec.Replicas != nil {
+		z.zyncOptions.ZyncQueReplicas = int32(*z.apimanager.Spec.Zync.QueSpec.Replicas)
+	}
 }
 
 func (z *ZyncOptionsProvider) commonLabels() map[string]string {

--- a/pkg/3scale/amp/operator/zync_reconciler.go
+++ b/pkg/3scale/amp/operator/zync_reconciler.go
@@ -45,13 +45,33 @@ func (r *ZyncReconciler) Reconcile() (reconcile.Result, error) {
 	}
 
 	// Zync DC
-	err = r.ReconcileDeploymentConfig(zync.DeploymentConfig(), reconcilers.GenericZyncMutators())
+	zyncMutators := []reconcilers.DCMutateFn{
+		reconcilers.DeploymentConfigImageChangeTriggerMutator,
+		reconcilers.DeploymentConfigContainerResourcesMutator,
+		reconcilers.DeploymentConfigAffinityMutator,
+		reconcilers.DeploymentConfigTolerationsMutator,
+		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
+	}
+	if r.apiManager.Spec.Zync.AppSpec.Replicas != nil {
+		zyncMutators = append(zyncMutators, reconcilers.DeploymentConfigReplicasMutator)
+	}
+	err = r.ReconcileDeploymentConfig(zync.DeploymentConfig(), reconcilers.DeploymentConfigMutator(zyncMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Zync Que DC
-	err = r.ReconcileDeploymentConfig(zync.QueDeploymentConfig(), reconcilers.GenericZyncMutators())
+	zyncQueMutators := []reconcilers.DCMutateFn{
+		reconcilers.DeploymentConfigImageChangeTriggerMutator,
+		reconcilers.DeploymentConfigContainerResourcesMutator,
+		reconcilers.DeploymentConfigAffinityMutator,
+		reconcilers.DeploymentConfigTolerationsMutator,
+		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
+	}
+	if r.apiManager.Spec.Zync.QueSpec.Replicas != nil {
+		zyncQueMutators = append(zyncQueMutators, reconcilers.DeploymentConfigReplicasMutator)
+	}
+	err = r.ReconcileDeploymentConfig(zync.QueDeploymentConfig(), reconcilers.DeploymentConfigMutator(zyncQueMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/prometheusrules/system_app_rules.go
+++ b/pkg/3scale/amp/prometheusrules/system_app_rules.go
@@ -35,7 +35,6 @@ func systemOptions(ns string) (*component.SystemOptions, error) {
 	o := component.NewSystemOptions()
 
 	tmp := "_"
-	var tmpInt int32 = 1
 
 	// Required options for generating PrometheusRules
 	o.CommonLabels = commonSystemLabels()
@@ -69,8 +68,8 @@ func systemOptions(ns string) (*component.SystemOptions, error) {
 	o.AppSecretKeyBase = "_"
 	o.BackendSharedSecret = "_"
 	o.TenantName = "_"
-	o.AppReplicas = &tmpInt
-	o.SidekiqReplicas = &tmpInt
+	o.AppReplicas = 1
+	o.SidekiqReplicas = 1
 	o.S3FileStorageOptions = &component.S3FileStorageOptions{ConfigurationSecretName: "_"}
 	o.SmtpSecretOptions = component.SystemSMTPSecretOptions{
 		Address:           &tmp,

--- a/pkg/reconcilers/deploymentconfig.go
+++ b/pkg/reconcilers/deploymentconfig.go
@@ -43,18 +43,6 @@ func DeploymentConfigMutator(opts ...DCMutateFn) MutateFn {
 	}
 }
 
-// GenericZyncMutators returns the generic mutators for zync components
-func GenericZyncMutators() MutateFn {
-	return DeploymentConfigMutator(
-		DeploymentConfigImageChangeTriggerMutator,
-		DeploymentConfigReplicasMutator,
-		DeploymentConfigContainerResourcesMutator,
-		DeploymentConfigAffinityMutator,
-		DeploymentConfigTolerationsMutator,
-		DeploymentConfigPodTemplateLabelsMutator,
-	)
-}
-
 // GenericBackendMutators returns the generic mutators for backend
 func GenericBackendMutators() []DCMutateFn {
 	return []DCMutateFn{

--- a/test/unitcontrollers/apimanager_controller_test.go
+++ b/test/unitcontrollers/apimanager_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	appscontrollers "github.com/3scale/3scale-operator/controllers/apps"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -114,13 +115,12 @@ func TestAPIManagerControllerCreate(t *testing.T) {
 		t.Fatalf("get APIManager: (%v)", err)
 	}
 
-	backendListenerExistingReplicas := finalAPIManager.Spec.Backend.ListenerSpec.Replicas
-	if backendListenerExistingReplicas == nil {
-		t.Errorf("APIManager's backend listener replicas does not have a default value set")
+	if finalAPIManager.Annotations == nil {
+		t.Error("APIManager's does not have annotations")
 
 	}
 
-	if *backendListenerExistingReplicas != 1 {
-		t.Errorf("APIManager's backend listener replicas size (%d) is not the expected size (%d)", backendListenerExistingReplicas, 1)
+	if val, ok := finalAPIManager.Annotations[appsv1alpha1.OperatorVersionAnnotation]; !ok || val != version.Version {
+		t.Error("APIManager's version annotation does not match")
 	}
 }


### PR DESCRIPTION
### what
Implements https://issues.redhat.com/browse/THREESCALE-8754

* Remove adding replica values to the CR
* Reconciliation (implemented by the mutator) only added when the `replicas` field is set

Components
- [x] backend listener
- [x] backend worker
- [x] backend cron
- [x] apicast staging
- [x] apicast production
- [x] system app
- [x] system sidekiq
- [x] zync
- [x] zync que

### Verification steps

run env

```
make install
make run
```
Deploy APIManager CR with no replica definition
```yaml
k apply -f -<<EOF
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: somekey
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: example.com
  AWS_REGION: us-east-1
type: Opaque
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: example.com
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```

Check that the APIManager  CR does not have replicas in the CR

```yaml
k get apimanager.apps.3scale.net/apimanager1 -o yaml
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  annotations:
    apps.3scale.net/apimanager-threescale-version: "2.13"
    apps.3scale.net/threescale-operator-version: 0.10.0
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"annotations":{},"name":"apimanager1","namespace":"3scale-operator-test"},"spec":{"resourceRequirementsEnabled":false,"system":{"fileStorage":{"simpleStorageService":{"configurationSecretRef":{"name":"aws-auth"}}}},"wildcardDomain":"3scale-operator-test.apps.dev-eng-ocp4-operator.dev.3sca.net"}}
  creationTimestamp: "2022-09-29T09:34:19Z"
  generation: 2
  name: apimanager1
  namespace: 3scale-operator-test
  resourceVersion: "9968928"
  uid: 14854404-5511-43fc-bfbb-181155e50aa3
spec:
  apicast:
    managementAPI: status
    openSSLVerify: false
    productionSpec: {}
    registryURL: http://apicast-staging:8090/policies
    responseCodes: true
    stagingSpec: {}
  appLabel: 3scale-api-management
  backend:
    cronSpec: {}
    listenerSpec: {}
    workerSpec: {}
  imageStreamTagImportInsecure: false
  resourceRequirementsEnabled: false
  system:
    appSpec: {}
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
    sidekiqSpec: {}
    sphinxSpec: {}
  tenantName: 3scale
  wildcardDomain: 3scale-operator-test.apps.dev-eng-ocp4-operator.dev.3sca.net
  zync:
    appSpec: {}
    queSpec: {}
```

Wait for deployment to be available
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
Let's pick one subcomponent (it should be the same for any one where you can specify replicas): apicast-staging

Check the number of pods is 1 for the apicast staging
```
k get dc apicast-staging
NAME              REVISION   DESIRED   CURRENT   TRIGGERED BY
apicast-staging   1          1         1         config,image(amp-apicast:2.13)
```

Scale to 3 via the deploymentconfig

```
k scale --replicas=3 deploymentconfig apicast-staging
Warning: extensions/v1beta1 Scale is deprecated in v1.2+, unavailable in v1.16+
deploymentconfig.apps.openshift.io/apicast-staging scaled
```
Check the deployment has 3 replicas

```
k get pods -l deploymentConfig=apicast-staging
NAME                      READY   STATUS    RESTARTS   AGE
apicast-staging-1-7ds4r   1/1     Running   0          14m
apicast-staging-1-l8l95   1/1     Running   0          106s
apicast-staging-1-lfstj   1/1     Running   0          106s
```

Add `replicas` to the APIManager CR with a value of 2

```
k patch apimanager apimanager1 --type merge --patch '{"spec":{"apicast": {"stagingSpec": {"replicas": 2}}}}'
apimanager.apps.3scale.net/apimanager1 patched
```
Check the deployment has 2 replicas
```
k get pods -l deploymentConfig=apicast-staging
NAME                      READY   STATUS    RESTARTS   AGE
apicast-staging-1-7ds4r   1/1     Running   0          16m
apicast-staging-1-lfstj   1/1     Running   0          4m21s
```
As replicas are set explicitly in the CR, changes in the deployment will be reverted back. If we try to scale to 3 via the deployment

```
k scale --replicas=3 deploymentconfig apicast-staging
```
The number of replicas will still be 2
```
k get pods -l deploymentConfig=apicast-staging
NAME                      READY   STATUS    RESTARTS   AGE
apicast-staging-1-7ds4r   1/1     Running   0          17m
apicast-staging-1-lfstj   1/1     Running   0          5m32s
```

