### PR TITLE
THREESCALE-8128 remove unnecesary camel case removal

### DIFF
--- a/apis/capabilities/v1beta1/backend_types.go
+++ b/apis/capabilities/v1beta1/backend_types.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"reflect"
 	"regexp"
-	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/apispkg/common"
 	"github.com/go-logr/logr"
@@ -165,14 +164,6 @@ func (backend *Backend) SetDefaults(logger logr.Logger) bool {
 	// Respect 3scale API defaults
 	if backend.Spec.SystemName == "" {
 		backend.Spec.SystemName = backendSystemNameRegexp.ReplaceAllString(backend.Spec.Name, "")
-		updated = true
-	}
-
-	// 3scale API ignores case of the system name field
-	systemNameLowercase := strings.ToLower(backend.Spec.SystemName)
-	if backend.Spec.SystemName != systemNameLowercase {
-		logger.Info("System name updated", "from", backend.Spec.SystemName, "to", systemNameLowercase)
-		backend.Spec.SystemName = systemNameLowercase
 		updated = true
 	}
 

--- a/apis/capabilities/v1beta1/product_types.go
+++ b/apis/capabilities/v1beta1/product_types.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/apispkg/common"
 	"github.com/go-logr/logr"
@@ -1188,14 +1187,6 @@ func (product *Product) SetDefaults(logger logr.Logger) bool {
 	// Respect 3scale API defaults
 	if product.Spec.SystemName == "" {
 		product.Spec.SystemName = productSystemNameRegexp.ReplaceAllString(product.Spec.Name, "")
-		updated = true
-	}
-
-	// 3scale API ignores case of the system name field
-	systemNameLowercase := strings.ToLower(product.Spec.SystemName)
-	if product.Spec.SystemName != systemNameLowercase {
-		logger.Info("System name updated", "from", product.Spec.SystemName, "to", systemNameLowercase)
-		product.Spec.SystemName = systemNameLowercase
 		updated = true
 	}
 

--- a/pkg/helper/openapi_utils.go
+++ b/pkg/helper/openapi_utils.go
@@ -24,8 +24,7 @@ var (
 
 func SystemNameFromOpenAPITitle(obj *openapi3.T) string {
 	openapiTitle := obj.Info.Title
-	openapiTitleToLower := strings.ToLower(openapiTitle)
-	return NonWordCharRegexp.ReplaceAllString(openapiTitleToLower, "_")
+	return NonWordCharRegexp.ReplaceAllString(openapiTitle, "_")
 }
 
 func K8sNameFromOpenAPITitle(obj *openapi3.T) string {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-8128

# What
Removed the toLower when making validation of backend and product spec. Few years ago 3scale api did not support the camelCase system name, it does now. 

# Verify
From this branch:
- run to create new project
```
oc new-project threescale
```
- run to install CRDs
```
make install
```
- create dummy secret
```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: s3-credentials
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```
- fetch cluster domain
```
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
```
- create apim
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: threescale
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```
- create OpenAPI yaml secret
```
kubectl apply -f - <<EOF               
---
kind: Secret
apiVersion: v1
metadata:
  name: myopenapi
stringData:
 myopenapi.yaml: |
  ---
  openapi: "3.0.2"
  info:
    title: "camelCaseSystem"
    description: "some description"
    version: "1.0.0"
  servers:
   - url: https://echo-api.3scale.net:443
  paths:
    /:
      get:
        operationId: "get"
        responses:
          405:
            description: "invalid input"
type: Opaque
EOF
```
## Creating OpenAPI with productSystemName specified as camel case

- create OpenAPI CR
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: camelcase
  namespace: threescale
spec:
  openapiRef:
    secretRef:
      name: myopenapi
      namespace: threescale
  productSystemName: camelCaseSys
EOF
```
- confirm that status of OpenAPI CR is "Ready" and "True"
- login to 3scale tenant as admin and confirm the backend and product are there and linked.

Remove the openapi CR and confirm all assets related to it are gone.

## Not specifying the productSystemName but using camel case in the openapi secret

- Create another OpenAPI CR:
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: camelcase
  namespace: threescale
spec:
  openapiRef:
    secretRef:
      name: myopenapi
      namespace: threescale
EOF
```
Verify that the OpenAPI CR was created successfully. 