### PR TITLE
THREESCALE-9491 / ProxyConfigPromotes deletes if product is promoted

### DIFF
--- a/controllers/capabilities/proxyconfigpromote_status_reconciler.go
+++ b/controllers/capabilities/proxyconfigpromote_status_reconciler.go
@@ -82,11 +82,7 @@ func (s *ProxyConfigPromoteStatusReconciler) calculateStatus() (*capabilitiesv1b
 func (s *ProxyConfigPromoteStatusReconciler) readyCondition(state string) common.Condition {
 	condition := common.Condition{
 		Type:   capabilitiesv1beta1.ProxyPromoteConfigReadyConditionType,
-		Status: corev1.ConditionFalse,
-	}
-
-	if state == "Completed" {
-		condition.Status = corev1.ConditionTrue
+		Status: corev1.ConditionTrue,
 	}
 
 	return condition


### PR DESCRIPTION
[THREESCALE-9491](https://issues.redhat.com/browse/THREESCALE-9491)

# WHAT 

3scale operator can promote APIcast configurations with a [ProxyConfigPromote](https://github.com/3scale/3scale-operator/blob/3scale-2.13-stable/doc/proxyConfigPromote-reference.md#proxyconfigpromotespec)  resource. When `spec.deleteCR` is set to `true`, the operator deletes the resource after a successful promotion.

3scale Operator didn't delete the resource when the APIcast configuration is already promoted and no promotion was made.

The changes now cause the ProxyConfigPromote  to delete despite no promotion being made.

# TEST

- Run Threescale locally on a cluster 
``` go mod vendor 
go mod tidy 
make install
export NAMESPACE=3scale-test
oc new-project $NAMESPACE
make download
make run
```
- For the operator to create routes we need to mock the s3 credentials secret, run the following command.
``` kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Create Api Manager ( replace cluster wih your cluster link found in the url)
``` apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: 3scale-test
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: apps.<cluster>.devshift.org

EOF
```
- Check for deployments to be all ready: `oc get apimanager apimanager-sample -oyaml | yq '.status'`
- Create a backend
```
kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend1-cr
  namespace: 3scale-test
spec:
  mappingRules:
    - httpMethod: GET
      increment: 1
      last: true
      metricMethodRef: hits
      pattern: /
  name: backend1
  privateBaseURL: 'https://api.example.com'
  systemName: backend1
EOF
```
- Create a product 
```kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1-cr
  namespace: 3scale-test
spec:
  name: product1
  backendUsages:
    backend1:
      path: /
EOF
```
- Create a  ProxyConfigPromote
```
kubectl apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product1-v1-production
  namespace: 3scale-test
spec:
  productCRName: product1-cr
  production: true
  deleteCR: true
EOF
```
- Make sure the  ProxyConfigPromote deletes and the product has a successful promotion
- create the same  ProxyConfigPromote as above and apply it again.
- The ProxyConfigPromote should once again delete with no errors.