### PR TITLE
THREESCALE-10162 add skip insecure verify to OpenAPI backend and product

### DIFF
--- a/controllers/capabilities/openapi_backend_reconciler.go
+++ b/controllers/capabilities/openapi_backend_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
@@ -101,6 +102,8 @@ func (p *OpenAPIBackendReconciler) desired() (*capabilitiesv1beta1.Backend, erro
 		return nil, err
 	}
 
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(p.openapiCR.GetAnnotations())
+
 	backend := &capabilitiesv1beta1.Backend{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       capabilitiesv1beta1.BackendKind,
@@ -109,6 +112,9 @@ func (p *OpenAPIBackendReconciler) desired() (*capabilitiesv1beta1.Backend, erro
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objName,
 			Namespace: p.openapiCR.Namespace,
+			Annotations: map[string]string{
+				"insecure_skip_verify": strconv.FormatBool(insecureSkipVerify),
+			},
 		},
 		Spec: capabilitiesv1beta1.BackendSpec{
 			Name:               name,

--- a/controllers/capabilities/openapi_product_reconciler.go
+++ b/controllers/capabilities/openapi_product_reconciler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
@@ -99,6 +100,8 @@ func (p *OpenAPIProductReconciler) desired() (*capabilitiesv1beta1.Product, erro
 	// product description
 	description := fmt.Sprintf(p.openapiObj.Info.Description)
 
+	insecureSkipVerify := controllerhelper.GetInsecureSkipVerifyAnnotation(p.openapiCR.GetAnnotations())
+
 	product := &capabilitiesv1beta1.Product{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       capabilitiesv1beta1.ProductKind,
@@ -107,6 +110,9 @@ func (p *OpenAPIProductReconciler) desired() (*capabilitiesv1beta1.Product, erro
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objName,
 			Namespace: p.openapiCR.Namespace,
+			Annotations: map[string]string{
+				"insecure_skip_verify": strconv.FormatBool(insecureSkipVerify),
+			},
 		},
 		Spec: capabilitiesv1beta1.ProductSpec{
 			Name:               name,

--- a/doc/openapi-reference.md
+++ b/doc/openapi-reference.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 * [OpenAPI](#openapi)
+   * [OpenAPIAnnotations](#openapiannotations)
    * [OpenAPISpec](#openapispec)
       * [OpenAPIRef](#openapiref)
       * [Provider Account Reference](#provider-account-reference)
@@ -17,6 +18,12 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 | --- | --- | --- | --- |
 | Spec | `spec` | [OpenAPISpec](#openapispec) | The specfication for the custom resource |
 | Status | `status` | [OpenAPIStatus](#openapistatus) | The status for the custom resource |
+
+### OpenAPIAnnotations
+
+| **Field** | **json field**| **Type** | **Info** | **Required** |
+| --- | --- | --- | --- | --- |
+| insecure_skip_verify | `insecure_skip_verify` | boolean | 3scale client skips certificate verification when reconciling a backend and product object created via OpenAPI - defaults to "false" | No |
 
 ### OpenAPISpec
 

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -824,6 +824,7 @@ Whenever a controller reconciles an object it creates a new porta client to make
 * CustomPolicyDefinition
 * DeveloperAccount
 * DeveloperUser
+* OpenAPI - backend and product
 * Product
 * ProxyConfigPromote
 * Tenant


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10162

# Verification

## Verification environment preparation

- Create new project
```
oc new-project threescale
```
- Install CRDs
```
make install
```
- Run the operator
```
make run
```
- Create new secret to be consumed by APIM
```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: s3-credentials
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```
- Fetch cluster domain
```
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
```
- Create APIM
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: threescale
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```
- Confirm 3scale is fully installed
```
oc get apimanager apimanager-sample -o json | jq -r '.status.deployments'
```
- Create OpenAPI secret
```
kubectl apply -f - <<EOF               
---
kind: Secret
apiVersion: v1
metadata:
  name: myopenapi
stringData:
 myopenapi.yaml: |
  ---
  openapi: "3.0.2"
  info:
    title: "testinsecure"
    description: "some description"
    version: "1.0.0"
  servers:
   - url: https://echo-api.3scale.net:443
  paths:
    /:
      get:
        operationId: "get"
        responses:
          405:
            description: "invalid input"
type: Opaque
EOF
```
- Create OpenAPI CR:
```
kubectl apply -f - <<EOF                                                        
---
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: ownertest
  namespace: threescale
  annotations:
     "insecure_skip_verify": "true"
spec:
  openapiRef:
    secretRef:
      name: myopenapi
      namespace: threescale
  productSystemName: testProduct
EOF
```
- Confirm OpenAPI resources have been created (product and backend) and that both resources have the insecure_skip_verify set to "true" and are created in 3scale
- Delete OpenAPI CR and re-create it, this time with insecure_skip_verify set to false, confirm both resources have the flag set to false and that both existing in 3scale