### PR TITLE
fix bundle-custom-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,8 @@ bundle-custom-updates: $(YQ)
 	$(YQ) --inplace '.spec.displayName = "$(BUNDLE_PREFIX) 3scale operator"' $(PROJECT_PATH)/bundle/manifests/3scale-operator.clusterserviceversion.yaml
 	$(YQ) --inplace '.spec.provider.name = "$(BUNDLE_PREFIX)"' $(PROJECT_PATH)/bundle/manifests/3scale-operator.clusterserviceversion.yaml
 	$(YQ) --inplace '.annotations."operators.operatorframework.io.bundle.package.v1" = "$(BUNDLE_PREFIX)-3scale-operator"' $(PROJECT_PATH)/bundle/metadata/annotations.yaml
-	$(SED_INLINE) -E 's/(operators\.operatorframework\.io\.bundle\.package\.v1=).+/\1$(BUNDLE_PREFIX)-3scale-operator/' $(PROJECT_PATH)/bundle.Dockerfile	@echo "Update operator image reference URL"
+	$(SED_INLINE) -E 's/(operators\.operatorframework\.io\.bundle\.package\.v1=).+/\1$(BUNDLE_PREFIX)-3scale-operator/' $(PROJECT_PATH)/bundle.Dockerfile
+	@echo "Update operator image reference URL"
 	$(YQ) --inplace '.metadata.annotations.containerImage = "$(IMG)"' $(PROJECT_PATH)/bundle/manifests/3scale-operator.clusterserviceversion.yaml
 	$(YQ) --inplace '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "$(IMG)"' $(PROJECT_PATH)/bundle/manifests/3scale-operator.clusterserviceversion.yaml
 


### PR DESCRIPTION
# What
make command bundle-custom-build failing on the sed command e.g.
```bash
make bundle-custom-build IMG=quay.io/austincunningham/3scale-operator:0.0.1 BUNDLE_IMG=quay.io/austincunningham/3scale-operator-bundles:0.0.1
Update metadata to avoid collision with existing 3scale Operator official public operators catalog entries
using BUNDLE_PREFIX dev1689318844
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.metadata.name = "dev1689318844-3scale-operator.0.0.1"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.spec.displayName = "dev1689318844 3scale operator"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.spec.provider.name = "dev1689318844"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.annotations."operators.operatorframework.io.bundle.package.v1" = "dev1689318844-3scale-operator"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/metadata/annotations.yaml
sed -i -E 's/(operators\.operatorframework\.io\.bundle\.package\.v1=).+/\1dev1689318844-3scale-operator/' /home/austincunningham/repo-integr8ly/3scale-operator/bundle.Dockerfile @echo "Update operator image reference URL"
sed: can't read @echo: No such file or directory
sed: can't read Update operator image reference URL: No such file or directory
make: *** [Makefile:218: bundle-custom-updates] Error 2
```
was working before this change https://github.com/3scale/3scale-operator/pull/813/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L202-R209 , Looks like its a space issue with the sed command.

# Verification
Run the following and the `bundle-custom-build` command should complete
```bash
DOCKER_ORG=<your org>
DOCKER_REGISTRY=quay.io

make docker-build-only IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:$1
make operator-image-push IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:$1

make bundle-custom-build IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator:$1 BUNDLE_IMG=$DOCKER_REGISTRY/$DOCKER_ORG/apicast-operator-bundles:$1
```
e.g.
```bash
make bundle-custom-build IMG=quay.io/austincunningham/3scale-operator:0.0.1 BUNDLE_IMG=quay.io/austincunningham/3scale-operator-bundles:0.0.1
Update metadata to avoid collision with existing 3scale Operator official public operators catalog entries
using BUNDLE_PREFIX dev1689318923
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.metadata.name = "dev1689318923-3scale-operator.0.0.1"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.spec.displayName = "dev1689318923 3scale operator"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.spec.provider.name = "dev1689318923"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.annotations."operators.operatorframework.io.bundle.package.v1" = "dev1689318923-3scale-operator"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/metadata/annotations.yaml
sed -i -E 's/(operators\.operatorframework\.io\.bundle\.package\.v1=).+/\1dev1689318923-3scale-operator/' /home/austincunningham/repo-integr8ly/3scale-operator/bundle.Dockerfile
Update operator image reference URL
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.metadata.annotations.containerImage = "quay.io/austincunningham/3scale-operator:0.0.1"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/yq --inplace '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "quay.io/austincunningham/3scale-operator:0.0.1"' /home/austincunningham/repo-integr8ly/3scale-operator/bundle/manifests/3scale-operator.clusterserviceversion.yaml
/home/austincunningham/repo-integr8ly/3scale-operator/bin/operator-sdk bundle validate ./bundle
INFO[0000] Found annotations file                        bundle-dir=bundle container-tool=docker
INFO[0000] Could not find optional dependencies file     bundle-dir=bundle container-tool=docker
INFO[0000] All validation tests have completed successfully 
docker build -f bundle.Dockerfile -t quay.io/austincunningham/3scale-operator-bundles:0.0.1 .
[+] Building 0.1s (7/7) FINISHED                                                                                                                                                                                                        
 => [internal] load .dockerignore                                                                                                                                                                                                  0.0s
 => => transferring context: 108B                                                                                                                                                                                                  0.0s
 => [internal] load build definition from bundle.Dockerfile                                                                                                                                                                        0.0s
 => => transferring dockerfile: 941B                                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                  0.0s
 => => transferring context: 57.09kB                                                                                                                                                                                               0.0s
 => [1/3] COPY bundle/manifests /manifests/                                                                                                                                                                                        0.0s
 => [2/3] COPY bundle/metadata /metadata/                                                                                                                                                                                          0.0s
 => [3/3] COPY bundle/tests/scorecard /tests/scorecard/                                                                                                                                                                            0.0s
 => exporting to image                                                                                                                                                                                                             0.0s
 => => exporting layers                                                                                                                                                                                                            0.0s
 => => writing image sha256:480a985cf5188a698c08d47cf2bb281bd8ee5ee10fba3d0ceb750b23f46010e0                                                                                                                                       0.0s
 => => naming to quay.io/austincunningham/3scale-operator-bundles:0.0.1                                                                                                                                                            0.0s
git checkout bundle/manifests/3scale-operator.clusterserviceversion.yaml bundle/metadata/annotations.yaml bundle.Dockerfile
Updated 3 paths from the index
```



