### PR TITLE
THREESCALE-8963: Reconcile updates to APICAST_SERVICE_CACHE_SIZE

### DIFF
--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -71,6 +71,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		apicastEnvironmentEnvVarMutator,
 		apicastHTTPSEnvVarMutator,
 		apicastProxyConfigurationsEnvVarMutator,
+		apicastServiceCacheSizeEnvVarMutator,
 		apicastVolumeMountsMutator,
 		apicastVolumesMutator,
 		apicastCustomPolicyAnnotationsMutator,  // Should be always after volume mutator
@@ -103,6 +104,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		apicastEnvironmentEnvVarMutator,
 		apicastHTTPSEnvVarMutator,
 		apicastProxyConfigurationsEnvVarMutator,
+		apicastServiceCacheSizeEnvVarMutator,
 		apicastVolumeMountsMutator,
 		apicastVolumesMutator,
 		apicastCustomPolicyAnnotationsMutator,  // Should be always after volume mutator
@@ -262,6 +264,10 @@ func apicastProxyConfigurationsEnvVarMutator(desired, existing *appsv1.Deploymen
 	}
 
 	return changed, nil
+}
+
+func apicastServiceCacheSizeEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_SERVICE_CACHE_SIZE"), nil
 }
 
 func portsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {


### PR DESCRIPTION
## Description

New fields were added to the APIManager CRD to reconcile the APICAST_SERVICE_CACHE_SIZE environment variable in the Apicast containers. However, it missed the logic to reconcile updates to the CR.

Add the mutator that sets the environment variable in the case of updates.

## Verification steps

On a cluster, run the operator and create an APIManager with the new fields set. Check that once reconciled the `DeploymentConfigs` include the environment variable with the value from the new fields:

1. Apply the manifests
    ```sh
    make install
    ``` 
2. Run the operator
    ```sh
    make run
    ```
3. Create an APIManager that includes the following in the spec:
    ```yaml
    apicast:
      productionSpec:
        serviceCacheSize: 20
      stagingSpec:
        serviceCacheSize: 10
    ```
4. Check the DeploymentConfigs for APICast
    ```sh
    oc get dc/apicast-staging -o yaml
    oc get dc/apicast-production -o yaml
    ```
5. Verify that they include the environment variable
    ```yaml
    # apicast-staging
    - name: APICAST_SERVICE_CACHE_SIZE
       value: '10'

    # apicast-production
    - name: APICAST_SERVICE_CACHE_SIZE
       value: '20'
    ```

6. Update the `apicast` field in the APIManager resource:
    ```yaml
    apicast:
      productionSpec:
        serviceCacheSize: 25
      stagingSpec:
        serviceCacheSize: 15
    ```

7. Verify that the environment variable in the DCs is updated
    ```sh
    oc get dc/apicast-staging -o yaml
    oc get dc/apicast-production -o yaml
    ```
    ```yaml
    # apicast-staging
    - name: APICAST_SERVICE_CACHE_SIZE
       value: '15'

    # apicast-production
    - name: APICAST_SERVICE_CACHE_SIZE
       value: '25'
    ```