### PR TITLE
MGDAPI-5152 - remove duplicate FILE_UPLOAD_STORAGE env var

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -243,7 +243,6 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 
 	if system.Options.S3FileStorageOptions != nil {
 		result = append(result,
-			helper.EnvVarFromConfigMap("FILE_UPLOAD_STORAGE", "system-environment", "FILE_UPLOAD_STORAGE"),
 			helper.EnvVarFromSecret(AwsBucket, system.Options.S3FileStorageOptions.ConfigurationSecretName, AwsBucket),
 			helper.EnvVarFromSecret(AwsRegion, system.Options.S3FileStorageOptions.ConfigurationSecretName, AwsRegion),
 			helper.EnvVarFromSecretOptional(AwsProtocol, system.Options.S3FileStorageOptions.ConfigurationSecretName, AwsProtocol),

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -89,6 +89,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigTolerationsMutator,
 		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
 		r.systemAppDCResourceMutator,
+		reconcilers.DeploymentConfigRemoveDuplicateEnvVarMutator,
 	}
 
 	if r.apiManager.Spec.System.AppSpec.Replicas != nil {
@@ -107,6 +108,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigAffinityMutator,
 		reconcilers.DeploymentConfigTolerationsMutator,
 		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
+		reconcilers.DeploymentConfigRemoveDuplicateEnvVarMutator,
 	}
 
 	if r.apiManager.Spec.System.SidekiqSpec.Replicas != nil {

--- a/pkg/helper/envvarutils.go
+++ b/pkg/helper/envvarutils.go
@@ -107,3 +107,18 @@ func EnsureEnvVar(desired v1.EnvVar, existingEnvVars *[]v1.EnvVar) bool {
 
 	return update
 }
+
+// RemoveDuplicateEnvVars removes duplicate env vars by name from a slice
+func RemoveDuplicateEnvVars(envVars []v1.EnvVar) []v1.EnvVar {
+	set := map[string]v1.EnvVar{}
+	var result []v1.EnvVar
+
+	for idx := range envVars {
+		if _, ok := set[envVars[idx].Name]; !ok {
+			set[envVars[idx].Name] = envVars[idx]
+			result = append(result, envVars[idx])
+		}
+	}
+
+	return result
+}

--- a/pkg/reconcilers/deploymentconfig.go
+++ b/pkg/reconcilers/deploymentconfig.go
@@ -196,8 +196,8 @@ func DeploymentConfigPodTemplateLabelsMutator(desired, existing *appsv1.Deployme
 	return updated, nil
 }
 
-// DeploymentConfigRemoveDuplicateEnvVarMutator ensures pod env vars not duplicated
-func DeploymentConfigRemoveDuplicateEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+// DeploymentConfigRemoveDuplicateEnvVarMutator ensures pod env vars are not duplicated
+func DeploymentConfigRemoveDuplicateEnvVarMutator(_, existing *appsv1.DeploymentConfig) (bool, error) {
 	updated := false
 	for idx := range existing.Spec.Template.Spec.Containers {
 		prunedEnvs := helper.RemoveDuplicateEnvVars(existing.Spec.Template.Spec.Containers[idx].Env)

--- a/pkg/reconcilers/deploymentconfig_test.go
+++ b/pkg/reconcilers/deploymentconfig_test.go
@@ -536,7 +536,7 @@ func TestDeploymentConfigPodTemplateLabelsMutator(t *testing.T) {
 	}
 }
 
-func TestDeploymentConfigEnvVarSyncMutator(t *testing.T) {
+func TestDeploymentConfigRemoveDuplicateEnvVarMutator(t *testing.T) {
 	dcFactory := func(envs []corev1.EnvVar) *appsv1.DeploymentConfig {
 		return &appsv1.DeploymentConfig{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/reconcilers/deploymentconfig_test.go
+++ b/pkg/reconcilers/deploymentconfig_test.go
@@ -572,19 +572,17 @@ func TestDeploymentConfigRemoveDuplicateEnvVarMutator(t *testing.T) {
 	cases := []struct {
 		testName        string
 		existingEnvs    []corev1.EnvVar
-		desiredEnvs     []corev1.EnvVar
 		expectedResult  bool
 		expectedNewEnvs []corev1.EnvVar
 	}{
-		{"NothingToReconcile", envsA, envsA, false, envsA},
-		{"EnvsReconciled", envsB, envsA, true, envsA},
+		{"NothingToReconcile", envsA, false, envsA},
+		{"EnvsReconciled", envsB, true, envsA},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(subT *testing.T) {
 			existing := dcFactory(tc.existingEnvs)
-			desired := dcFactory(tc.desiredEnvs)
-			update, err := DeploymentConfigRemoveDuplicateEnvVarMutator(desired, existing)
+			update, err := DeploymentConfigRemoveDuplicateEnvVarMutator(nil, existing)
 			if err != nil {
 				subT.Fatal(err)
 			}


### PR DESCRIPTION
`FILE_UPLOAD_STORAGE` env var is added as part of the config map, and added separately after resulting in duplicate env vars on some DeploymentConfigs.

On v4.11 when updating any of the deployment configs a new replication controller is created and there are warnings about a duplicate `FILE_UPLOAD_STORAGE` env var in the deploy logs. However on v4.13 these no longer show as warnings but as errors and the rollout is marked as failed. This duplicate env var is present as it is added from the base config map and then appended again.

*v4.11*
```
--> pre: Running hook pod ...
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /opt/deps/rubygems/github.com/3scale/prawn/prawn-external-gitcommit-88aead0d97e230d08e9f51a18711d01317965bfe/app/prawn-core.gemspec:36.
fatal: not a git repository (or any of the parent directories): .git
Removing :environment prerequisite from db:create
I, [2023-03-31T10:45:53.839087 #1] INFO -- : ActiveMerchant MODE set to 'production'
W, [2023-03-31T10:45:53.854215 #1] WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
I, [2023-03-31T10:45:54.026795 #1] INFO -- : [Core] Using http://backend-listener:3000/internal/ as URL
OpenIdAuthentication.store is nil. Using in-memory store.
Creating scope :admins. Overwriting existing method User.admins.
Creating scope :by_name. Overwriting existing method Cinstance.by_name.
[core] non-native log levels verbose, notice, critical emulated using UNKNOWN severity
Backend Internal API version 3.4.3 status: ok
Connected to mysql2://root@system-mysql/system
Connected to redis://system-redis:6379/1
--> pre: Success
W0331 10:45:59.726113 1 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (containers "system-master", "system-provider", "system-developer" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "system-master", "system-provider", "system-developer" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0331 10:45:59.754015 1 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (containers "system-master", "system-provider", "system-developer" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "system-master", "system-provider", "system-developer" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
--> Scaling up system-app-2 from 0 to 1, scaling down system-app-1 from 1 to 0 (keep 1 pods available, don't exceed 2 pods)
Scaling system-app-2 up to 1
W0331 10:45:59.764889 1 warnings.go:70] spec.template.spec.containers[0].env[47].name: duplicate name "FILE_UPLOAD_STORAGE"
W0331 10:45:59.764905 1 warnings.go:70] spec.template.spec.containers[1].env[47].name: duplicate name "FILE_UPLOAD_STORAGE"
W0331 10:45:59.764909 1 warnings.go:70] spec.template.spec.containers[2].env[47].name: duplicate name "FILE_UPLOAD_STORAGE"
Scaling system-app-1 down to 0
W0331 10:47:05.746333 1 warnings.go:70] spec.template.spec.containers[0].env[47].name: duplicate name "FILE_UPLOAD_STORAGE"
W0331 10:47:05.746347 1 warnings.go:70] spec.template.spec.containers[1].env[47].name: duplicate name "FILE_UPLOAD_STORAGE"
W0331 10:47:05.746351 1 warnings.go:70] spec.template.spec.containers[2].env[47].name: duplicate name "FILE_UPLOAD_STORAGE"
W0331 10:47:06.778809 1 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (containers "system-master", "system-provider", "system-developer" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "system-master", "system-provider", "system-developer" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
--> post: Running hook pod ...
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /opt/deps/rubygems/github.com/3scale/prawn/prawn-external-gitcommit-88aead0d97e230d08e9f51a18711d01317965bfe/app/prawn-core.gemspec:36.
fatal: not a git repository (or any of the parent directories): .git
Removing :environment prerequisite from db:create
I, [2023-03-31T10:47:18.526897 #1] INFO -- : ActiveMerchant MODE set to 'production'
W, [2023-03-31T10:47:18.541539 #1] WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
I, [2023-03-31T10:47:18.711720 #1] INFO -- : [Core] Using http://backend-listener:3000/internal/ as URL
OpenIdAuthentication.store is nil. Using in-memory store.
Creating scope :admins. Overwriting existing method User.admins.
Creating scope :by_name. Overwriting existing method Cinstance.by_name.
[core] non-native log levels verbose, notice, critical emulated using UNKNOWN severity
Backend Internal API version 3.4.3 status: ok
Connected to mysql2://root@system-mysql/system
Connected to redis://system-redis:6379/1
Enqueued BackendStorageRewriteWorker#5b9bbe78ad70d110a38d8a61 with args: [1]
Enqueued BackendStorageRewriteWorker#318f39ded0f3d1e70cca4165 with args: [2]
Enqueued 2 accounts for rewrite
--> post: Success
--> Success
```
*v4.13*
```
--> pre: Running hook pod ...
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /opt/deps/rubygems/github.com/3scale/prawn/prawn-external-gitcommit-88aead0d97e230d08e9f51a18711d01317965bfe/app/prawn-core.gemspec:36.
fatal: not a git repository (or any of the parent directories): .git
Removing :environment prerequisite from db:create
I, [2023-03-31T12:23:43.046402 #1] INFO -- : ActiveMerchant MODE set to 'production'
W, [2023-03-31T12:23:43.061022 #1] WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
I, [2023-03-31T12:23:43.219970 #1] INFO -- : [Core] Using http://backend-listener:3000/internal/ as URL
OpenIdAuthentication.store is nil. Using in-memory store.
Creating scope :admins. Overwriting existing method User.admins.
Creating scope :by_name. Overwriting existing method Cinstance.by_name.
[core] non-native log levels verbose, notice, critical emulated using UNKNOWN severity
Backend Internal API version 3.4.3 status: ok
Connected to mysql2://root@system-mysql/system
Connected to redis://system-redis:6379/1
--> pre: Success
error: couldn't assign source annotation to deployment system-app-2: failed to create manager for existing fields: failed to convert new object (3scale-operator/system-app-2; /v1, Kind=ReplicationController) to smd typed: errors:
.spec.template.spec.containers[name="system-master"].env: duplicate entries for key [name="FILE_UPLOAD_STORAGE"]
.spec.template.spec.containers[name="system-provider"].env: duplicate entries for key [name="FILE_UPLOAD_STORAGE"]
.spec.template.spec.containers[name="system-developer"].env: duplicate entries for key [name="FILE_UPLOAD_STORAGE"]
```

With the changes in this PR we no longer have the duplicate entry and the deployment config can be updated successfully on v4.13:

```
--> pre: Running hook pod ...
Removing :environment prerequisite from db:create
I, [2023-03-31T13:36:08.725595 #1] INFO -- : ActiveMerchant MODE set to 'production'
W, [2023-03-31T13:36:08.743611 #1] WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
I, [2023-03-31T13:36:08.918910 #1] INFO -- : [Core] Using http://backend-listener:3000/internal/ as URL
OpenIdAuthentication.store is nil. Using in-memory store.
Creating scope :admins. Overwriting existing method User.admins.
Creating scope :by_name. Overwriting existing method Cinstance.by_name.
[core] non-native log levels verbose, notice, critical emulated using UNKNOWN severity
Backend Internal API version 3.4.3 status: ok
Connected to mysql2://root@system-mysql/system
Connected to redis://system-redis:6379/1
--> pre: Success
W0331 13:36:13.598613 1 warnings.go:70] would violate PodSecurity "restricted:latest": seccompProfile (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0331 13:36:13.641820 1 warnings.go:70] would violate PodSecurity "restricted:latest": seccompProfile (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
--> Scaling up system-app-2 from 0 to 1, scaling down system-app-1 from 1 to 0 (keep 1 pods available, don't exceed 2 pods)
Scaling system-app-2 up to 1
Scaling system-app-1 down to 0
W0331 13:37:15.742399 1 warnings.go:70] would violate PodSecurity "restricted:latest": seccompProfile (pod or containers "system-master", "system-provider", "system-developer" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
--> post: Running hook pod ...
Removing :environment prerequisite from db:create
I, [2023-03-31T13:37:24.713843 #1] INFO -- : ActiveMerchant MODE set to 'production'
W, [2023-03-31T13:37:24.731184 #1] WARN -- [Bugsnag]: No valid API key has been set, notifications will not be sent
I, [2023-03-31T13:37:24.907571 #1] INFO -- : [Core] Using http://backend-listener:3000/internal/ as URL
OpenIdAuthentication.store is nil. Using in-memory store.
Creating scope :admins. Overwriting existing method User.admins.
Creating scope :by_name. Overwriting existing method Cinstance.by_name.
[core] non-native log levels verbose, notice, critical emulated using UNKNOWN severity
Backend Internal API version 3.4.3 status: ok
Connected to mysql2://root@system-mysql/system
Connected to redis://system-redis:6379/1
Enqueued BackendStorageRewriteWorker#ec164faac0d81388c0fdd09f with args: [1]
Enqueued BackendStorageRewriteWorker#23d2aaff28bd257b1638c692 with args: [2]
Enqueued 2 accounts for rewrite
--> post: Success
--> Success
```

WIP as I have not verified the upgrade scenario