### PR TITLE
THREESCALE-7864 set async by default on backend work

### DIFF
--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -393,6 +393,7 @@ func (backend *Backend) buildBackendWorkerEnv() []v1.EnvVar {
 	result := []v1.EnvVar{}
 	result = append(result, backend.buildBackendCommonEnv()...)
 	result = append(result,
+		helper.EnvVarFromValue("CONFIG_REDIS_ASYNC", "1"),
 		helper.EnvVarFromSecret("CONFIG_EVENTS_HOOK", "system-events-hook", "URL"),
 		helper.EnvVarFromSecret("CONFIG_EVENTS_HOOK_SHARED_SECRET", "system-events-hook", "PASSWORD"),
 	)

--- a/pkg/reconcilers/deploymentconfig.go
+++ b/pkg/reconcilers/deploymentconfig.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 )
@@ -54,7 +55,21 @@ func GenericBackendMutators() []DCMutateFn {
 		DeploymentConfigPriorityClassMutator,
 		DeploymentConfigTopologySpreadConstraintsMutator,
 		DeploymentConfigPodTemplateAnnotationsMutator,
+		DeploymentConfigEnvMutator,
 	}
+}
+
+func DeploymentConfigEnvMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	update := false
+	if desired.Name == component.BackendWorkerName {
+		if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env) {
+			diff := cmp.Diff(existing.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env)
+			log.Info(fmt.Sprintf("%s spec.template.spec.containers[0].Env has changed: %s", common.ObjectInfo(desired), diff))
+			existing.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
+			update = true
+		}
+	}
+	return update, nil
 }
 
 func DeploymentConfigReplicasMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {


### PR DESCRIPTION
# Jira
[THREESCALE-7864](https://issues.redhat.com//browse/THREESCALE-7864)

# What
set async by default on backend work

# Verification
- Create a project `oc new-project 3scale-test`
- `make install`
- `make run`
- Create a s3 secret
```bash
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Create an apimanager CR using that secret e.g.
```bash
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: apps.aucunnin.wx3t.s1.devshift.org
EOF
```
- Check the backend work pod for the `CONFIG_REDIS_ASYNC` envar
```bash
$ oc get po | grep backend-worker
backend-worker-1-deploy       0/1     Completed   0             12m
backend-worker-1-jn29j        1/1     Running     0             12m
$ oc exec backend-worker-1-jn29j -- env | grep CONFIG_REDIS_ASYNC
Defaulted container "backend-worker" out of: backend-worker, backend-redis-svc (init)
CONFIG_REDIS_ASYNC=1
```
- remove the envar from the backend-worker deployment config `spec.containers.env` and see if its reconciled back e.g. remove this
```yaml
- name: CONFIG_REDIS_ASYNC
  value: '1'
```
 