### PR TITLE
OCP version managemenet

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -10,8 +10,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-LABEL com.redhat.openshift.versions: v4.11-v4.14
-
+LABEL com.redhat.openshift.versions=v4.11-v4.14
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -10,6 +10,8 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL com.redhat.openshift.versions: v4.11-v4.14
+
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -202,9 +202,11 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
+    com.redhat.openshift.versions: v4.11-v4.14
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
     description: 3scale Operator to provision 3scale and publish/manage API
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["Red Hat Integration", "Red Hat 3scale API Management"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,3 +9,4 @@ annotations:
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  com.redhat.openshift.versions: v4.11-v4.14

--- a/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     description: 3scale Operator to provision 3scale and publish/manage API
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["Red Hat Integration", "Red Hat 3scale API Management"]'

--- a/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
@@ -6,10 +6,11 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
+    com.redhat.openshift.versions: v4.11-v4.14
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     description: 3scale Operator to provision 3scale and publish/manage API
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["Red Hat Integration", "Red Hat 3scale API Management"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0


### PR DESCRIPTION
### What

[Controlling Operator compatibility with OpenShift Container Platform versions](https://docs.openshift.com/container-platform/4.13/operators/operator_sdk/osdk-working-bundle-images.html#osdk-control-compat_osdk-working-bundle-images) at the upstream level.

