### PR TITLE
update internal postgresql to 13

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -459,9 +459,9 @@ spec:
                 - name: RELATED_IMAGE_SYSTEM_MYSQL
                   value: centos/mysql-57-centos7
                 - name: RELATED_IMAGE_SYSTEM_POSTGRESQL
-                  value: centos/postgresql-10-centos7
+                  value: centos/postgresql-13-centos7
                 - name: RELATED_IMAGE_ZYNC_POSTGRESQL
-                  value: centos/postgresql-10-centos7
+                  value: centos/postgresql-13-centos7
                 - name: RELATED_IMAGE_OC_CLI
                   value: quay.io/openshift/origin-cli:4.7
                 image: quay.io/3scale/3scale-operator:master

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,9 +66,9 @@ spec:
         - name: RELATED_IMAGE_SYSTEM_MYSQL
           value: "centos/mysql-57-centos7"
         - name: RELATED_IMAGE_SYSTEM_POSTGRESQL
-          value: "centos/postgresql-10-centos7"
+          value: "centos/postgresql-13-centos7"
         - name: RELATED_IMAGE_ZYNC_POSTGRESQL
-          value: "centos/postgresql-10-centos7"
+          value: "centos/postgresql-13-centos7"
         - name: RELATED_IMAGE_OC_CLI
           value: "quay.io/openshift/origin-cli:4.7"
       terminationGracePeriodSeconds: 10

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -29,7 +29,7 @@ func SystemMySQLImageURL() string {
 }
 
 func SystemPostgreSQLImageURL() string {
-	return "centos/postgresql-10-centos7"
+	return "centos/postgresql-13-centos7"
 }
 
 func SystemMemcachedImageURL() string {
@@ -37,7 +37,7 @@ func SystemMemcachedImageURL() string {
 }
 
 func ZyncPostgreSQLImageURL() string {
-	return "centos/postgresql-10-centos7"
+	return "centos/postgresql-13-centos7"
 }
 
 func OCCLIImageURL() string {

--- a/pkg/3scale/amp/operator/ampimages_options_provider_test.go
+++ b/pkg/3scale/amp/operator/ampimages_options_provider_test.go
@@ -18,7 +18,7 @@ const (
 	backendImage         = "quay.io/3scale/backend:mytag"
 	systemImage          = "quay.io/3scale/backend:mytag"
 	zyncImage            = "quay.io/3scale/zync:mytag"
-	zyncPostgresqlImage  = "postgresql-10:mytag"
+	zyncPostgresqlImage  = "postgresql-13:mytag"
 	systemMemcachedImage = "memcached:mytag"
 )
 

--- a/scripts/Upgrade_internal_Postgres.md
+++ b/scripts/Upgrade_internal_Postgres.md
@@ -1,0 +1,47 @@
+# Upgrade Internal on Cluster Posgresql v10 to v13
+
+Firstly it is not recommended that you run production workloads on an on-cluster Postgresql. As 3scale operator 
+will shortly be removing support for Internal on-cluster Postgresql v10, It's recommend that you migrate from 
+Postgresql-v10 to Postgresql-v13.
+
+The following script `upgrade_internal_postgresql.sh` will carry out this upgrade. It has to be run before the 3scale 
+operator is upgrade to a version that doesn't support Postgresql-v10
+
+Location of script is in the [3scale-operator](https://github.com/3scale/3scale-operator) git repo in the scripts directory. 
+- bash script and needs to be executed on a supporting system(mac/linux). 
+- You need to be logged into the cluster with cluster-admin privileges
+- oc cli(4 >)
+
+
+
+Usage is as follows
+```bash
+./upgrade_internal_posgresql.sh
+ 
+###################################################################################################################
+# Upgrade Postgresql-v10 to Postgresql-v13
+###################################################################################################################
+waiting for server to shut down....command terminated with exit code 137
+ 
+###################################################################################################################
+# Starting upgrade to Postgresql-v12
+###################################################################################################################
+clusterserviceversion.operators.coreos.com/dev1675239463-3scale-operator.0.0.1 patched
+deploymentconfig.apps.openshift.io/system-postgresql updated
+deploymentconfig.apps.openshift.io/system-postgresql updated
+postgres (PostgreSQL) 12.7
+ 
+###################################################################################################################
+# Starting upgrade to Postgresql-v13
+###################################################################################################################
+clusterserviceversion.operators.coreos.com/dev1675239463-3scale-operator.0.0.1 patched
+deploymentconfig.apps.openshift.io/system-postgresql updated
+deploymentconfig.apps.openshift.io/system-postgresql updated
+postgres (PostgreSQL) 13.3
+ 
+###################################################################################################################
+# Upgrade to Postgresql-v13 finished
+###################################################################################################################
+```
+
+

--- a/scripts/upgrade_internal_posgresql.sh
+++ b/scripts/upgrade_internal_posgresql.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Usage:
+# Used to upgrade on cluster internal Postgresql-10 to Postgresql-13
+# ./upgrade_internal_postgresql.sh
+# Prerequisite:
+# - This script needs to be executed before upgrade to version of 3scale that only supports internal Postgresql-13
+# - Logged into the cluster with cluster-admin privileges
+# - oc cli
+
+
+deploymentReady(){
+  # Check deploy pod is running and wait till its not
+  sleep 40
+  DEPLOY_POD_STATUS=$(oc get po --all-namespaces | grep "system-postgresql-.*-deploy" | grep Running | awk '{print $4}')
+  DEPLOY_POD_NAME=$(oc get po --all-namespaces | grep "system-postgresql-.*-deploy" | grep Running | awk '{print $2}')
+  while [ DEPLOY_POD_STATUS == Running ]
+  do
+  	DEPLOY_POD_STATUS=$(oc get po --all-namespaces | grep "system-postgresql-.*-deploy" | grep Running | awk '{print $4}')
+  	echo the $DEPLOY_POD_NAME deployment is $DEPLOY_POD_STATUS
+    POD_NAME=$(oc get po --all-namespaces | grep "system-postgresql-" | awk '{print $2}' | grep -wv deploy)
+    POD_STATUS=$(oc get po --all-namespaces | grep $POD_NAME| awk '{print $4}')
+    if [ $POD_STATUS == Error ]; then
+      echo The pod $POD_NAME status is now in expected $POD_STATUS state, continuing rollout
+      break
+    fi
+  done
+}
+
+stopPostgresql(){
+  # get the non deployment pod for system-posgresql
+  POD=$(oc get po --all-namespaces | grep "system-postgresql-" | awk '{print $2}' | grep -wv deploy)
+  POLL=y
+  while [[ $POLL == y ]]
+  do
+    if [[ -z $POD ]]; then
+      POLL=y
+      POD=$(oc get po --all-namespaces | grep "system-postgresql-" | awk '{print $2}' | grep -wv deploy)
+    else
+      POLL=n
+    fi
+  done
+
+  oc exec -it $POD -c system-postgresql -n $THREESCALE_NS -- /usr/bin/pg_ctl stop -D /var/lib/pgsql/data/userdata
+  oc exec -it $POD -c system-postgresql -n $THREESCALE_NS  -- rm /var/lib/pgsql/data/userdata/postmaster.pid
+}
+
+echo " "
+echo "###################################################################################################################"
+echo "# Upgrade Postgresql-v10 to Postgresql-v13"
+echo "###################################################################################################################"
+
+# Get the 3scale operator csv name and namespace
+THREESCALE_OPERATOR_VERSION=$(oc get csv --all-namespaces | grep 3scale-operator | awk '{print $2}')
+THREESCALE_NS=$(oc get csv --all-namespaces | grep 3scale-operator | awk '{print $1}')
+
+
+# Stop postgres and remove the lock file
+stopPostgresql
+
+# update the image in the CSV, need some check to see if the deployment is finished
+echo " "
+echo "###################################################################################################################"
+echo "# Starting upgrade to Postgresql-v12"
+echo "###################################################################################################################"
+oc patch ClusterServiceVersion $THREESCALE_OPERATOR_VERSION -n $THREESCALE_NS --type='json' -p='[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/9/value", "value":"centos/postgresql-12-centos7"}]'
+deploymentReady
+oc set env dc/system-postgresql -n $THREESCALE_NS POSTGRESQL_UPGRADE=copy
+deploymentReady
+oc set env dc/system-postgresql -n $THREESCALE_NS POSTGRESQL_UPGRADE-
+deploymentReady
+# check the posgresql version in container
+oc exec -it $(oc get po --all-namespaces | grep "system-postgresql-" | awk '{print $2}' | grep -wv deploy) -n $THREESCALE_NS -- postgres -V
+
+echo " "
+echo "###################################################################################################################"
+echo "# Starting upgrade to Postgresql-v13"
+echo "###################################################################################################################"
+oc patch ClusterServiceVersion $THREESCALE_OPERATOR_VERSION -n $THREESCALE_NS --type='json' -p='[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/9/value", "value":"centos/postgresql-13-centos7"}]'
+deploymentReady
+oc set env dc/system-postgresql -n $THREESCALE_NS POSTGRESQL_UPGRADE=copy
+deploymentReady
+oc set env dc/system-postgresql -n $THREESCALE_NS POSTGRESQL_UPGRADE-
+sleep 40
+# check the posgresql version in container
+oc exec -it $(oc get po --all-namespaces | grep "system-postgresql-" | awk '{print $2}' | grep -wv deploy) -n $THREESCALE_NS -- postgres -V
+echo " "
+echo "###################################################################################################################"
+echo "# Upgrade to Postgresql-v13 finished"
+echo "###################################################################################################################"
+
+


### PR DESCRIPTION
# What
PR updates the base image for internal postgresql to v13
Includes a script for updating the postgresql-v10 to postgresql-v13 for the system-postgresql

# Verification
- create a project 3scale-test
```bash
oc new-project 3scale-test
```
- Create a catalogSource for the 3scale operator based off an image made from master and apply it to a cluster
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: 3scale-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/austincunningham/3scale-index:0.0.1
```
- When the CatalogSource is ready check the operator hub for an operator called `dev1675239463 3scale operator` 
- Install the operator in the `3scale-test` ns
- Create a dummy s3 secret in the `3scale-test` ns
```bash
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: 3scale-test
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Create an apimanager CR with internal posgresql  making sure to update the wildcardDomain to one valid for your cluster e.g.
```bash
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata: 
  name: apimanager-sample
  namespace: 3scale-test
spec: 
  system: 
    fileStorage: 
      simpleStorageService: 
        configurationSecretRef: 
          name: s3-credentials
    database: 
      postgresql: {}
  wildcardDomain: apps.aucunnin.pf40.s1.devshift.org
```
- wait for the 3scale-operator install to complete
- run the `./upgrade_internal_postgresql.sh` and expect the following output
```bash
./upgrade_internal_posgresql.sh
 
###################################################################################################################
# Upgrade Postgresql-v10 to Postgresql-v13
###################################################################################################################
waiting for server to shut down....command terminated with exit code 137
 
###################################################################################################################
# Starting upgrade to Postgresql-v12
###################################################################################################################
clusterserviceversion.operators.coreos.com/dev1675239463-3scale-operator.0.0.1 patched
deploymentconfig.apps.openshift.io/system-postgresql updated
deploymentconfig.apps.openshift.io/system-postgresql updated
postgres (PostgreSQL) 12.7
 
###################################################################################################################
# Starting upgrade to Postgresql-v13
###################################################################################################################
clusterserviceversion.operators.coreos.com/dev1675239463-3scale-operator.0.0.1 patched
deploymentconfig.apps.openshift.io/system-postgresql updated
deploymentconfig.apps.openshift.io/system-postgresql updated
postgres (PostgreSQL) 13.3
 
###################################################################################################################
# Upgrade to Postgresql-v13 finished
###################################################################################################################
```
- Once the upgrade is completed the system-postgresql will be using posgresql-v13
- upgrade the catalogSource with an index built of this branch  `quay.io/austincunningham/3scale-index:0.0.2` to trigger an olm upgrade
- Once the upgrade is complete the `zync-database` will also be using posgresql-v13 , note there may be some downtime   in the zync-que during the upgrade.

