### PR TITLE
add 4.13 as maxOpenshift version to threescale 2.13

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -185,6 +185,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.13"}]'
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2

--- a/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.13"}]'
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2


### PR DESCRIPTION
Adding maxOpenshiftVersion to 3scale operator 2.13 stable. 