### PR TITLE
[WIP] THREESCALE-10088 - Reconcile secrets - OpenApi secret, for OpenApi and ActiveDoc CRs

### DIFF
--- a/controllers/apps/secret_to_apimanager_event_mapper.go
+++ b/controllers/apps/secret_to_apimanager_event_mapper.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	APImanagerSecretLabelPrefix = "secret.apimanager.apps.3scale.net/"
+)
+
+// SecretToApimanagerEventMapper is an EventHandler that maps secret object to apimanager CR's
+type SecretToApimanagerEventMapper struct {
+	K8sClient client.Client
+	Logger    logr.Logger
+	Namespace string
+}
+
+func apimanagerSecretLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", APImanagerSecretLabelPrefix, uid)
+}
+
+func (s *SecretToApimanagerEventMapper) Map(obj client.Object) []reconcile.Request {
+
+	apimanagerList := &appsv1alpha1.APIManagerList{}
+
+	// filter by Secret UID
+	opts := []client.ListOption{client.HasLabels{apimanagerSecretLabelKey(string(obj.GetUID()))}}
+
+	// Support namespace scope or cluster scoped
+	if s.Namespace != "" {
+		opts = append(opts, client.InNamespace(s.Namespace))
+	}
+
+	err := s.K8sClient.List(context.Background(), apimanagerList, opts...)
+	if err != nil {
+		s.Logger.Error(err, "reading apimanager list")
+		return nil
+	}
+
+	s.Logger.V(1).Info("Processing object", "key", client.ObjectKeyFromObject(obj), "accepted", len(apimanagerList.Items) > 0)
+
+	requests := []reconcile.Request{}
+	for idx := range apimanagerList.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      apimanagerList.Items[idx].GetName(),
+			Namespace: apimanagerList.Items[idx].GetNamespace(),
+		}})
+	}
+
+	return requests
+}

--- a/controllers/capabilities/openapi_utils.go
+++ b/controllers/capabilities/openapi_utils.go
@@ -1,0 +1,46 @@
+package controllers
+
+import (
+	"fmt"
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+	"reflect"
+	"strings"
+)
+
+const (
+	OpenApiSecretLabelPrefix = "secret.openapi.apps.3scale.net/"
+	OpenApiSecretLabelValue  = "true"
+)
+
+func openApiSecretLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", OpenApiSecretLabelPrefix, uid)
+}
+
+func openapiSecretLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", OpenApiSecretLabelPrefix, uid)
+}
+
+func replaceOpenAPISecretLabels(openapi *capabilitiesv1beta1.OpenAPI, secretUID string) bool {
+	existingLabels := openapi.GetLabels()
+	if existingLabels == nil {
+		existingLabels = map[string]string{}
+	}
+
+	existingSecretLabels := map[string]string{}
+	// existing Secret UIDs not included in desiredAPIUIDs are deleted
+	for k := range existingLabels {
+		if strings.HasPrefix(k, OpenApiSecretLabelPrefix) {
+			existingSecretLabels[k] = OpenApiSecretLabelValue
+			// it is safe to remove keys while looping in range
+			delete(existingLabels, k)
+		}
+	}
+
+	desiredSecretLabels := map[string]string{}
+	desiredSecretLabels[openapiSecretLabelKey(secretUID)] = OpenApiSecretLabelValue
+	existingLabels[openapiSecretLabelKey(secretUID)] = OpenApiSecretLabelValue
+
+	openapi.SetLabels(existingLabels)
+
+	return !reflect.DeepEqual(existingSecretLabels, desiredSecretLabels)
+}

--- a/controllers/capabilities/secret_to_activedoc_event_mapper.go
+++ b/controllers/capabilities/secret_to_activedoc_event_mapper.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"context"
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecretToActiveDocEventMapper is an EventHandler that maps OpenApi secret object to ActiveDoc CR's
+type SecretToActiveDocEventMapper struct {
+	K8sClient client.Client
+	Logger    logr.Logger
+	Namespace string
+}
+
+func (s *SecretToActiveDocEventMapper) Map(obj client.Object) []reconcile.Request {
+
+	activeDocList := &capabilitiesv1beta1.ActiveDocList{}
+
+	// filter by Secret UID
+	opts := []client.ListOption{client.HasLabels{openApiSecretLabelKey(string(obj.GetUID()))}}
+
+	// Support namespace scope or cluster scoped
+	if s.Namespace != "" {
+		opts = append(opts, client.InNamespace(s.Namespace))
+	}
+
+	err := s.K8sClient.List(context.Background(), activeDocList, opts...)
+	if err != nil {
+		s.Logger.Error(err, "reading ActiveDoc list")
+		return nil
+	}
+
+	s.Logger.V(1).Info("Processing object", "key", client.ObjectKeyFromObject(obj), "accepted", len(activeDocList.Items) > 0)
+
+	requests := []reconcile.Request{}
+	for idx := range activeDocList.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      activeDocList.Items[idx].GetName(),
+			Namespace: activeDocList.Items[idx].GetNamespace(),
+		}})
+	}
+
+	return requests
+}

--- a/controllers/capabilities/secret_to_openapi_event_mapper.go
+++ b/controllers/capabilities/secret_to_openapi_event_mapper.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"context"
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecretToOpenApiEventMapper is an EventHandler that maps secret object to openApi CR's
+type SecretToOpenApiEventMapper struct {
+	K8sClient client.Client
+	Logger    logr.Logger
+	Namespace string
+}
+
+func (s *SecretToOpenApiEventMapper) Map(obj client.Object) []reconcile.Request {
+
+	openApiList := &capabilitiesv1beta1.OpenAPIList{}
+
+	// filter by Secret UID
+	opts := []client.ListOption{client.HasLabels{openApiSecretLabelKey(string(obj.GetUID()))}}
+
+	// Support namespace scope or cluster scoped
+	if s.Namespace != "" {
+		opts = append(opts, client.InNamespace(s.Namespace))
+	}
+
+	err := s.K8sClient.List(context.Background(), openApiList, opts...)
+	if err != nil {
+		s.Logger.Error(err, "reading openApi list")
+		return nil
+	}
+
+	s.Logger.V(1).Info("Processing object", "key", client.ObjectKeyFromObject(obj), "accepted", len(openApiList.Items) > 0)
+
+	requests := []reconcile.Request{}
+	for idx := range openApiList.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      openApiList.Items[idx].GetName(),
+			Namespace: openApiList.Items[idx].GetNamespace(),
+		}})
+	}
+
+	return requests
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	apimachinerymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"runtime"
 
@@ -119,6 +120,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	secretLabelSelector, err := apimachinerymetav1.ParseToLabelSelector("apimanager.apps.3scale.net/watched-by=apimanager")
+	if err != nil {
+		setupLog.Error(err, "unable parse apimanager secrets label")
+		os.Exit(1)
+	}
+
+	if secretLabelSelector == nil {
+		setupLog.Info("secretLabelSelector is empty")
+		os.Exit(1)
+	}
+
 	discoveryClientAPIManager, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to create discovery client")
@@ -130,6 +142,8 @@ func main() {
 			ctrl.Log.WithName("controllers").WithName("APIManager"),
 			discoveryClientAPIManager,
 			mgr.GetEventRecorderFor("APIManager")),
+		SecretLabelSelector: *secretLabelSelector,
+		WatchedNamespace:    namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "APIManager")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -229,6 +229,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	secretLabelSelectorOpenAPI, err := apimachinerymetav1.ParseToLabelSelector("openapis.capabilities.3scale.net/watched-by=openapi")
+	if err != nil {
+		setupLog.Error(err, "unable parse openapi secrets label")
+		os.Exit(1)
+	}
+
+	if secretLabelSelectorOpenAPI == nil {
+		setupLog.Info("secretLabelSelectorOpenAPI is empty")
+		os.Exit(1)
+	}
+
 	discoveryClientOpenAPI, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to create discovery client")
@@ -240,6 +251,8 @@ func main() {
 			ctrl.Log.WithName("controllers").WithName("OpenAPI"),
 			discoveryClientOpenAPI,
 			mgr.GetEventRecorderFor("OpenAPI")),
+		SecretLabelSelector: *secretLabelSelectorOpenAPI,
+		WatchedNamespace:    namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenAPI")
 		os.Exit(1)
@@ -272,6 +285,8 @@ func main() {
 			ctrl.Log.WithName("controllers").WithName("ActiveDoc"),
 			discoveryClientActiveDoc,
 			mgr.GetEventRecorderFor("ActiveDoc")),
+		SecretLabelSelector: *secretLabelSelectorOpenAPI, // ActiveDoc is using OpenApi Secret
+		WatchedNamespace:    namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ActiveDoc")
 		os.Exit(1)

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -606,7 +606,7 @@ func (apicast *Apicast) productionVolumes() []v1.Volume {
 			Name: customPolicy.VolumeName(),
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: customPolicy.SecretRef.Name,
+					SecretName: customPolicy.Secret.Name,
 				},
 			},
 		})
@@ -662,7 +662,7 @@ func (apicast *Apicast) stagingVolumes() []v1.Volume {
 			Name: customPolicy.VolumeName(),
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: customPolicy.SecretRef.Name,
+					SecretName: customPolicy.Secret.Name,
 				},
 			},
 		})

--- a/pkg/3scale/amp/component/apicast_options.go
+++ b/pkg/3scale/amp/component/apicast_options.go
@@ -12,9 +12,9 @@ import (
 )
 
 type CustomPolicy struct {
-	Name      string
-	Version   string
-	SecretRef v1.LocalObjectReference
+	Name    string
+	Version string
+	Secret  *v1.Secret
 }
 
 func (c CustomPolicy) VolumeName() string {

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -478,6 +478,13 @@ func (a *ApicastOptionsProvider) additionalPodAnnotations() map[string]string {
 		annotations[annotationKey] = a.apicastOptions.ProductionCustomPolicies[idx].Secret.ResourceVersion
 	}
 
+	for idx := range a.apicastOptions.StagingCustomPolicies {
+		// Secrets must exist
+		// Annotation key includes the name of the secret
+		annotationKey := fmt.Sprintf("%s%s", CustomPoliciesSecretResverAnnotationPrefix, a.apicastOptions.StagingCustomPolicies[idx].Secret.Name)
+		annotations[annotationKey] = a.apicastOptions.StagingCustomPolicies[idx].Secret.ResourceVersion
+	}
+
 	return annotations
 }
 

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -26,8 +26,9 @@ type ApicastOptionsProvider struct {
 }
 
 const (
-	APIcastEnvironmentCMAnnotation = "apps.3scale.net/env-configmap-hash"
-	PodPrioritySystemNodeCritical  = "system-node-critical"
+	APIcastEnvironmentCMAnnotation             = "apps.3scale.net/env-configmap-hash"
+	PodPrioritySystemNodeCritical              = "system-node-critical"
+	CustomPoliciesSecretResverAnnotationPrefix = "apimanager.apps.3scale.net/custompolicy-secret-resource-version-"
 )
 
 func NewApicastOptionsProvider(apimanager *appsv1alpha1.APIManager, client client.Client) *ApicastOptionsProvider {
@@ -212,7 +213,13 @@ func (a *ApicastOptionsProvider) productionPodTemplateLabels() map[string]string
 func (a *ApicastOptionsProvider) setCustomPolicies() error {
 	for idx, customPolicySpec := range a.apimanager.Spec.Apicast.ProductionSpec.CustomPolicies {
 		// CR Validation ensures secret name is not nil
-		err := a.validateCustomPolicySecret(customPolicySpec.SecretRef.Name)
+
+		namespacedName := types.NamespacedName{
+			Name:      customPolicySpec.SecretRef.Name, // CR Validation ensures not nil
+			Namespace: a.apimanager.Namespace,
+		}
+
+		secret, err := a.validateCustomPolicySecret(context.TODO(), customPolicySpec.SecretRef.Name, namespacedName)
 		if err != nil {
 			errors := field.ErrorList{}
 			customPoliciesIdxFldPath := field.NewPath("spec").
@@ -224,16 +231,22 @@ func (a *ApicastOptionsProvider) setCustomPolicies() error {
 		}
 
 		a.apicastOptions.ProductionCustomPolicies = append(a.apicastOptions.ProductionCustomPolicies, component.CustomPolicy{
-			Name:      customPolicySpec.Name,
-			Version:   customPolicySpec.Version,
-			SecretRef: *customPolicySpec.SecretRef,
+			Name:    customPolicySpec.Name,
+			Version: customPolicySpec.Version,
+			Secret:  secret,
 		})
 	}
 
 	// TODO(eastizle): DRY!!
 	for idx, customPolicySpec := range a.apimanager.Spec.Apicast.StagingSpec.CustomPolicies {
 		// CR Validation ensures secret name is not nil
-		err := a.validateCustomPolicySecret(customPolicySpec.SecretRef.Name)
+
+		namespacedName := types.NamespacedName{
+			Name:      customPolicySpec.SecretRef.Name, // CR Validation ensures not nil
+			Namespace: a.apimanager.Namespace,
+		}
+
+		secret, err := a.validateCustomPolicySecret(context.TODO(), customPolicySpec.SecretRef.Name, namespacedName)
 		if err != nil {
 			errors := field.ErrorList{}
 			customPoliciesIdxFldPath := field.NewPath("spec").
@@ -245,27 +258,35 @@ func (a *ApicastOptionsProvider) setCustomPolicies() error {
 		}
 
 		a.apicastOptions.StagingCustomPolicies = append(a.apicastOptions.StagingCustomPolicies, component.CustomPolicy{
-			Name:      customPolicySpec.Name,
-			Version:   customPolicySpec.Version,
-			SecretRef: *customPolicySpec.SecretRef,
+			Name:    customPolicySpec.Name,
+			Version: customPolicySpec.Version,
+			Secret:  secret,
 		})
 	}
 
 	return nil
 }
 
-func (a *ApicastOptionsProvider) validateCustomPolicySecret(name string) error {
-	_, err := a.secretSource.RequiredFieldValueFromRequiredSecret(name, "init.lua")
+func (a *ApicastOptionsProvider) validateCustomPolicySecret(ctx context.Context, name string, nn types.NamespacedName) (*v1.Secret, error) {
+	secret := &v1.Secret{}
+	err := a.client.Get(ctx, nn, secret)
+
 	if err != nil {
-		return err
+		// NotFoundError is also an error, it is required to exist
+		return nil, err
+	}
+
+	_, err = a.secretSource.RequiredFieldValueFromRequiredSecret(name, "init.lua")
+	if err != nil {
+		return nil, err
 	}
 
 	_, err = a.secretSource.RequiredFieldValueFromRequiredSecret(name, "apicast-policy.json")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return secret, nil
 }
 
 func (a *ApicastOptionsProvider) setTracingConfiguration() error {
@@ -448,6 +469,13 @@ func (a *ApicastOptionsProvider) setProductionProxyConfigurations() {
 func (a *ApicastOptionsProvider) additionalPodAnnotations() map[string]string {
 	annotations := map[string]string{
 		APIcastEnvironmentCMAnnotation: a.envConfigMapHash(),
+	}
+
+	for idx := range a.apicastOptions.ProductionCustomPolicies {
+		// Secrets must exist
+		// Annotation key includes the name of the secret
+		annotationKey := fmt.Sprintf("%s%s", CustomPoliciesSecretResverAnnotationPrefix, a.apicastOptions.ProductionCustomPolicies[idx].Secret.Name)
+		annotations[annotationKey] = a.apicastOptions.ProductionCustomPolicies[idx].Secret.ResourceVersion
 	}
 
 	return annotations

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -556,11 +556,6 @@ func apicastPodTemplateEnvConfigMapAnnotationsMutator(desired, existing *appsv1.
 }
 
 func (r *ApicastReconciler) reconcileAPImanagerCR(ctx context.Context) (ctrl.Result, error) {
-	//logger, err := logr.FromContext(ctx)
-	//if err != nil {
-	//	return ctrl.Result{}, err
-	//
-	//}
 
 	changed := false
 	changed, err := r.reconcileApimanagerSecretLabels(ctx)
@@ -570,7 +565,7 @@ func (r *ApicastReconciler) reconcileAPImanagerCR(ctx context.Context) (ctrl.Res
 
 	if changed {
 		err = r.Client().Update(ctx, r.apiManager)
-		//logger.Info("reconciling", "error", err)
+		r.logger.Info("reconciling", "error", err)
 	}
 
 	return ctrl.Result{Requeue: changed}, err
@@ -587,10 +582,20 @@ func (r *ApicastReconciler) reconcileApimanagerSecretLabels(ctx context.Context)
 
 func (r *ApicastReconciler) getSecretUIDs(ctx context.Context) ([]string, error) {
 	// production custom policy
+	// staging custom policy
 
 	secretKeys := []client.ObjectKey{}
 	if r.apiManager.Spec.Apicast.ProductionSpec.CustomPolicies != nil {
 		for _, customPolicy := range r.apiManager.Spec.Apicast.ProductionSpec.CustomPolicies {
+			secretKeys = append(secretKeys, client.ObjectKey{
+				Name:      customPolicy.SecretRef.Name,
+				Namespace: r.apiManager.Namespace,
+			})
+		}
+	}
+
+	if r.apiManager.Spec.Apicast.StagingSpec.CustomPolicies != nil {
+		for _, customPolicy := range r.apiManager.Spec.Apicast.StagingSpec.CustomPolicies {
 			secretKeys = append(secretKeys, client.ObjectKey{
 				Name:      customPolicy.SecretRef.Name,
 				Namespace: r.apiManager.Namespace,

--- a/pkg/3scale/amp/operator/apicast_reconciler_test.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler_test.go
@@ -154,16 +154,29 @@ func TestApicastReconcilerCustomPolicyParts(t *testing.T) {
 		trueValue                  = true
 		oneValue             int64 = 1
 
+		p1Secret = &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "someSecretP1",
+				Namespace: namespace, // Update this with the appropriate namespace
+			},
+			Data: map[string][]byte{
+				"apicast-policy.json": []byte("testApicastPolicy"),
+				"example.lua":         []byte("testExampleLua"),
+				"init.lua":            []byte("testInitLua"),
+			},
+			Type: v1.SecretTypeOpaque,
+		}
+
 		p1CustomPolicy = component.CustomPolicy{
-			Name:      "P1",
-			Version:   "0.1.0",
-			SecretRef: v1.LocalObjectReference{Name: "someSecretP1"},
+			Name:    "P1",
+			Version: "0.1.0",
+			Secret:  p1Secret,
 		}
 
 		p2CustomPolicy = component.CustomPolicy{
-			Name:      "P2",
-			Version:   "0.1.0",
-			SecretRef: v1.LocalObjectReference{Name: "someSecretP2"},
+			Name:    "P2",
+			Version: "0.1.0",
+			Secret:  p1Secret,
 		}
 	)
 
@@ -195,7 +208,7 @@ func TestApicastReconcilerCustomPolicyParts(t *testing.T) {
 						{
 							Name:      p2CustomPolicy.Name,
 							Version:   p2CustomPolicy.Version,
-							SecretRef: &p2CustomPolicy.SecretRef,
+							SecretRef: &v1.LocalObjectReference{Name: "someSecretP1"},
 						},
 					},
 				},
@@ -231,7 +244,7 @@ func TestApicastReconcilerCustomPolicyParts(t *testing.T) {
 
 	p2Secret := &v1.Secret{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-		ObjectMeta: metav1.ObjectMeta{Name: p2CustomPolicy.SecretRef.Name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: p2CustomPolicy.Secret.Name, Namespace: namespace},
 		Data: map[string][]byte{
 			"init.lua":            []byte("some lua code"),
 			"apicast-policy.json": []byte("{}"),

--- a/pkg/3scale/amp/operator/apimanager_utils.go
+++ b/pkg/3scale/amp/operator/apimanager_utils.go
@@ -1,0 +1,48 @@
+package operator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+)
+
+const (
+	APIManagerSecretLabelPrefix = "secret.apimanager.apps.3scale.net/"
+	APIManagerSecretLabelValue  = "true"
+)
+
+func apimanagerSecretLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", APIManagerSecretLabelPrefix, uid)
+}
+
+func replaceAPIManagerSecretLabels(apimanager *appsv1alpha1.APIManager, desiredSecretUIDs []string) bool {
+
+	existingLabels := apimanager.GetLabels()
+
+	if existingLabels == nil {
+		existingLabels = map[string]string{}
+	}
+
+	existingSecretLabels := map[string]string{}
+
+	// existing Secret UIDs not included in desiredAPIUIDs are deleted
+	for k := range existingLabels {
+		if strings.HasPrefix(k, APIManagerSecretLabelPrefix) {
+			existingSecretLabels[k] = APIManagerSecretLabelValue
+			// it is safe to remove keys while looping in range
+			delete(existingLabels, k)
+		}
+	}
+
+	desiredSecretLabels := map[string]string{}
+	for _, uid := range desiredSecretUIDs {
+		desiredSecretLabels[apimanagerSecretLabelKey(uid)] = APIManagerSecretLabelValue
+		existingLabels[apimanagerSecretLabelKey(uid)] = APIManagerSecretLabelValue
+	}
+
+	apimanager.SetLabels(existingLabels)
+
+	return !reflect.DeepEqual(existingSecretLabels, desiredSecretLabels)
+}


### PR DESCRIPTION
## WHAT
Jira: https://issues.redhat.com/browse/THREESCALE-10088

Reconcile secrets
- This PR is for **OpenApi Secret**, for **OpenApi and ActiveDoc CRs**.
- This PR was related to https://issues.redhat.com/browse/THREESCALE-6735, but was removed from Epic and delayed.
- Need rebase/update after merge of https://github.com/3scale/3scale-operator/pull/861 

- Changes in this PR:
```
$ git diff THREESCALE-6735-openapi..patryk/THREESCALE-6735 --name-only
controllers/capabilities/activedoc_controller.go
controllers/capabilities/openapi_controller.go
controllers/capabilities/openapi_utils.go
controllers/capabilities/secret_to_activedoc_event_mapper.go
controllers/capabilities/secret_to_openapi_event_mapper.go
main.go
```

**NOTES**
- Current status of PR - OpenApi and ActiveDoc CRs are labled with OpenApisecret UID.  
- Further development for OpenApi and ActiveDoc CRs, if required, will be done after PR review and discussion with 3scale operator experts.

# Validation

1. Install and run 3scale operator

```
cd 3scale-operator
make install
oc new-project 3scale-test
make download
make run
```

2. Apply s3 secret
- Secret example (s3-creds-secret.yaml):
```
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: QU12345
  AWS_SECRET_ACCESS_KEY: aU12345=
  AWS_BUCKET: dm12345=
  AWS_REGION: ZX1234==
type: Opaque
```
```
oc apply -f s3-creds-secret.yaml
```

3. Apply Apimanager CR
- Apimanager CR example (apimanagerCR.yaml):

```
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
    name: example-apimanager
    namespace: 3scale-test
spec:
    wildcardDomain: apps.vmogilev01.cnbz.s1.devshift.org
```
```
oc apply -f apimanagerCR.yaml
```

- check DCs and Pods
```
oc get dc
```
Expecting:
```
$ oc get dc
NAME                 REVISION   DESIRED   CURRENT   TRIGGERED BY
apicast-production   1          1         1         config,image(amp-apicast:2.14)
apicast-staging      1          1         1         config,image(amp-apicast:2.14)
backend-cron         1          1         1         config,image(amp-backend:2.14)
backend-listener     1          1         1         config,image(amp-backend:2.14)
backend-redis        1          1         1         config,image(backend-redis:2.14)
backend-worker       1          1         1         config,image(amp-backend:2.14)
system-app           1          1         1         config,image(amp-system:2.14)
system-memcache      1          1         1         config,image(system-memcached:2.14)
system-mysql         1          1         1         config,image(system-mysql:2.14)
system-redis         1          1         1         config,image(system-redis:2.14)
system-searchd       1          1         1         config,image(system-searchd:2.14)
system-sidekiq       1          1         1         config,image(amp-system:2.14)
zync                 1          1         1         config,image(amp-zync:2.14)
zync-database        1          1         1         config,image(zync-database-postgresql:2.14)
zync-que             1          1         1         config,image(amp-zync:2.14)
```

4. Create OpenApi secret

Create a secret with the OpenAPI spec document. The name of the secret object will be referenced in the OpenAPI CR.

The following example shows how to create a secret out of a file:

```
$ cat myopenapi.yaml
---
openapi: "3.0.2"
info:
  title: "some title"
  description: "some description"
  version: "1.0.0"
paths:
  /pet:
    get:
      operationId: "getPet"
      responses:
        405:
          description: "invalid input"


$ oc create secret generic myopenapi --from-file myopenapi.yaml
```

5 Label OpenApi secret:
label secret with label: **openapis.capabilities.3scale.net/watched-by=openapi**
```
oc label secret myopenapi openapis.capabilities.3scale.net/watched-by=openapi
```

6. Create OpenAPI CR providing reference to the secret holding the OpenAPI document.

OpenAPI_CR.yml:  
```
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: openapi1
spec:
  openapiRef:
    secretRef:
      name: myopenapi
```


```
oc apply -f  OpenAPI_CR.yml
```

7. Look at OpenAPI CR - check label created with secret UID
Example:
- check secret  uid:
```
$ oc get secret myopenapi -oyaml |grep uid
  uid: 774376cb-e7da-4182-81bd-bf327b1e7378
```

- check OpenAPI CR
```
$ oc get OpenAPI -o=jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{@.metadata.labels}{"\n"}{end}'
openapi1
{"secret.openapi.apps.3scale.net/774376cb-e7da-4182-81bd-bf327b1e7378":"true"}
[vmogilev@vmogilev THREESCALE-6735]$ 
```

8. Create & Check ActiveDoc CR

```
$ cat ActiveDocCR.yaml
apiVersion: capabilities.3scale.net/v1beta1
kind: ActiveDoc
metadata:
  name: activedoc
spec:
  name: "Operated ActiveDoc From secret"
  activeDocOpenAPIRef:
    secretRef:
      name: myopenapi
```
```
oc apply -f ActiveDocCR.yaml
```
```
$ oc get activedoc -o=jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{@.metadata.labels}{"\n"}{end}'
activedoc
{"secret.openapi.apps.3scale.net/774376cb-e7da-4182-81bd-bf327b1e7378":"true"}
```
Check that label in ActiveDoc contains OpenApi Secret UID.








