### PR TITLE
THREESCALE-10137 add owner ref to openapi

### DIFF
--- a/controllers/capabilities/openapi_backend_reconciler.go
+++ b/controllers/capabilities/openapi_backend_reconciler.go
@@ -127,7 +127,7 @@ func (p *OpenAPIBackendReconciler) desired() (*capabilitiesv1beta1.Backend, erro
 		return nil, errors.New(validationErrors.ToAggregate().Error())
 	}
 
-	err = p.SetOwnerReference(p.openapiCR, backend)
+	err = p.SetControllerOwnerReference(p.openapiCR, backend)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/capabilities/openapi_product_reconciler.go
+++ b/controllers/capabilities/openapi_product_reconciler.go
@@ -147,7 +147,7 @@ func (p *OpenAPIProductReconciler) desired() (*capabilitiesv1beta1.Product, erro
 		return nil, errors.New(validationErrors.ToAggregate().Error())
 	}
 
-	err = p.SetOwnerReference(p.openapiCR, product)
+	err = p.SetControllerOwnerReference(p.openapiCR, product)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/capabilities/tenant_internal_reconciler.go
+++ b/controllers/capabilities/tenant_internal_reconciler.go
@@ -196,7 +196,7 @@ func (r *TenantInternalReconciler) reconcileAccessTokenSecret(tenantDef *porta_c
 		Type: v1.SecretTypeOpaque,
 	}
 
-	err = r.SetOwnerReference(r.tenantR, desiredSecret)
+	err = r.SetControllerOwnerReference(r.tenantR, desiredSecret)
 	if err != nil {
 		return err
 	}

--- a/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
+++ b/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
@@ -189,7 +189,7 @@ func (r *BaseAPIManagerLogicReconciler) ReconcileResource(obj, desired common.Ku
 	// already have controller-based OwnerReferences and K8s objects
 	// can only be owned by a single controller-based OwnerReference.
 	if desired.GetObjectKind().GroupVersionKind().Kind != "Secret" {
-		if err := r.SetOwnerReference(r.apiManager, desired); err != nil {
+		if err := r.SetControllerOwnerReference(r.apiManager, desired); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10137

# Verification

## Verification environment preparation

- Create new project
```
oc new-project threescale
```
- Install CRDs
```
make install
```
- Run the operator
```
make run
```
- Create new secret to be consumed by APIM
```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: s3-credentials
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```
- Fetch cluster domain
```
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
```
- Create APIM
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: threescale
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```
- Confirm 3scale is fully installed
```
oc get apimanager apimanager-sample -o json | jq -r '.status.deployments'
```
- Create OpenAPI secret
```
kubectl apply -f - <<EOF               
---
kind: Secret
apiVersion: v1
metadata:
  name: myopenapi
stringData:
 myopenapi.yaml: |
  ---
  openapi: "3.0.2"
  info:
    title: "testowner"
    description: "some description"
    version: "1.0.0"
  servers:
   - url: https://echo-api.3scale.net:443
  paths:
    /:
      get:
        operationId: "get"
        responses:
          405:
            description: "invalid input"
type: Opaque
EOF
```
- Create tenant secret
```
oc apply -f - <<EOF
---
apiVersion: v1
kind: Secret
metadata:
  name: example-admin-secret
type: Opaque
stringData:
  admin_password: "password"
EOF
```

### Scenario 1: OpenAPI CR can be deleted when created using the default 3scale tenant

- Create OpenAPI CR:
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: ownertest
  namespace: threescale
spec:
  openapiRef:
    secretRef:
      name: myopenapi
      namespace: threescale
  productSystemName: ownertest
EOF
```
- Confirm OpenAPI resources have been created (product and backend) and that both assets are available under the default 3scale tenant.

### Scenario 2: OpenAPI works as expected when using the created via CR tenant

- Fetch master portal route

```
MASTER_ROUTE=https://$(oc get route -n threescale | grep master |awk '{print $2}')
```
- Create tenant

```
oc apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: example-tenant
spec:
  username: admin
  systemMasterUrl: $MASTER_ROUTE
  email: admin@example.com
  organizationName: example
  masterCredentialsRef:
    name: system-seed
  passwordCredentialsRef:
    name: example-admin-secret
  tenantSecretRef:
    name: example-tenant-secret
EOF
```
- Create OpenAPI CR with the tenant reference

```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: ownertest
  namespace: threescale
spec:
  openapiRef:
    secretRef:
      name: myopenapi
      namespace: threescale
  productSystemName: ownertest
  providerAccountRef:
    name: example-tenant-secret
EOF
```
- Confirm that OpenAPI assets have been created (product and backend CRs and in 3scale created tenant - "example"). Once confirmed delete the tenant CR, which in turn should also delete the OpenAPI CR and it's resources.

### Scenario 3: OpenAPI deletion works as expected when it's referencing the tenant CR

- Fetch master portal route

```
MASTER_ROUTE=https://$(oc get route -n threescale | grep master |awk '{print $2}')
```
- Create tenant

```
oc apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: example-tenant2
spec:
  username: admin
  systemMasterUrl: $MASTER_ROUTE
  email: admin@example.com
  organizationName: example2
  masterCredentialsRef:
    name: system-seed
  passwordCredentialsRef:
    name: example-admin-secret
  tenantSecretRef:
    name: example-tenant-secret2
EOF
```
- Create OpenAPI CR with the tenant reference

```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: ownertest
  namespace: threescale
spec:
  openapiRef:
    secretRef:
      name: myopenapi
      namespace: threescale
  productSystemName: ownertest
  providerAccountRef:
    name: example-tenant-secret2
EOF
```
- Confirm that all assets for OpenAPI have been created for tenant called "example2" - then delete the OpenAPI CR, confirm that assets associated with OpenAPI CR are gone but tenant called "example2" is intact.

