### PR TITLE
THREESCALE-9710 searchd deployment strategy: recreate

### DIFF
--- a/pkg/3scale/amp/component/system_searchd.go
+++ b/pkg/3scale/amp/component/system_searchd.go
@@ -80,20 +80,7 @@ func (s *SystemSearchd) DeploymentConfig() *appsv1.DeploymentConfig {
 			Replicas: 1,
 			Selector: map[string]string{"deploymentConfig": SystemSearchdDeploymentName},
 			Strategy: appsv1.DeploymentStrategy{
-				RollingParams: &appsv1.RollingDeploymentStrategyParams{
-					IntervalSeconds: &[]int64{1}[0],
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
-						StrVal: "25%",
-					},
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
-						StrVal: "25%",
-					},
-					TimeoutSeconds:      &[]int64{1200}[0],
-					UpdatePeriodSeconds: &[]int64{1}[0],
-				},
-				Type: appsv1.DeploymentStrategyTypeRolling,
+				Type: appsv1.DeploymentStrategyTypeRecreate,
 			},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/3scale/amp/operator/system_searchd_reconciler.go
+++ b/pkg/3scale/amp/operator/system_searchd_reconciler.go
@@ -54,6 +54,7 @@ func (r *SystemSearchdReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigTolerationsMutator,
 		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
 		reconcilers.DeploymentConfigPriorityClassMutator,
+		reconcilers.DeploymentConfigStrategyMutator,
 	)
 	err = r.ReconcileDeploymentConfig(searchd.DeploymentConfig(), searchdDCmutator)
 	if err != nil {

--- a/pkg/reconcilers/deploymentconfig.go
+++ b/pkg/reconcilers/deploymentconfig.go
@@ -246,3 +246,15 @@ func DeploymentConfigPriorityClassMutator(desired, existing *appsv1.DeploymentCo
 
 	return updated, nil
 }
+
+// DeploymentConfigPriorityClassMutator ensures priorityclass is reconciled
+func DeploymentConfigStrategyMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Strategy, desired.Spec.Strategy) {
+		existing.Spec.Strategy = desired.Spec.Strategy
+		updated = true
+	}
+
+	return updated, nil
+}

--- a/pkg/reconcilers/deploymentconfig.go
+++ b/pkg/reconcilers/deploymentconfig.go
@@ -247,7 +247,7 @@ func DeploymentConfigPriorityClassMutator(desired, existing *appsv1.DeploymentCo
 	return updated, nil
 }
 
-// DeploymentConfigPriorityClassMutator ensures priorityclass is reconciled
+// DeploymentConfigStrategyMutator ensures desired strategy
 func DeploymentConfigStrategyMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
 	updated := false
 


### PR DESCRIPTION
### What

Fixes https://issues.redhat.com/browse/THREESCALE-9710

The searchd deployment had [Rolling](https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/deployment_strategies.html#rolling-strategy) and a PVC with RWO access mode. Thus, on rolling, the new pod would never be fully deployed because the PV was attached to the old pod. And the old pod would never release the PVC until the new pod was up and running. A deadlock situation. 

The fix is to use the [Recreate Strategy](https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/deployment_strategies.html#recreate-strategy). Same strategy that other 3scale component deployments have when PVCs with RWO access mode is required. For example, mysql, postgresql or redis. Databases.

### Verification steps

* Requires openshift (oc CLI) session 

* Create new project
```
oc new-project 3scale-testing
```
* Checkout this branch and run the operator
```
make install
make run
```
* Deploy 3scale 
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: test01.example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 

* Check system searchd deployment strategy is `Recreate`

```yaml
❯ k get deploymentconfig system-searchd -o jsonpath='{.spec.strategy}' | yq e -P
activeDeadlineSeconds: 21600
recreateParams:
  timeoutSeconds: 600
resources: {}
type: Recreate
```

 