### PR TITLE
THREESCALE-10092 refactor status reporting on proxyConfigPromote

### DIFF
--- a/apis/capabilities/v1beta1/proxyconfigpromote_types.go
+++ b/apis/capabilities/v1beta1/proxyconfigpromote_types.go
@@ -29,7 +29,9 @@ const (
 
 	// ProxyPromoteConfigReadyConditionType indicates the activedoc has been successfully synchronized.
 	// Steady state
-	ProxyPromoteConfigReadyConditionType common.ConditionType = "Ready"
+	ProxyPromoteConfigReadyConditionType      common.ConditionType = "Ready"
+	ProxyPromoteConfigFailedConditionType     common.ConditionType = "Failed"
+	ProxyPromoteConfigInProgressConditionType common.ConditionType = "In-progress"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/controllers/capabilities/application_controller_test.go
+++ b/controllers/capabilities/application_controller_test.go
@@ -142,7 +142,7 @@ func TestApplicationReconciler_applicationReconciler(t *testing.T) {
 		{
 			name: "Create application successful",
 			fields: fields{
-				BaseReconciler: getApplicationBaseReconciler(),
+				BaseReconciler: getBaseReconciler(getApplicationCR(), getProductList()),
 			},
 			args: args{
 				applicationResource: getApplicationCR(),
@@ -157,7 +157,7 @@ func TestApplicationReconciler_applicationReconciler(t *testing.T) {
 				accountResource:         getApplicationDeveloperAccount(),
 			},
 			want: NewApplicationStatusReconciler(
-				getApplicationBaseReconciler(),
+				getBaseReconciler(getApplicationCR()),
 				getApplicationCR(),
 				getApplicationEntity(),
 				"https://3scale-admin.test.3scale.net",
@@ -167,7 +167,7 @@ func TestApplicationReconciler_applicationReconciler(t *testing.T) {
 		{
 			name: "Attempt to create application with unknown Product and Account CR",
 			fields: fields{
-				BaseReconciler: getApplicationBaseReconciler(),
+				BaseReconciler: getBaseReconciler(),
 			},
 			args: args{
 				applicationResource: getFailedApplicationCR(),
@@ -186,7 +186,7 @@ func TestApplicationReconciler_applicationReconciler(t *testing.T) {
 		{
 			name: "Attempt to create application with unknown Account CR name",
 			fields: fields{
-				BaseReconciler: getApplicationBaseReconciler(),
+				BaseReconciler: getBaseReconciler(),
 			},
 			args: args{
 				applicationResource: unknowAccountApplicationCR(),
@@ -205,7 +205,7 @@ func TestApplicationReconciler_applicationReconciler(t *testing.T) {
 		{
 			name: "Attempt to create application with invalid applicacationPlanName",
 			fields: fields{
-				BaseReconciler: getApplicationBaseReconciler(),
+				BaseReconciler: getBaseReconciler(),
 			},
 			args: args{
 				applicationResource: getUnknownPlanApplicationCR(),
@@ -264,7 +264,7 @@ func TestApplicationReconciler_removeApplicationFrom3scale(t *testing.T) {
 		{
 			name: "Delete Application successfully",
 			fields: fields{
-				BaseReconciler: getApplicationBaseReconciler(),
+				BaseReconciler: getBaseReconciler(getApplicationCR(), getProviderAccount(), getApiManger(), getApplicationProductList(), getApplicationDeveloperAccount(), getProviderAccountRefSecret()),
 			},
 			args: args{
 				application: getApplicationDeleteCR(),

--- a/controllers/capabilities/applications_test.go
+++ b/controllers/capabilities/applications_test.go
@@ -110,7 +110,7 @@ func TestApplicationThreescaleReconciler_syncApplication(t1 *testing.T) {
 		{
 			name: "Application CR no change ",
 			fields: fields{
-				BaseReconciler:      getApplicationBaseReconciler(),
+				BaseReconciler:      getBaseReconciler(),
 				applicationResource: getApplicationCR(),
 				applicationEntity:   getApplicationEntity(),
 				accountResource:     getApplicationDeveloperAccount(),
@@ -123,7 +123,7 @@ func TestApplicationThreescaleReconciler_syncApplication(t1 *testing.T) {
 		{
 			name: "Application CR setting state to suspend",
 			fields: fields{
-				BaseReconciler:      getApplicationBaseReconciler(),
+				BaseReconciler:      getBaseReconciler(),
 				applicationResource: getApplicationCRSuspend(),
 				applicationEntity:   getApplicationEntity(),
 				accountResource:     getApplicationDeveloperAccount(),
@@ -136,7 +136,7 @@ func TestApplicationThreescaleReconciler_syncApplication(t1 *testing.T) {
 		{
 			name: "Application CR setting state to live",
 			fields: fields{
-				BaseReconciler:      getApplicationBaseReconciler(),
+				BaseReconciler:      getBaseReconciler(),
 				applicationResource: getApplicationCR(),
 				applicationEntity:   getApplicationEntitySuspended(),
 				accountResource:     getApplicationDeveloperAccount(),
@@ -149,7 +149,7 @@ func TestApplicationThreescaleReconciler_syncApplication(t1 *testing.T) {
 		{
 			name: "Application CR change application Plan",
 			fields: fields{
-				BaseReconciler:      getApplicationBaseReconciler(),
+				BaseReconciler:      getBaseReconciler(),
 				applicationResource: getApplicationCR(),
 				applicationEntity:   getApplicationEntityPlanID(),
 				accountResource:     getApplicationDeveloperAccount(),

--- a/controllers/capabilities/proxyconfigpromote_controller.go
+++ b/controllers/capabilities/proxyconfigpromote_controller.go
@@ -210,7 +210,7 @@ func (r *ProxyConfigPromoteReconciler) proxyConfigPromoteReconciler(proxyConfigP
 			_, err = threescaleAPIClient.PromoteProxyConfig(productIDStr, "sandbox", strconv.Itoa(stageElement.ProxyConfig.Version), "production")
 			if err != nil {
 				// The version can already be in the production meaning that it can't be updated again, the proxyPromote is not going to be deleted by the operator but instead, will notify the user of the issue
-				statusReconciler := NewProxyConfigPromoteStatusReconciler(r.BaseReconciler, proxyConfigPromote, string(capabilitiesv1beta1.ProxyPromoteConfigFailedConditionType), productIDStr, latestProductionVersion, latestStagingVersion, err)
+				statusReconciler := NewProxyConfigPromoteStatusReconciler(r.BaseReconciler, proxyConfigPromote, string(capabilitiesv1beta1.ProxyPromoteConfigFailedConditionType), productIDStr, latestProductionVersion, latestStagingVersion, fmt.Errorf("can't promote to production as no product changes detected, delete the proxyConfigPromote CR or introduce changes to stage env first to proceed"))
 				return statusReconciler, err
 			} else {
 				latestProductionVersion = latestStagingVersion

--- a/controllers/capabilities/proxyconfigpromote_controller_test.go
+++ b/controllers/capabilities/proxyconfigpromote_controller_test.go
@@ -327,7 +327,6 @@ func TestProxyConfigPromoteReconciler_proxyConfigPromoteReconciler(t *testing.T)
 			want: &ProxyConfigPromoteStatusReconciler{
 				BaseReconciler:          getBaseReconciler(),
 				resource:                getProxyConfigPromoteCRStaging(),
-				state:                   "Completed",
 				productID:               "3",
 				latestProductionVersion: 0,
 				latestStagingVersion:    1,
@@ -350,7 +349,6 @@ func TestProxyConfigPromoteReconciler_proxyConfigPromoteReconciler(t *testing.T)
 			want: &ProxyConfigPromoteStatusReconciler{
 				BaseReconciler:          getBaseReconciler(),
 				resource:                getProxyConfigPromoteCRProduction(),
-				state:                   "Completed",
 				productID:               "3",
 				latestProductionVersion: 1,
 				latestStagingVersion:    1,
@@ -382,9 +380,6 @@ func TestProxyConfigPromoteReconciler_proxyConfigPromoteReconciler(t *testing.T)
 			if (err != nil) && tt.wantErr {
 				t.Logf("proxyConfigPromoteReconciler(), wantErr %v", tt.wantErr)
 				return
-			}
-			if !reflect.DeepEqual(got.state, tt.want.state) {
-				t.Errorf("proxyConfigPromoteReconciler() got.state = %v, want.state %v", got.state, tt.want.state)
 			}
 			if !reflect.DeepEqual(got.productID, tt.want.productID) {
 				t.Errorf("proxyConfigPromoteReconciler() got.productID = %v, want.productID %v", got.productID, tt.want.productID)

--- a/controllers/capabilities/proxyconfigpromote_status_reconciler_test.go
+++ b/controllers/capabilities/proxyconfigpromote_status_reconciler_test.go
@@ -209,7 +209,7 @@ func TestProxyConfigPromoteStatusReconciler_Reconcile(t *testing.T) {
 		{
 			name: "Test StatusReconciler",
 			fields: fields{
-				BaseReconciler:          getBaseReconciler(),
+				BaseReconciler:          getBaseReconciler(getProxyConfigPromoteCR(), getProviderAccount(), getApiManger(), getProductList()),
 				resource:                getProxyConfigPromoteCR(),
 				state:                   "Completed",
 				productID:               "3",

--- a/controllers/capabilities/proxyconfigpromote_status_reconciler_test.go
+++ b/controllers/capabilities/proxyconfigpromote_status_reconciler_test.go
@@ -87,7 +87,6 @@ func TestProxyConfigPromoteStatusReconciler_calculateStatus(t *testing.T) {
 	type fields struct {
 		BaseReconciler          *reconcilers.BaseReconciler
 		resource                *capabilitiesv1beta1.ProxyConfigPromote
-		state                   string
 		productID               string
 		latestProductionVersion int
 		latestStagingVersion    int
@@ -105,7 +104,6 @@ func TestProxyConfigPromoteStatusReconciler_calculateStatus(t *testing.T) {
 			fields: fields{
 				BaseReconciler:          getBaseReconciler(),
 				resource:                getProxyConfigPromoteCR(),
-				state:                   "Completed",
 				productID:               "3",
 				latestProductionVersion: 1,
 				latestStagingVersion:    1,
@@ -130,7 +128,6 @@ func TestProxyConfigPromoteStatusReconciler_calculateStatus(t *testing.T) {
 			fields: fields{
 				BaseReconciler:          getBaseReconciler(),
 				resource:                getProxyConfigPromoteCR(),
-				state:                   "Failed",
 				productID:               "3",
 				latestProductionVersion: 1,
 				latestStagingVersion:    1,
@@ -156,7 +153,6 @@ func TestProxyConfigPromoteStatusReconciler_calculateStatus(t *testing.T) {
 			s := &ProxyConfigPromoteStatusReconciler{
 				BaseReconciler:          tt.fields.BaseReconciler,
 				resource:                tt.fields.resource,
-				state:                   tt.fields.state,
 				productID:               tt.fields.productID,
 				latestProductionVersion: tt.fields.latestProductionVersion,
 				latestStagingVersion:    tt.fields.latestStagingVersion,
@@ -227,7 +223,6 @@ func TestProxyConfigPromoteStatusReconciler_Reconcile(t *testing.T) {
 			s := &ProxyConfigPromoteStatusReconciler{
 				BaseReconciler:          tt.fields.BaseReconciler,
 				resource:                tt.fields.resource,
-				state:                   tt.fields.state,
 				productID:               tt.fields.productID,
 				latestProductionVersion: tt.fields.latestProductionVersion,
 				latestStagingVersion:    tt.fields.latestStagingVersion,


### PR DESCRIPTION
**What**
Slight refactor to proxyConfigPromote so that the status is updated even if there's an error of updating to production if there's no actual updates to be done. Jira: https://issues.redhat.com/browse/THREESCALE-10092

NOTE: Some unit tests have been slightly refactored - there's more refactors to unit tests to be done in future Jiras, for example, configuring mock client that could be used within different tests instead of relying on proxyPromote tests etc.

**To Verify**
From this branch run:
- Create project
```
oc new-project threescale
```
- Create dummy secret
```
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: threescale
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Fetch cluster domain
```
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
```
- Create APIM and let 3scale fully install
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: threescale
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```
- Create backend
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend1-cr
  namespace: threescale
spec:
  mappingRules: 
    - httpMethod: GET
      increment: 1
      last: true
      metricMethodRef: hits
      pattern: /
  name: backend1
  privateBaseURL: 'https://api.example.com'
  systemName: backend1
EOF
```
**Scenario 1**
Successful reconciliation - going through stage and prod without explicit bump to stage
- Create product
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1-cr
  namespace: threescale
spec:
  name: product1
  backendUsages:
    backend1:
      path: /
EOF
```
- Create proxyConfigPromote
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product1-v1-production
  namespace: threescale
spec:
  productCRName: product1-cr
  production: true
  deleteCR: true
EOF
```
Expected outcome:
The ProxyConfigPromote CR is deleted
The product got promoted to production
**Scenario 2**
Successful promotion first to stage, then in seperate CR to production:
- create product CR
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product2-cr
  namespace: threescale
spec:
  name: product2
  backendUsages:
    backend1:
      path: /
EOF
```
- create proxy promote 
```
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product2-v1-stage
  namespace: threescale
spec:
  productCRName: product2-cr
EOF
```
The outcome is:
Product is created and promoted to stage, not production, the proxyConfigPromote CR status is updated with appropriate status. The CR is not deleted
- Create second proxyConfigPromote CR 
```
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product2-v1-stage
  namespace: threescale
spec:
  productCRName: product2-cr
  production: true
EOF
```
The outcome is:
Product got bumped to production in 3scale, the CR is not deleted.
Now delete the proxy promote CR by applying the flag to the above resource:
```
deleteCR: true
```
The CR should be deleted.
**Scenario 3**
Verify that the status of proxyConfigPromote CR has been applied although no updates has been done.
- create another product
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product3-cr
  namespace: threescale
spec:
  name: product3
  backendUsages:
    backend1:
      path: /
EOF
```
- create proxyConfigPromote to promote to production
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product2-v1-stage
  namespace: threescale
spec:
  productCRName: product3-cr
  production: true
  deleteCR: true
EOF
```
Product is now promoted and the CR is gone, apply the same CR again
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product2-v1-stage
  namespace: threescale
spec:
  productCRName: product3-cr
  production: true
  deleteCR: true
EOF
```
The outcome is that the proxyConfigPromote CR has updated status with an error (coming from 3scale) on why was it not successful. The Deletion should NOT be triggered as user should have decide himself on what to do next.


