### PR TITLE
[WIP] Threescale 6735 - Reconcile Secrets

### DIFF
--- a/controllers/apps/secret_to_apimanager_event_mapper.go
+++ b/controllers/apps/secret_to_apimanager_event_mapper.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	APImanagerSecretLabelPrefix = "secret.apimanager.apps.3scale.net/"
+)
+
+// SecretToApimanagerEventMapper is an EventHandler that maps secret object to apimanager CR's
+type SecretToApimanagerEventMapper struct {
+	K8sClient client.Client
+	Logger    logr.Logger
+	Namespace string
+}
+
+func apimanagerSecretLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", APImanagerSecretLabelPrefix, uid)
+}
+
+func (s *SecretToApimanagerEventMapper) Map(obj client.Object) []reconcile.Request {
+
+	apimanagerList := &appsv1alpha1.APIManagerList{}
+
+	// filter by Secret UID
+	opts := []client.ListOption{client.HasLabels{apimanagerSecretLabelKey(string(obj.GetUID()))}}
+
+	// Support namespace scope or cluster scoped
+	if s.Namespace != "" {
+		opts = append(opts, client.InNamespace(s.Namespace))
+	}
+
+	err := s.K8sClient.List(context.Background(), apimanagerList, opts...)
+	if err != nil {
+		s.Logger.Error(err, "reading apimanager list")
+		return nil
+	}
+
+	s.Logger.V(1).Info("Processing object", "key", client.ObjectKeyFromObject(obj), "accepted", len(apimanagerList.Items) > 0)
+
+	requests := []reconcile.Request{}
+	for idx := range apimanagerList.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      apimanagerList.Items[idx].GetName(),
+			Namespace: apimanagerList.Items[idx].GetNamespace(),
+		}})
+	}
+
+	return requests
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	apimachinerymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"runtime"
 
@@ -119,6 +120,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	secretLabelSelector, err := apimachinerymetav1.ParseToLabelSelector("apimanager.apps.3scale.net/watched-by=apimanager")
+	if err != nil {
+		setupLog.Error(err, "unable parse apimanager secrets label")
+		os.Exit(1)
+	}
+
+	if secretLabelSelector == nil {
+		setupLog.Info("secretLabelSelector is empty")
+		os.Exit(1)
+	}
+
 	discoveryClientAPIManager, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to create discovery client")
@@ -130,6 +142,8 @@ func main() {
 			ctrl.Log.WithName("controllers").WithName("APIManager"),
 			discoveryClientAPIManager,
 			mgr.GetEventRecorderFor("APIManager")),
+		SecretLabelSelector: *secretLabelSelector,
+		WatchedNamespace:    namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "APIManager")
 		os.Exit(1)

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -606,7 +606,7 @@ func (apicast *Apicast) productionVolumes() []v1.Volume {
 			Name: customPolicy.VolumeName(),
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: customPolicy.SecretRef.Name,
+					SecretName: customPolicy.Secret.Name,
 				},
 			},
 		})
@@ -662,7 +662,7 @@ func (apicast *Apicast) stagingVolumes() []v1.Volume {
 			Name: customPolicy.VolumeName(),
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: customPolicy.SecretRef.Name,
+					SecretName: customPolicy.Secret.Name,
 				},
 			},
 		})

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -12,9 +12,9 @@ import (
 )
 
 type CustomPolicy struct {
-	Name      string
-	Version   string
-	SecretRef v1.LocalObjectReference
+	Name    string
+	Version string
+	Secret  *v1.Secret
 }
 
 func (c CustomPolicy) VolumeName() string {

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -26,8 +26,9 @@ type ApicastOptionsProvider struct {
 }
 
 const (
-	APIcastEnvironmentCMAnnotation = "apps.3scale.net/env-configmap-hash"
-	PodPrioritySystemNodeCritical  = "system-node-critical"
+	APIcastEnvironmentCMAnnotation             = "apps.3scale.net/env-configmap-hash"
+	PodPrioritySystemNodeCritical              = "system-node-critical"
+	CustomPoliciesSecretResverAnnotationPrefix = "apimanager.apps.3scale.net/custompolicy-secret-resource-version-"
 )
 
 func NewApicastOptionsProvider(apimanager *appsv1alpha1.APIManager, client client.Client) *ApicastOptionsProvider {
@@ -212,7 +213,13 @@ func (a *ApicastOptionsProvider) productionPodTemplateLabels() map[string]string
 func (a *ApicastOptionsProvider) setCustomPolicies() error {
 	for idx, customPolicySpec := range a.apimanager.Spec.Apicast.ProductionSpec.CustomPolicies {
 		// CR Validation ensures secret name is not nil
-		err := a.validateCustomPolicySecret(customPolicySpec.SecretRef.Name)
+
+		namespacedName := types.NamespacedName{
+			Name:      customPolicySpec.SecretRef.Name, // CR Validation ensures not nil
+			Namespace: a.apimanager.Namespace,
+		}
+
+		secret, err := a.validateCustomPolicySecret(context.TODO(), customPolicySpec.SecretRef.Name, namespacedName)
 		if err != nil {
 			errors := field.ErrorList{}
 			customPoliciesIdxFldPath := field.NewPath("spec").
@@ -224,16 +231,22 @@ func (a *ApicastOptionsProvider) setCustomPolicies() error {
 		}
 
 		a.apicastOptions.ProductionCustomPolicies = append(a.apicastOptions.ProductionCustomPolicies, component.CustomPolicy{
-			Name:      customPolicySpec.Name,
-			Version:   customPolicySpec.Version,
-			SecretRef: *customPolicySpec.SecretRef,
+			Name:    customPolicySpec.Name,
+			Version: customPolicySpec.Version,
+			Secret:  secret,
 		})
 	}
 
 	// TODO(eastizle): DRY!!
 	for idx, customPolicySpec := range a.apimanager.Spec.Apicast.StagingSpec.CustomPolicies {
 		// CR Validation ensures secret name is not nil
-		err := a.validateCustomPolicySecret(customPolicySpec.SecretRef.Name)
+
+		namespacedName := types.NamespacedName{
+			Name:      customPolicySpec.SecretRef.Name, // CR Validation ensures not nil
+			Namespace: a.apimanager.Namespace,
+		}
+
+		secret, err := a.validateCustomPolicySecret(context.TODO(), customPolicySpec.SecretRef.Name, namespacedName)
 		if err != nil {
 			errors := field.ErrorList{}
 			customPoliciesIdxFldPath := field.NewPath("spec").
@@ -245,27 +258,35 @@ func (a *ApicastOptionsProvider) setCustomPolicies() error {
 		}
 
 		a.apicastOptions.StagingCustomPolicies = append(a.apicastOptions.StagingCustomPolicies, component.CustomPolicy{
-			Name:      customPolicySpec.Name,
-			Version:   customPolicySpec.Version,
-			SecretRef: *customPolicySpec.SecretRef,
+			Name:    customPolicySpec.Name,
+			Version: customPolicySpec.Version,
+			Secret:  secret,
 		})
 	}
 
 	return nil
 }
 
-func (a *ApicastOptionsProvider) validateCustomPolicySecret(name string) error {
-	_, err := a.secretSource.RequiredFieldValueFromRequiredSecret(name, "init.lua")
+func (a *ApicastOptionsProvider) validateCustomPolicySecret(ctx context.Context, name string, nn types.NamespacedName) (*v1.Secret, error) {
+	secret := &v1.Secret{}
+	err := a.client.Get(ctx, nn, secret)
+
 	if err != nil {
-		return err
+		// NotFoundError is also an error, it is required to exist
+		return nil, err
+	}
+
+	_, err = a.secretSource.RequiredFieldValueFromRequiredSecret(name, "init.lua")
+	if err != nil {
+		return nil, err
 	}
 
 	_, err = a.secretSource.RequiredFieldValueFromRequiredSecret(name, "apicast-policy.json")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return secret, nil
 }
 
 func (a *ApicastOptionsProvider) setTracingConfiguration() error {
@@ -448,6 +469,13 @@ func (a *ApicastOptionsProvider) setProductionProxyConfigurations() {
 func (a *ApicastOptionsProvider) additionalPodAnnotations() map[string]string {
 	annotations := map[string]string{
 		APIcastEnvironmentCMAnnotation: a.envConfigMapHash(),
+	}
+
+	for idx := range a.apicastOptions.ProductionCustomPolicies {
+		// Secrets must exist
+		// Annotation key includes the name of the secret
+		annotationKey := fmt.Sprintf("%s%s", CustomPoliciesSecretResverAnnotationPrefix, a.apicastOptions.ProductionCustomPolicies[idx].Secret.Name)
+		annotations[annotationKey] = a.apicastOptions.ProductionCustomPolicies[idx].Secret.ResourceVersion
 	}
 
 	return annotations

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -556,11 +556,6 @@ func apicastPodTemplateEnvConfigMapAnnotationsMutator(desired, existing *appsv1.
 }
 
 func (r *ApicastReconciler) reconcileAPImanagerCR(ctx context.Context) (ctrl.Result, error) {
-	//logger, err := logr.FromContext(ctx)
-	//if err != nil {
-	//	return ctrl.Result{}, err
-	//
-	//}
 
 	changed := false
 	changed, err := r.reconcileApimanagerSecretLabels(ctx)
@@ -570,7 +565,7 @@ func (r *ApicastReconciler) reconcileAPImanagerCR(ctx context.Context) (ctrl.Res
 
 	if changed {
 		err = r.Client().Update(ctx, r.apiManager)
-		//logger.Info("reconciling", "error", err)
+		r.logger.Info("reconciling", "error", err)
 	}
 
 	return ctrl.Result{Requeue: changed}, err
@@ -587,10 +582,20 @@ func (r *ApicastReconciler) reconcileApimanagerSecretLabels(ctx context.Context)
 
 func (r *ApicastReconciler) getSecretUIDs(ctx context.Context) ([]string, error) {
 	// production custom policy
+	// staging custom policy
 
 	secretKeys := []client.ObjectKey{}
 	if r.apiManager.Spec.Apicast.ProductionSpec.CustomPolicies != nil {
 		for _, customPolicy := range r.apiManager.Spec.Apicast.ProductionSpec.CustomPolicies {
+			secretKeys = append(secretKeys, client.ObjectKey{
+				Name:      customPolicy.SecretRef.Name,
+				Namespace: r.apiManager.Namespace,
+			})
+		}
+	}
+
+	if r.apiManager.Spec.Apicast.StagingSpec.CustomPolicies != nil {
+		for _, customPolicy := range r.apiManager.Spec.Apicast.StagingSpec.CustomPolicies {
 			secretKeys = append(secretKeys, client.ObjectKey{
 				Name:      customPolicy.SecretRef.Name,
 				Namespace: r.apiManager.Namespace,

--- a/pkg/3scale/amp/operator/apimanager_utils.go
+++ b/pkg/3scale/amp/operator/apimanager_utils.go
@@ -1,0 +1,48 @@
+package operator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+)
+
+const (
+	APIManagerSecretLabelPrefix = "secret.apimanager.apps.3scale.net/"
+	APIManagerSecretLabelValue  = "true"
+)
+
+func apimanagerSecretLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", APIManagerSecretLabelPrefix, uid)
+}
+
+func replaceAPIManagerSecretLabels(apimanager *appsv1alpha1.APIManager, desiredSecretUIDs []string) bool {
+
+	existingLabels := apimanager.GetLabels()
+
+	if existingLabels == nil {
+		existingLabels = map[string]string{}
+	}
+
+	existingSecretLabels := map[string]string{}
+
+	// existing Secret UIDs not included in desiredAPIUIDs are deleted
+	for k := range existingLabels {
+		if strings.HasPrefix(k, APIManagerSecretLabelPrefix) {
+			existingSecretLabels[k] = APIManagerSecretLabelValue
+			// it is safe to remove keys while looping in range
+			delete(existingLabels, k)
+		}
+	}
+
+	desiredSecretLabels := map[string]string{}
+	for _, uid := range desiredSecretUIDs {
+		desiredSecretLabels[apimanagerSecretLabelKey(uid)] = APIManagerSecretLabelValue
+		existingLabels[apimanagerSecretLabelKey(uid)] = APIManagerSecretLabelValue
+	}
+
+	apimanager.SetLabels(existingLabels)
+
+	return !reflect.DeepEqual(existingSecretLabels, desiredSecretLabels)
+}


### PR DESCRIPTION
### What 
[THREESCALE-6735](https://issues.redhat.com/browse/THREESCALE-6735) - Addition of label reconciliation for Apicast Custom Policies

### How

- The APIManager referencing the secret will have labels with the UID of the secrets being referenced.
- The controller will watch secrets with the `apimanager.apps.3scale.net/watched-by=apimanager` label.  The operator will get notified of the changes in the secret only when this label is present.
- Controller implements a custom mapper that:
  - Lists all the APIManager CRs with the secrets referencing the label 
  -  Creates a reconciliation request for each element in the list
- The deployment will be notified of the update to the secret through annotations in the pod template. The annotations in the pod template will specify the resource version of the secret so each time the secret is updated the resource version changes and it then updates the annotation in the pod template causing a redeployment of the pod. When the pod is redeployed it will read the updated content of the secret.

### Verification 

1.  Run the following commands to install the 3scale operator

```bash
go mod vendor 
go mod tidy 
make install
export NAMESPACE=3scale-test
oc new-project $NAMESPACE
make download
make run
```

2.  For the operator to create routes we need to mock the s3 credentials secret, run the following command.
```bash
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```

3. Save the following to files to create custom policy secrets.

- apicast-policy.json 
```bash 
{
  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
  "name": "APIcast Example Policy",
  "summary": "This is just an example.",
  "description": "This policy is just an example how to write your custom policy.",
  "version": "0.1",
  "configuration": {
    "type": "object",
    "properties": { }
  }
}
```

- example.lua
```bash
local setmetatable = setmetatable

local _M = require('apicast.policy').new('Example', '0.1')
local mt = { __index = _M }

function _M.new()
  return setmetatable({}, mt)
end

function _M:init()
  -- do work when nginx master process starts
end

function _M:init_worker()
  -- do work when nginx worker process is forked from master
end

function _M:rewrite()
  -- change the request before it reaches upstream
    ngx.req.set_header('X-CustomPolicy', 'customValue')
end

function _M:access()
  -- ability to deny the request before it is sent upstream
end

function _M:content()
  -- can create content instead of connecting to upstream
end

function _M:post_action()
  -- do something after the response was sent to the client
end

function _M:header_filter()
  -- can change response headers
end

function _M:body_filter()
  -- can read and change response body
  -- https://github.com/openresty/lua-nginx-module/blob/master/README.markdown#body_filter_by_lua
end

function _M:log()
  -- can do extra logging
end

function _M:balancer()
  -- use for example require('resty.balancer.round_robin').call to do load balancing
end

return _M
```

- init.lua
```bash 
return require('example')
```


4. Create apicast customPolicy secrets 
```bash
 oc create secret generic custom-policy2-secret \
  --from-file=./apicast-policy.json \
  --from-file=./init.lua \
  --from-file=./example.lua
  
   oc create secret generic custom-policy1-secret \
  --from-file=./apicast-policy.json \
  --from-file=./init.lua \
  --from-file=./example.lua
```

5. Add this label to the secrets `apimanager.apps.3scale.net/watched-by: apimanager`

6. Deploy the APIManager CR , specifying the secrets and wildcardDomain.
```bash
oc apply -f - <<EOF
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: 3scale-test
spec:
  system: 
    fileStorage: 
      simpleStorageService: 
        configurationSecretRef: 
          name: s3-credentials
  wildcardDomain: apps.pstefans.giq5.s1.devshift.org
  apicast:
    stagingSpec:
      customPolicies:
        - name: custom-policy1
          version: "0.1"
          secretRef:
             name: custom-policy1-secret
        - name: custom-policy2
          version: "0.1"
          secretRef:
              name: custom-policy2-secret
    productionSpec:
      customPolicies:
        - name: custom-policy1
          version: "0.1"
          secretRef:
             name: custom-policy1-secret
        - name: custom-policy2
          version: "0.1"
          secretRef:
              name: custom-policy2-secret
              
EOF
```

7. APIManager should have a label with the UIDs of the two secrets
8. Apicast production DC should have annotations with the two secret file names
9.  The pod template in the apicast production CR should have two annotations for the labels along with their resourceVersion number.
20. Add a new label to one of the secrets the new resourceVersion of the secret should update the pod template annotation in the apicast production DC


