### PR TITLE
THREESCALE-10092 fix promote to stage with false production value

### DIFF
--- a/controllers/capabilities/proxyconfigpromote_controller.go
+++ b/controllers/capabilities/proxyconfigpromote_controller.go
@@ -146,7 +146,7 @@ func (r *ProxyConfigPromoteReconciler) proxyConfigPromoteReconciler(proxyConfigP
 		productIDStr := strconv.Itoa(int(productIDInt64))
 
 		// If wanting to promote to Stage but not production.
-		if proxyConfigPromote.Spec.Production == nil {
+		if proxyConfigPromote.Spec.Production == nil || !*proxyConfigPromote.Spec.Production {
 			// Promote to stage
 			_, err := threescaleAPIClient.DeployProductProxy(*productID)
 			if err != nil {


### PR DESCRIPTION
Follow up from https://github.com/3scale/3scale-operator/pull/863

Verification:
Follow steps from the previous PR as follow up.

Add another case where the proxyConfigPromote created only promotes to stage but with production set to false.
Example:
```
spec:
  productCRName: product1
  production: false
  deleteCR: false
```