### PR TITLE
add RELATED_IMAGE_SYSTEM_SEARCHD to the CSV

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -466,6 +466,8 @@ spec:
                   value: centos/postgresql-10-centos7
                 - name: RELATED_IMAGE_OC_CLI
                   value: quay.io/openshift/origin-cli:4.7
+                - name: RELATED_IMAGE_SYSTEM_SEARCHD
+                  value: quay.io/3scale/searchd:latest
                 image: quay.io/3scale/3scale-operator:master
                 name: manager
                 ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,4 +71,6 @@ spec:
           value: "centos/postgresql-10-centos7"
         - name: RELATED_IMAGE_OC_CLI
           value: "quay.io/openshift/origin-cli:4.7"
+        - name: RELATED_IMAGE_SYSTEM_SEARCHD
+          value: "quay.io/3scale/searchd:latest"
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Fixes missing env in the CSV that should have been added in #818 