### PR TITLE
THREESCALE-9564 redis 6

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -455,9 +455,9 @@ spec:
                 - name: RELATED_IMAGE_SYSTEM_MEMCACHED
                   value: memcached:1.5
                 - name: RELATED_IMAGE_BACKEND_REDIS
-                  value: centos/redis-5-centos7
+                  value: quay.io/centos7/redis-6-centos7:latest
                 - name: RELATED_IMAGE_SYSTEM_REDIS
-                  value: centos/redis-5-centos7
+                  value: quay.io/centos7/redis-6-centos7:latest
                 - name: RELATED_IMAGE_SYSTEM_MYSQL
                   value: centos/mysql-80-centos7
                 - name: RELATED_IMAGE_SYSTEM_POSTGRESQL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,9 +60,9 @@ spec:
         - name: RELATED_IMAGE_SYSTEM_MEMCACHED
           value: "memcached:1.5"
         - name: RELATED_IMAGE_BACKEND_REDIS
-          value: "centos/redis-5-centos7"
+          value: "quay.io/centos7/redis-6-centos7:latest"
         - name: RELATED_IMAGE_SYSTEM_REDIS
-          value: "centos/redis-5-centos7"
+          value: "quay.io/centos7/redis-6-centos7:latest"
         - name: RELATED_IMAGE_SYSTEM_MYSQL
           value: "centos/mysql-80-centos7"
         - name: RELATED_IMAGE_SYSTEM_POSTGRESQL

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -21,11 +21,11 @@ func ZyncImageURL() string {
 }
 
 func BackendRedisImageURL() string {
-	return "centos/redis-5-centos7"
+	return "quay.io/centos7/redis-6-centos7:latest"
 }
 
 func SystemRedisImageURL() string {
-	return "centos/redis-5-centos7"
+	return "quay.io/centos7/redis-6-centos7:latest"
 }
 
 func SystemMySQLImageURL() string {

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -1,15 +1,16 @@
 package operator
 
 import (
-	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	appsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/pkg/upgrade"
 )
 
 // RedisDependencyReconciler is a generic DependencyReconciler that reconciles
@@ -68,6 +69,8 @@ func (r *RedisReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigPriorityClassMutator,
 		reconcilers.DeploymentConfigTopologySpreadConstraintsMutator,
 		reconcilers.DeploymentConfigPodTemplateAnnotationsMutator,
+		// 3scale 2.13 -> 2.14
+		upgrade.RedisCommandArgsEnv,
 	)
 	err = r.ReconcileDeploymentConfig(r.DeploymentConfig(redis), dcMutator)
 	if err != nil {

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -70,7 +70,7 @@ func (r *RedisReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigTopologySpreadConstraintsMutator,
 		reconcilers.DeploymentConfigPodTemplateAnnotationsMutator,
 		// 3scale 2.13 -> 2.14
-		upgrade.RedisCommandArgsEnv,
+		upgrade.Redis6CommandArgsEnv,
 	)
 	err = r.ReconcileDeploymentConfig(r.DeploymentConfig(redis), dcMutator)
 	if err != nil {

--- a/pkg/upgrade/common.go
+++ b/pkg/upgrade/common.go
@@ -1,0 +1,7 @@
+package upgrade
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("upgrade")

--- a/pkg/upgrade/redis_2.14.go
+++ b/pkg/upgrade/redis_2.14.go
@@ -1,0 +1,48 @@
+package upgrade
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/3scale/3scale-operator/pkg/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+// SystemBackendUrls reconciles environment variables for Backend URLs on system DC
+func RedisCommandArgsEnv(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	var updated bool
+
+	desiredName := common.ObjectInfo(desired)
+
+	if len(desired.Spec.Template.Spec.Containers) != 1 {
+		return false, fmt.Errorf("%s desired spec.template.spec.containers length changed to '%d', should be 1", desiredName, len(desired.Spec.Template.Spec.Containers))
+	}
+
+	if len(existing.Spec.Template.Spec.Containers) != 1 {
+		log.Info(fmt.Sprintf("%s spec.template.spec.containers length changed to '%d', recreating dc", desiredName, len(existing.Spec.Template.Spec.Containers)))
+		existing.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+		updated = true
+	}
+
+	// Env Vars added in 2.14
+	tmpChanged := helper.EnvVarReconciler(
+		desired.Spec.Template.Spec.Containers[0].Env,
+		&existing.Spec.Template.Spec.Containers[0].Env,
+		"REDIS_CONF")
+	updated = updated || tmpChanged
+
+	// Command updated in 2.14
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Command, desired.Spec.Template.Spec.Containers[0].Command) {
+		existing.Spec.Template.Spec.Containers[0].Command = desired.Spec.Template.Spec.Containers[0].Command
+		updated = true
+	}
+
+	// Args updated in 2.14
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Args, desired.Spec.Template.Spec.Containers[0].Args) {
+		existing.Spec.Template.Spec.Containers[0].Args = desired.Spec.Template.Spec.Containers[0].Args
+		updated = true
+	}
+
+	return updated, nil
+}

--- a/pkg/upgrade/redis_2.14.go
+++ b/pkg/upgrade/redis_2.14.go
@@ -9,8 +9,8 @@ import (
 	appsv1 "github.com/openshift/api/apps/v1"
 )
 
-// SystemBackendUrls reconciles environment variables for Backend URLs on system DC
-func RedisCommandArgsEnv(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+// Redis6CommandArgsEnv reconciles environment variables, command and args
+func Redis6CommandArgsEnv(desired, existing *appsv1.DeploymentConfig) (bool, error) {
 	var updated bool
 
 	desiredName := common.ObjectInfo(desired)


### PR DESCRIPTION
### What
Support Redis 6 for internal databases. System and Backend redis are upgraded to Redis 6

Fixes https://issues.redhat.com/browse/THREESCALE-9564

The upgrade should only happen when redis is used as internal database, either for backend or system. 

From the  [Redis 6 release notes](https://raw.githubusercontent.com/antirez/redis/6.0/00-RELEASENOTES)

```
Migrating from 5.0 to 6.0
=========================

Redis 6.0 is mostly a strict superset of 5.0, you should not have any problem
upgrading your application from 5.0 to 6.0. However this is a list of small
non-backward compatible changes introduced in the 6.0 release:

* The SPOP <count> command no longer returns null when the set key does not
  exist. Now it returns the empty set as it should and as happens when it is
  called with a 0 argument. This is technically a fix, however it changes the
  old behavior.
```

Command level compatibility should not be an issue for 3scale, as there is support for Redis 6 since 3scale 2.11. 

### Verification Steps: Fresh install

* Requires openshift (oc CLI) session

* Create new project
```
oc new-project 3scale-redis-6
```
* Checkout this PR's branch and run the operator
```
make install
make run
```
* Deploy 3scale
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 
* Check the backend redis imagestream for the redis image based on `quay.io/centos7/redis-6-centos7`
```
❯ k get is backend-redis -o jsonpath='{.status.tags}' | yq e -P
- items:
    - created: "2023-07-07T14:44:09Z"
      dockerImageReference: quay.io/centos7/redis-6-centos7@sha256:b549dc0714dd1307e2b6be9cc28adceac4d2d1b6bf032898d88f425b7c8939d0
      generation: 2
      image: sha256:b549dc0714dd1307e2b6be9cc28adceac4d2d1b6bf032898d88f425b7c8939d0
  tag: "2.14"
```
* Use 3scale's default product, default application to run a request against 3scale echo api. The request should be validated by backend. Backend listener logs should show the following line
```
 ❯ k logs $(oc get pods --selector deploymentconfig=backend-listener -o name)
.....
0.129.0.160 - - [07/Jul/2023 14:03:19 UTC] "GET /transactions/authrep.xml?service_token=a7e833147f4e834d007f1f44ef72b45602d246d06ef414c8641c7eb0770bc51d&service_id=2&usage%5Bhits%5D=1&user_key=f088e04d70d4434688208c125b1cf3ff HTTP/1.1" 200 - 0.031655315 0 0 0 12 19 7 - "rejection_reason_header=1&limit_headers=1&no_body=1"
....
```

### Verification Steps: Upgrade from 2.13

* Requires openshift (oc CLI) session

* Create new project
```
oc new-project 3scale-redis-6-upgrade
```
* Install upstream (community) 3scale Operator with a subscription to the 2.13 channel
* Deploy 3scale
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 

* Check the backend redis imagestream for the redis image based on `centos/redis-5-centos7`
```
❯ k get is backend-redis -o jsonpath='{.status.tags}' | yq e -P
- items:
    - created: "2023-07-07T14:57:12Z"
      dockerImageReference: centos/redis-5-centos7@sha256:7e12e362a6430f8831a445b26181285c3d36df29b1fdd2abe1247d5068905129
      generation: 2
      image: sha256:7e12e362a6430f8831a445b26181285c3d36df29b1fdd2abe1247d5068905129
  tag: "2.13"
```
* Use 3scale's default product, default application to run a request against 3scale echo api.
* Remove the running operator 2.13 (remove subscription or from "Installed Operators" in the catalog UI.
* Run Upgrade: Checkout this PR's branch and run the operator
```
make install
make run
```
During upgrade, some pods my restart and report error. That is expected as redis is being replaced and living pods will see connections being dropped. 

Wait until all pods are up&running. `oc wait ` does not work during upgrade because all the deploymentconfigs will report as available (they have at least one available pod up&running) during the upgrade. 

* Check new redis pod runs image based on `quay.io/centos7/redis-6-centos7`
```
❯ k get $(oc get pods --selector deploymentconfig=backend-redis -o name) -o jsonpath='{.spec.containers[0].image}' | yq e -P
quay.io/centos7/redis-6-centos7@sha256:b549dc0714dd1307e2b6be9cc28adceac4d2d1b6bf032898d88f425b7c8939d0
``` 

* Check redis new pod logs
```
❯ k logs $(oc get pods --selector deploymentconfig=backend-redis -o name) 
---> 15:13:07     Processing Redis configuration files ...
---> 15:13:07     WARNING: setting REDIS_PASSWORD is recommended
---> 15:13:07     Sourcing post-init.sh ...
---> 15:13:07     Cleaning up environment variable REDIS_PASSWORD ...
---> 15:13:07     Running final exec -- Only Redis logs after this point
1:C 07 Jul 2023 15:13:07.403 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 07 Jul 2023 15:13:07.403 # Redis version=6.0.16, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 07 Jul 2023 15:13:07.403 # Configuration loaded
1:M 07 Jul 2023 15:13:07.405 * Running mode=standalone, port=6379.
1:M 07 Jul 2023 15:13:07.405 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
1:M 07 Jul 2023 15:13:07.405 # Server initialized
1:M 07 Jul 2023 15:13:07.405 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo madvise > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled (set to 'madvise' or 'never').
1:M 07 Jul 2023 15:13:07.422 * DB loaded from append only file: 0.016 seconds
1:M 07 Jul 2023 15:13:07.422 * Ready to accept connections
```
Note on the line "DB loaded from append only file: 0.016 seconds". It seems that redis just loads the append only file as if it was generated by another redis 6 instance. Seems that the format has not change since redis 5, hence updating data file is not even needed.

5. Run the same request it was done before the upgrade. The request is returning 200OK and 3scale backend is validating the request.
```
 ❯ k logs $(oc get pods --selector deploymentconfig=backend-listener -o name)
.....
0.129.0.160 - - [07/Jul/2023 14:03:19 UTC] "GET /transactions/authrep.xml?service_token=a7e833147f4e834d007f1f44ef72b45602d246d06ef414c8641c7eb0770bc51d&service_id=2&usage%5Bhits%5D=1&user_key=f088e04d70d4434688208c125b1cf3ff HTTP/1.1" 200 - 0.031655315 0 0 0 12 19 7 - "rejection_reason_header=1&limit_headers=1&no_body=1"
....
```
