### PR TITLE
MGDAPI-5152 - replace deprecated clock package usage

### DIFF
--- a/controllers/apps/apimanagerbackup_logic_reconciler.go
+++ b/controllers/apps/apimanagerbackup_logic_reconciler.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	kubeclock "k8s.io/apimachinery/pkg/util/clock"
+	kubeclock "k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
+	k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e
 	sigs.k8s.io/controller-runtime v0.12.2
 )
 
@@ -107,7 +108,6 @@ require (
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
-	k8s.io/utils v0.0.0-20220713171938-56c0de1e6f5e // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/pkg/common/status_conditions.go
+++ b/pkg/common/status_conditions.go
@@ -24,7 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeclock "k8s.io/apimachinery/pkg/util/clock"
+	kubeclock "k8s.io/utils/clock"
 )
 
 // clock is used to set status condition timestamps.


### PR DESCRIPTION
[MGDAPI-5152](https://issues.redhat.com/browse/MGDAPI-5152)

As part of the changes for the above ticket for openshift v4.13 support I was unable to resolve dep conflicts in 3scale-operator without removing use of the deprecated clock package. I've swapped the two uses for the newer version in this PR.