### PR TITLE
THREESCALE-9001 / Added Zync Routes Resync Function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.2
 )
 
+require github.com/moby/spdystream v0.2.0 // indirect
+
 require (
 	cloud.google.com/go/compute v1.7.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -185,6 +186,7 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -623,6 +625,7 @@ github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=

--- a/pkg/helper/podHelper.go
+++ b/pkg/helper/podHelper.go
@@ -1,0 +1,131 @@
+package helper
+
+import (
+	"bytes"
+	l "github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	kube "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+//go:generate moq -out pod_executor_moq.go . PodExecutorInterface
+type PodExecutorInterface interface {
+	ExecuteRemoteCommand(ns string, podName string, command []string) (string, string, error)
+	ExecuteRemoteContainerCommand(ns string, podName string, container string, command []string) (string, string, error)
+}
+
+type PodExecutor struct {
+	Log l.Logger
+}
+
+var _ PodExecutorInterface = &PodExecutor{}
+
+func NewPodExecutor(log l.Logger) *PodExecutor {
+	return &PodExecutor{
+		Log: log,
+	}
+}
+
+func (p PodExecutor) ExecuteRemoteCommand(ns string, podName string, command []string) (string, string, error) {
+
+	kubeClient, restConfig, err := getClient()
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed to get client")
+	}
+
+	req := kubeClient.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
+		Namespace(ns).SubResource("exec")
+	option := &v1.PodExecOptions{
+		Command: command,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+		//Container: container,
+	}
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: buf,
+		Stderr: errBuf,
+	})
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	return buf.String(), errBuf.String(), nil
+}
+
+func (p PodExecutor) ExecuteRemoteContainerCommand(ns string, podName string, container string, command []string) (string, string, error) {
+	kubeClient, restConfig, err := getClient()
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed to get client")
+	}
+
+	req := kubeClient.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
+		Namespace(ns).SubResource("exec")
+	option := &v1.PodExecOptions{
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       true,
+		Container: container,
+	}
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+
+	streamOptions := remotecommand.StreamOptions{
+		Stdout: buf,
+		Stderr: errBuf,
+		Tty:    option.TTY,
+	}
+	
+	err = exec.Stream(streamOptions)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	return buf.String(), errBuf.String(), nil
+}
+
+func getClient() (*kube.Clientset, *restclient.Config, error) {
+
+	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	)
+	restCfg, err := kubeCfg.ClientConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kubeClient, err := kube.NewForConfig(restCfg)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Failed to generate new client")
+	}
+	return kubeClient, restCfg, nil
+}


### PR DESCRIPTION
[THREESCALE-9001](https://issues.redhat.com/browse/THREESCALE-9001)

# WHAT

There are instances where the "bundle exec rake zync:resync:domains" needs to run on the system-sidekiq pod to recreate routes.
This was previously done in RHOAM but now it will be managed by the threescale operator.

# TEST

- Checkout this branch
- Run the following commands: 
- - `make docker-build-only IMG=docker.io/<user>/3scale-operator:<tag>`
- - `make operator-image-push IMG=docker.io/<user>/3scale-operator:<tag>`
- - `make bundle-custom-build IMG=docker.io/<user>/3scale-operator:<tag> BUNDLE_IMG=docker.io/<user>/3scale-operator-bundles:<tag>`
- - `make bundle-image-push BUNDLE_IMG=docker.io/<user>/3scale-operator-bundles:<tag>`
- - `make bundle-run BUNDLE_IMG=docker.io/<user>/3scale-operator-bundles:<tag>`

- Once that runs and the operator is installed create the apimanager: 
- -  `oc new-project 3scale-test`
- -  Create the test secret:
``` 
oc apply -f - << EOF
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: 3scale-test
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```

- -  Create the api manager (Make sure to change the wildcard domain to your personal cluster , you can find it in the url)
```
oc create -f - << EOF
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: 3scale-test
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: apps.<cluster>.devshift.org

EOF
```
- - Check the progress of the api manager : 
- - `oc get apimanager apimanager-sample -oyaml | yq '.status'`

- Navigate to `Networking -> Routes` on the `3scale-test` namespace once all deployments are in the `Ready` status.
- If a route gets deleted it should be restored.

### Testing multitenancy

- go into Secrets -> system-seed -> get master password
- click the master route and put in (username: master) along with the password you got.
- Find Accounts -> Create account .
- In Networking -> routes there should be new routes created linked to the account you just made.
- Delete one of the `system-provider` or `system-developer` routes  associated with the new tenant they should also recreate.

-------------------------------------------------------------------------------------

# TODO

Implement unit testing for the additional logic in this pr.
