### PR TITLE
RBAC permissions for the `coordination/v1` API

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -438,8 +438,10 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          - coordination.k8s.io
           resources:
           - configmaps
+          - leases
           verbs:
           - get
           - list

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,8 +6,10 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list


### PR DESCRIPTION
### what

New RBAC permissions are needed by default for leaderelection for the `coordination/v1` API

### why

The PR https://github.com/3scale/3scale-operator/pull/785 upgraded controller-runtime from 0.6 to 0.12. However, the controller runtime's v0.7.0 added a change  leaderlock from ConfigMap to ConfigMapsLeasesResourceLock. From [changelog](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.7.0)

```
Change leaderlock from ConfigMap to ConfigMapsLeasesResourceLock (https://github.com/kubernetes-sigs/controller-runtime/pull/1144)

Impact: New RBAC permissions are needed by default for leaderelection (for
the coordination/v1 API). The new lock will automatically deal with
existing configmap locks (e.g. during upgrades). The can be set to its
previous value ("configmaps") in manager.Options.
```

So after 0.7.0, the operator manager, when leader election is enabled, which is in the 3scale operator, uses configmaps and leases (from leases.coordination/v1 API). Both of them. The operator needs permissions to manage leases. 

### verification steps

Deploy custom 3scale Operator using OLM

* Build and upload custom operator image

```
make docker-build-only IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator:myversiontag
make operator-image-push IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator:myversiontag
```

* Build and upload custom operator bundle image. Changes to avoid conflicts will be made by the makefile.
```
make bundle-custom-build IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator:myversiontag BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator-bundles:myversiontag
make bundle-image-push BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator-bundles:myversiontag
```
* Deploy the operator in your currently configured and active cluster in $HOME/.kube/config
```
make bundle-run BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/3scale-operator-bundles:myversiontag
```

The pod running the operator should run without errors. It must **NOT** show the following line
```
E1027 09:21:49.686423       1 leaderelection.go:330] error retrieving resource lock app-test/82355b9c.3scale.net: leases.coordination.k8s.io "82355b9c.3scale.net" is forbidden: User "system:serviceaccount:app-test:3scale-operator" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "app-test"
```
