### PR TITLE
THREESCALE-7836 Refactor TLS InsecureSkipVerify logic to use annotations

### DIFF
--- a/controllers/capabilities/activedoc_controller.go
+++ b/controllers/capabilities/activedoc_controller.go
@@ -144,7 +144,8 @@ func (r *ActiveDocReconciler) reconcileSpec(activeDocCR *capabilitiesv1beta1.Act
 		return statusReconciler, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(activeDocCR.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		statusReconciler := NewActiveDocStatusReconciler(r.BaseReconciler, activeDocCR, providerAccount.AdminURLStr, nil, err)
 		return statusReconciler, err

--- a/controllers/capabilities/application_controller.go
+++ b/controllers/capabilities/application_controller.go
@@ -103,7 +103,8 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(application.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/capabilities/backend_controller.go
+++ b/controllers/capabilities/backend_controller.go
@@ -207,7 +207,8 @@ func (r *BackendReconciler) reconcile(backendResource *capabilitiesv1beta1.Backe
 		return statusReconciler, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(backendResource.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		statusReconciler := NewBackendStatusReconciler(r.BaseReconciler, backendResource, nil, providerAccount.AdminURLStr, err)
 		return statusReconciler, err
@@ -298,7 +299,8 @@ func (r *BackendReconciler) removeBackendFrom3scale(backend *capabilitiesv1beta1
 		return err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(backend.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		return err
 	}

--- a/controllers/capabilities/custompolicydefinition_controller.go
+++ b/controllers/capabilities/custompolicydefinition_controller.go
@@ -115,7 +115,8 @@ func (r *CustomPolicyDefinitionReconciler) reconcileSpec(customPolicyDefinitionC
 		return statusReconciler, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(customPolicyDefinitionCR.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		statusReconciler := NewCustomPolicyDefinitionStatusReconciler(r.BaseReconciler, customPolicyDefinitionCR, providerAccount.AdminURLStr, nil, err)
 		return statusReconciler, err

--- a/controllers/capabilities/developeraccount_controller.go
+++ b/controllers/capabilities/developeraccount_controller.go
@@ -189,7 +189,8 @@ func (r *DeveloperAccountReconciler) reconcileSpec(accountCR *capabilitiesv1beta
 		return statusReconciler, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(accountCR.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		statusReconciler := NewDeveloperAccountStatusReconciler(r.BaseReconciler, accountCR, providerAccount.AdminURLStr, nil, err)
 		return statusReconciler, err
@@ -240,7 +241,8 @@ func (r *DeveloperAccountReconciler) removeDeveloperAccountFrom3scale(developerA
 		return err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(developerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(developerAccountCR.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(developerAccount, insecureSkipVerify)
 	if err != nil {
 		return err
 	}

--- a/controllers/capabilities/developeruser_controller.go
+++ b/controllers/capabilities/developeruser_controller.go
@@ -202,7 +202,8 @@ func (r *DeveloperUserReconciler) reconcileSpec(userCR *capabilitiesv1beta1.Deve
 		return statusReconciler, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(userCR.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		statusReconciler := NewDeveloperUserStatusReconciler(r.BaseReconciler, userCR, parentAccountCR, providerAccount.AdminURLStr, nil, err)
 		return statusReconciler, err
@@ -298,7 +299,8 @@ func (r *DeveloperUserReconciler) removeDeveloperUserFrom3scale(developerUser *c
 		return err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(developerUser.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		return err
 	}

--- a/controllers/capabilities/product_controller.go
+++ b/controllers/capabilities/product_controller.go
@@ -207,7 +207,8 @@ func (r *ProductReconciler) reconcile(productResource *capabilitiesv1beta1.Produ
 		return statusReconciler, err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(productResource.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		statusReconciler := NewProductStatusReconciler(r.BaseReconciler, productResource, nil, providerAccount.AdminURLStr, err)
 		return statusReconciler, err
@@ -400,7 +401,8 @@ func (r *ProductReconciler) removeProductFrom3scale(product *capabilitiesv1beta1
 		return err
 	}
 
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(product.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		return err
 	}

--- a/controllers/capabilities/proxyconfigpromote_controller.go
+++ b/controllers/capabilities/proxyconfigpromote_controller.go
@@ -90,7 +90,8 @@ func (r *ProxyConfigPromoteReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// connect to the 3scale porta client
-	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(proxyConfigPromote.GetAnnotations())
+	threescaleAPIClient, err := controllerhelper.PortaClient(providerAccount, insecureSkipVerify)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/capabilities/tenant_controller.go
+++ b/controllers/capabilities/tenant_controller.go
@@ -98,7 +98,8 @@ func (r *TenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	portaClient, err := controllerhelper.PortaClientFromURLString(tenantR.Spec.SystemMasterUrl, masterAccessToken)
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(tenantR.GetAnnotations())
+	portaClient, err := controllerhelper.PortaClientFromURLString(tenantR.Spec.SystemMasterUrl, masterAccessToken, insecureSkipVerify)
 	if err != nil {
 		reqLogger.Error(err, "Error creating porta client object")
 		// Error reading the object - requeue the request.

--- a/doc/development.md
+++ b/doc/development.md
@@ -118,13 +118,11 @@ the _OperatorHub_ section of the OpenShift console _Catalog_. It can be
 easily found by filtering the provider type to _Custom_.
 
 ### 3scale Operator Environment Variables
-There are a few environment variables that may be used to aid in development. Refer to the table below for details:
+There are environment variables that may be used to aid in development. Refer to the table below for details:
 
 | Variable                    | Options    |   Type   | Default | Details                                                                                                                                                    |
 |-----------------------------|------------|:--------:|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | THREESCALE_DEBUG            | `1` or `0` | Optional | `0`     | If `1`, sets the porta client logging to be more verbose.                                                                                                  |
-| INSECURE_SKIP_VERIFY_CLIENT | `1` or `0` | Optional | `0`     | If `1`, sets the porta client to _not_ verify the server's certificate chain and host name. **NOTE:** this should only be used during development/testing. |
-|
 
 ### Run tests
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -7,6 +7,7 @@
 * [Run 3scale Operator](#run-3scale-operator)
    * [Run 3scale Operator Locally](#run-3scale-operator-locally)
    * [Deploy custom 3scale Operator using OLM](#deploy-custom-3scale-operator-using-olm)
+   * [Environment Variables](#3scale-operator-environment-variables)
    * [Run tests](#run-tests)
       * [Run all tests](#run-all-tests)
       * [Run unit tests](#run-unit-tests)
@@ -115,6 +116,15 @@ and install it namespace or cluster scoped.
 It will take a few minutes for the operator to become visible under
 the _OperatorHub_ section of the OpenShift console _Catalog_. It can be
 easily found by filtering the provider type to _Custom_.
+
+### 3scale Operator Environment Variables
+There are a few environment variables that may be used to aid in development. Refer to the table below for details:
+
+| Variable                    | Options    |   Type   | Default | Details                                                                                                                                                    |
+|-----------------------------|------------|:--------:|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| THREESCALE_DEBUG            | `1` or `0` | Optional | `0`     | If `1`, sets the porta client logging to be more verbose.                                                                                                  |
+| INSECURE_SKIP_VERIFY_CLIENT | `1` or `0` | Optional | `0`     | If `1`, sets the porta client to _not_ verify the server's certificate chain and host name. **NOTE:** this should only be used during development/testing. |
+|
 
 ### Run tests
 

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -22,6 +22,7 @@
          * [Setting custom TopologySpreadConstraints](#setting-custom-topologyspreadconstraints)
          * [Setting custom labels](#setting-custom-labels)
          * [Setting custom Annotations](#setting-custom-annotations)
+         * [Setting porta client to skip certificate verification](#setting-porta-client-to-skip-certificate-verification)
       * [Reconciliation](#reconciliation)
          * [Resources](#resources)
          * [Backend replicas](#backend-replicas)
@@ -815,6 +816,17 @@ spec:
         anno-sample2: anno2
 ```
 
+#### Setting porta client to skip certificate verification
+Whenever a controller reconciles an object it creates a new porta client to make API calls. That client is configured to verify the server's certificate chain by default. For development/testing purposes, you may want the client to skip certificate verification when reconciling an object. This can be done using the annotation `insecure_skip_verify: true`, which can be added to the following objects:
+* ActiveDoc
+* Application
+* Backend
+* CustomPolicyDefinition
+* DeveloperAccount
+* DeveloperUser
+* Product
+* ProxyConfigPromote
+* Tenant
 
 ### Reconciliation
 After 3scale API Management solution has been installed, 3scale Operator enables updating a given set

--- a/pkg/controller/helper/threescale_api.go
+++ b/pkg/controller/helper/threescale_api.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	HTTP_VERBOSE_ENVVAR         = "THREESCALE_DEBUG"
-	INSECURE_SKIP_VERIFY_ENVVAR = "INSECURE_SKIP_VERIFY_CLIENT"
+	HTTP_VERBOSE_ENVVAR = "THREESCALE_DEBUG"
 )
 
 type ProviderAccount struct {
@@ -20,29 +19,25 @@ type ProviderAccount struct {
 	Token       string
 }
 
-// PortaClient instantiate porta_client.ThreeScaleClient from ProviderAccount object
-func PortaClient(providerAccount *ProviderAccount) (*threescaleapi.ThreeScaleClient, error) {
-	return PortaClientFromURLString(providerAccount.AdminURLStr, providerAccount.Token)
+// PortaClient instantiates porta_client.ThreeScaleClient from ProviderAccount object
+func PortaClient(providerAccount *ProviderAccount, insecureSkipVerify bool) (*threescaleapi.ThreeScaleClient, error) {
+	return PortaClientFromURLString(providerAccount.AdminURLStr, providerAccount.Token, insecureSkipVerify)
 }
 
-func PortaClientFromURLString(adminURLStr, token string) (*threescaleapi.ThreeScaleClient, error) {
+// PortaClientFromURLString instantiates porta_client.ThreeScaleClient from url string
+func PortaClientFromURLString(adminURLStr, token string, insecureSkipVerify bool) (*threescaleapi.ThreeScaleClient, error) {
 	adminURL, err := url.Parse(adminURLStr)
 	if err != nil {
 		return nil, err
 	}
-	return PortaClientFromURL(adminURL, token)
+	return PortaClientFromURL(adminURL, token, insecureSkipVerify)
 }
 
 // PortaClientFromURL instantiates porta_client.ThreeScaleClient from admin url object
-func PortaClientFromURL(url *url.URL, token string) (*threescaleapi.ThreeScaleClient, error) {
+func PortaClientFromURL(url *url.URL, token string, insecureSkipVerify bool) (*threescaleapi.ThreeScaleClient, error) {
 	adminPortal, err := threescaleapi.NewAdminPortal(url.Scheme, url.Hostname(), helper.PortFromURL(url))
 	if err != nil {
 		return nil, err
-	}
-
-	insecureSkipVerify := false
-	if helper.GetEnvVar(INSECURE_SKIP_VERIFY_ENVVAR, "0") == "1" {
-		insecureSkipVerify = true
 	}
 
 	// Activated by some env var or Spec param
@@ -56,4 +51,13 @@ func PortaClientFromURL(url *url.URL, token string) (*threescaleapi.ThreeScaleCl
 	}
 
 	return threescaleapi.NewThreeScale(adminPortal, token, &http.Client{Transport: transport}), nil
+}
+
+// GetInsecureSkipVerifyAnnotation extracts the insecure_skip_verify annotation from an object
+func GetInsecureSkipVerifyAnnotation(annotations map[string]string) bool {
+	insecureSkipVerify, ok := annotations["insecure_skip_verify"]
+	if ok && insecureSkipVerify == "true" {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/helper/threescale_api_test.go
+++ b/pkg/controller/helper/threescale_api_test.go
@@ -7,28 +7,28 @@ import (
 
 func TestPortaClientInvalidURL(t *testing.T) {
 	providerAccount := &ProviderAccount{AdminURLStr: ":foo", Token: "some token"}
-	_, err := PortaClient(providerAccount)
+	_, err := PortaClient(providerAccount, false)
 	assert(t, err != nil, "error should not be nil")
 }
 
 func TestPortaClient(t *testing.T) {
 	providerAccount := &ProviderAccount{AdminURLStr: "http://somedomain.example.com", Token: "some token"}
-	_, err := PortaClient(providerAccount)
+	_, err := PortaClient(providerAccount, false)
 	ok(t, err)
 }
 
 func TestPortaClientFromURLStringInvalidURL(t *testing.T) {
-	_, err := PortaClientFromURLString(":foo", "some token")
+	_, err := PortaClientFromURLString(":foo", "some token", false)
 	assert(t, err != nil, "error should not be nil")
 }
 
 func TestPortaClientFromURLString(t *testing.T) {
-	_, err := PortaClientFromURLString("http://somedomain.example.com", "some token")
+	_, err := PortaClientFromURLString("http://somedomain.example.com", "some token", false)
 	ok(t, err)
 }
 
 func TestPortaClientFromURL(t *testing.T) {
 	url := &url.URL{}
-	_, err := PortaClientFromURL(url, "some token")
+	_, err := PortaClientFromURL(url, "some token", false)
 	assert(t, err != nil, "error should not be nil")
 }


### PR DESCRIPTION
# Issue link
[THREESCALE-7836](https://issues.redhat.com/browse/THREESCALE-7836)

# What
This refactors the insecure skip verify logic for the porta client to be enabled via annotations on individual CRs rather than globally as an environment variable.

This PR also add documentation around supported environment variables.

# Verification steps