### PR TITLE
THREESCALE-9558: Separate env vars for Core API and public route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Expose apicast metric ports in service [#791](https://github.com/3scale/3scale-operator/pull/791)
 
 ### Fixed
-- APIManager CRD: system-app env vars `BACKEND_PUBLIC_URL` and `THREESCALE_CORE_INTERNAL_API` from backend-listener secret [#821](https://github.com/3scale/3scale-operator/pull/821)
+- APIManager CRD: add system-app env vars `BACKEND_URL` and `BACKEND_PUBLIC_URL` with values from backend-listener secret [#821](https://github.com/3scale/3scale-operator/pull/821)
 
 ## [0.10.1] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to set `APICAST_SERVICE_CACHE_SIZE` [#793](https://github.com/3scale/3scale-operator/pull/793)
 - Expose apicast metric ports in service [#791](https://github.com/3scale/3scale-operator/pull/791)
 
+### Fixed
+- APIManager CRD: system-app env vars `BACKEND_PUBLIC_URL` and `THREESCALE_CORE_INTERNAL_API` from backend-listener secret [#821](https://github.com/3scale/3scale-operator/pull/821)
+
 ## [0.10.1] - 2023-02-01
 
 ### Added

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -206,9 +206,9 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 	result = append(result, system.SystemRedisEnvVars()...)
 	result = append(result, system.BackendRedisEnvVars()...)
 	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
-	bckCoreInternalAPIEndpointEnv := helper.EnvVarFromValue("THREESCALE_CORE_INTERNAL_API", system.Options.CoreInternalAPIEndpoint)
+	bckServiceEndpointEnv := helper.EnvVarFromSecret("BACKEND_URL", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerServiceEndpointFieldName)
 	bckPublicRouteEndpointEnv := helper.EnvVarFromSecret("BACKEND_PUBLIC_URL", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
-	result = append(result, bckListenerApicastRouteEnv, bckCoreInternalAPIEndpointEnv, bckPublicRouteEndpointEnv)
+	result = append(result, bckListenerApicastRouteEnv, bckServiceEndpointEnv, bckPublicRouteEndpointEnv)
 
 	smtpEnvSecretEnvs := system.getSystemSMTPEnvsFromSMTPSecret()
 	result = append(result, smtpEnvSecretEnvs...)

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -206,8 +206,9 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 	result = append(result, system.SystemRedisEnvVars()...)
 	result = append(result, system.BackendRedisEnvVars()...)
 	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
-	bckListenerRouteEnv := helper.EnvVarFromValue("BACKEND_ROUTE", system.Options.BackendServiceEndpoint)
-	result = append(result, bckListenerApicastRouteEnv, bckListenerRouteEnv)
+	bckCoreInternalAPIEndpointEnv := helper.EnvVarFromValue("THREESCALE_CORE_INTERNAL_API", system.Options.CoreInternalAPIEndpoint)
+	bckPublicRouteEndpointEnv := helper.EnvVarFromSecret("BACKEND_PUBLIC_URL", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
+	result = append(result, bckListenerApicastRouteEnv, bckCoreInternalAPIEndpointEnv, bckPublicRouteEndpointEnv)
 
 	smtpEnvSecretEnvs := system.getSystemSMTPEnvsFromSMTPSecret()
 	result = append(result, smtpEnvSecretEnvs...)

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -103,7 +103,7 @@ type SystemOptions struct {
 
 	IncludeOracleOptionalSettings bool
 
-	BackendServiceEndpoint string `validate:"required"`
+	CoreInternalAPIEndpoint string `validate:"required"`
 
 	AppPriorityClassName     string `validate:"-"`
 	SideKiqPriorityClassName string `validate:"-"`

--- a/pkg/3scale/amp/component/system_options.go
+++ b/pkg/3scale/amp/component/system_options.go
@@ -103,8 +103,6 @@ type SystemOptions struct {
 
 	IncludeOracleOptionalSettings bool
 
-	CoreInternalAPIEndpoint string `validate:"required"`
-
 	AppPriorityClassName     string `validate:"-"`
 	SideKiqPriorityClassName string `validate:"-"`
 	SphinxPriorityClassName  string `validate:"-"`

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -377,7 +377,8 @@ func (s *SystemOptionsProvider) setBackendOptions() error {
 		return fmt.Errorf("'%s' field of '%s' secret must have 'scheme://user:password@host/path' format", component.BackendSecretBackendListenerServiceEndpointFieldName, component.BackendSecretBackendListenerSecretName)
 	}
 
-	s.options.CoreInternalAPIEndpoint = urlObj.JoinPath("/internal/").String()
+	urlObj.Path += "/internal/"
+	s.options.CoreInternalAPIEndpoint = urlObj.String()
 
 	return nil
 }

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -377,11 +377,7 @@ func (s *SystemOptionsProvider) setBackendOptions() error {
 		return fmt.Errorf("'%s' field of '%s' secret must have 'scheme://user:password@host/path' format", component.BackendSecretBackendListenerServiceEndpointFieldName, component.BackendSecretBackendListenerSecretName)
 	}
 
-	if urlObj.Path == "" {
-		urlObj.Path = "/internal/"
-	}
-
-	s.options.BackendServiceEndpoint = urlObj.String()
+	s.options.CoreInternalAPIEndpoint = urlObj.JoinPath("/internal/").String()
 
 	return nil
 }

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
@@ -111,11 +110,6 @@ func (s *SystemOptionsProvider) setSecretBasedOptions() error {
 	err = s.setSystemSMTPOptions()
 	if err != nil {
 		return fmt.Errorf("unable to create System SMTP secret options - %s", err)
-	}
-
-	err = s.setBackendOptions()
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -360,26 +354,6 @@ func (s *SystemOptionsProvider) setSystemSMTPOptions() error {
 	}
 
 	s.options.SmtpSecretOptions = smtpSecretOptions
-	return nil
-}
-
-func (s *SystemOptionsProvider) setBackendOptions() error {
-	rawURL, err := s.secretSource.FieldValue(
-		component.BackendSecretBackendListenerSecretName,
-		component.BackendSecretBackendListenerServiceEndpointFieldName,
-		component.DefaultBackendServiceEndpoint())
-	if err != nil {
-		return err
-	}
-
-	urlObj, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("'%s' field of '%s' secret must have 'scheme://user:password@host/path' format", component.BackendSecretBackendListenerServiceEndpointFieldName, component.BackendSecretBackendListenerSecretName)
-	}
-
-	urlObj.Path += "/internal/"
-	s.options.CoreInternalAPIEndpoint = urlObj.String()
-
 	return nil
 }
 

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -339,7 +338,6 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		SideKiqMetrics:                true,
 		AppMetrics:                    true,
 		IncludeOracleOptionalSettings: true,
-		CoreInternalAPIEndpoint:       fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
 		Namespace:                     opts.Namespace,
 	}
 

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -339,7 +339,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 		SideKiqMetrics:                true,
 		AppMetrics:                    true,
 		IncludeOracleOptionalSettings: true,
-		BackendServiceEndpoint:        fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
+		CoreInternalAPIEndpoint:       fmt.Sprintf("%s%s", component.DefaultBackendServiceEndpoint(), "/internal/"),
 		Namespace:                     opts.Namespace,
 	}
 

--- a/pkg/3scale/amp/prometheusrules/system_app_rules.go
+++ b/pkg/3scale/amp/prometheusrules/system_app_rules.go
@@ -87,7 +87,6 @@ func systemOptions(ns string) (*component.SystemOptions, error) {
 	o.DeveloperUILabels = map[string]string{}
 	o.MemcachedLabels = map[string]string{}
 	o.SMTPLabels = map[string]string{}
-	o.CoreInternalAPIEndpoint = "_"
 	o.UserSessionTTL = &tmp
 
 	return o, o.Validate()

--- a/pkg/3scale/amp/prometheusrules/system_app_rules.go
+++ b/pkg/3scale/amp/prometheusrules/system_app_rules.go
@@ -87,8 +87,7 @@ func systemOptions(ns string) (*component.SystemOptions, error) {
 	o.DeveloperUILabels = map[string]string{}
 	o.MemcachedLabels = map[string]string{}
 	o.SMTPLabels = map[string]string{}
-	o.BackendServiceEndpoint = "_"
-	o.BackendServiceEndpoint = "_"
+	o.CoreInternalAPIEndpoint = "_"
 	o.UserSessionTTL = &tmp
 
 	return o, o.Validate()

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -289,11 +289,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/pkg/upgrade/upgrade_system_backend_urls_2.14.go
+++ b/pkg/upgrade/upgrade_system_backend_urls_2.14.go
@@ -6,7 +6,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 )
 
-// DeploymentConfigPodTemplateLabelsMutator ensures pod template labels are reconciled
+// SystemBackendUrls reconciles environment variables for Backend URLs on system DC
 func SystemBackendUrls(desired, existing *appsv1.DeploymentConfig) (bool, error) {
 	var changed bool
 

--- a/pkg/upgrade/upgrade_system_backend_urls_2.14.go
+++ b/pkg/upgrade/upgrade_system_backend_urls_2.14.go
@@ -1,0 +1,22 @@
+package upgrade
+
+import (
+	appsv1 "github.com/openshift/api/apps/v1"
+
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+)
+
+// DeploymentConfigPodTemplateLabelsMutator ensures pod template labels are reconciled
+func SystemBackendUrls(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	var changed bool
+
+	// Remove old env var
+	oldVarRemoved := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_ROUTE")
+
+	// Add new env vars
+	newVar1Added := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_URL")
+	newVar2Added := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_PUBLIC_URL")
+	changed = oldVarRemoved || newVar1Added || newVar2Added
+
+	return changed, nil
+}


### PR DESCRIPTION
Related to https://github.com/3scale/porta/pull/3324

The description about different Backend URLs that are used in the System component are provided in the [porta PR description](https://github.com/3scale/porta/pull/3324).

This PR removes the `BACKEND_ROUTE` environment variable, whose value is now `http://backend-listener:3000/internal/` - which is confusing because "route" kind of suggests that it would be the value of the backend OCP route.

### What

* Deleted `system-app` env var `APICAST_BACKEND_ROOT_ENDPOINT`
* Deleted `system-app` env var `BACKEND_ROUTE`
* Add `system-app` env var `BACKEND_URL`:  `service_endpoint` value from `backend-listener` secret (i.e. `http://backend-listener:3000`). Note `/internal` is no longer provided. That will be added by System.
* Add `system-app` env var `BACKEND_PUBLIC_URL`:  `route_endpoint` value from `backend-listener` secret (i.e. `https://backend-3scale.apps.mycluster.com`). 
* Upgrade procedure from the previous release

### Verification steps

* Requires openshift (oc CLI) session 

#### New deployment

* Create new project
```
oc new-project 3scale-testing-new-deployment
```
* Checkout this branch and run the operator
```
make install
make run
```
* Deploy 3scale 
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: test01.example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 

* Check the system-app deployment no longer has `APICAST_BACKEND_ROOT_ENDPOINT` or `BACKEND_ROUTE` env vars
```
# It should report empty
❯ k get dc system-app -o yaml | grep -A 1  APICAST_BACKEND_ROOT_ENDPOINT

# It should report empty
❯ k get dc system-app -o yaml | grep -A 1 BACKEND_ROUTE
```

* Check the system-app deployment has the `BACKEND_URL` env var from the  `backend-listener` secret and  `service_endpoint` field
```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_URL
          - name: BACKEND_URL
            valueFrom:
              secretKeyRef:
                key: service_endpoint
                name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
```

It is replicated 4 times in 4 different deployment: pre-hook pod deployment container and `system-master`, `system-provider`, `system-developer` containers.

* Check the system-app deployment has the `BACKEND_PUBLIC_URL` env var from the  `backend-listener` secret and  `route_endpoint` field

```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_PUBLIC_URL
          - name: BACKEND_PUBLIC_URL
            valueFrom:
              secretKeyRef:
                key: route_endpoint
                name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
```
The `backend-listener` secret values

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.service_endpoint}" | base64 --decode
http://backend-listener:3000
```

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.route_endpoint}" | base64 --decode
https://backend-3scale.example.net
```
#### Upgrade from 2.13

* Create new project
```
oc new-project 3scale-testing-upgrade
```

* Checkout current [master](https://github.com/3scale/3scale-operator/commit/8cc98759cc1ee761bf5fb811fb2dcfccf122b71a) branch and run the operator
```
git checkout 8cc98759cc1ee761bf5fb811fb2dcfccf122b71a
make install
make run
```
* Deploy 3scale from current master
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: test01.example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 

* Check the system-app deployment has the `APICAST_BACKEND_ROOT_ENDPOINT` and `BACKEND_ROUTE` env var. Note that `BACKEND_ROUTE` is set to `http://backend-listener:3000/internal/`

```
❯ k get dc system-app -o yaml | grep -A 4  APICAST_BACKEND_ROOT_ENDPOINT
          - name: APICAST_BACKEND_ROOT_ENDPOINT
            valueFrom:
              secretKeyRef:
                key: route_endpoint
                name: backend-listener
--
        - name: APICAST_BACKEND_ROOT_ENDPOINT
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: APICAST_BACKEND_ROOT_ENDPOINT
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: APICAST_BACKEND_ROOT_ENDPOINT
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener

❯ k get dc system-app -o yaml | grep -A 1 BACKEND_ROUTE
          - name: BACKEND_ROUTE
            value: http://backend-listener:3000/internal/
--
        - name: BACKEND_ROUTE
          value: http://backend-listener:3000/internal/
--
        - name: BACKEND_ROUTE
          value: http://backend-listener:3000/internal/
--
        - name: BACKEND_ROUTE
          value: http://backend-listener:3000/internal/
```

* Let's run upgrade. Checkout this PR's branch and run the operator
```
git checkout <new-branch-name>
make run
```
The upgrade should happen automatically

* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 
* All the deployments should be `ready`. Note the `system-app` deployment as it should have been rolled out automatically.
```yaml
❯ k get apimanager apimanager1 -o jsonpath='{.status.deployments}' | yq e -P
ready:
  - apicast-production
  - apicast-staging
  - backend-cron
  - backend-listener
  - backend-redis
  - backend-worker
  - system-app
  - system-memcache
  - system-mysql
  - system-redis
  - system-searchd
  - system-sidekiq
  - zync
  - zync-database
  - zync-que
```
* Check the system-app deployment no longer has `APICAST_BACKEND_ROOT_ENDPOINT` or `BACKEND_ROUTE` env vars
```
# It should report empty
❯ k get dc system-app -o yaml | grep -A 1  APICAST_BACKEND_ROOT_ENDPOINT

# It should report empty
❯ k get dc system-app -o yaml | grep -A 1 BACKEND_ROUTE
```

* Check the system-app deployment has the `BACKEND_URL` env var from the  `backend-listener` secret and  `service_endpoint` field
```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_URL
          - name: BACKEND_URL
            valueFrom:
              secretKeyRef:
                key: service_endpoint
                name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
```

It is replicated 4 times in 4 different deployment: pre-hook pod deployment container and `system-master`, `system-provider`, `system-developer` containers.

* Check the system-app deployment has the `BACKEND_PUBLIC_URL` env var from the  `backend-listener` secret and  `route_endpoint` field

```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_PUBLIC_URL
          - name: BACKEND_PUBLIC_URL
            valueFrom:
              secretKeyRef:
                key: route_endpoint
                name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
```
The `backend-listener` secret values

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.service_endpoint}" | base64 --decode
http://backend-listener:3000
```

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.route_endpoint}" | base64 --decode
https://backend-3scale.example.net
```
