### PR TITLE
THREESCALE-10098 Remove Prometheus Rule 'ThreescaleApicastRequestTime'

### DIFF
--- a/doc/prometheusrules/apicast.yaml
+++ b/doc/prometheusrules/apicast.yaml
@@ -22,18 +22,6 @@ spec:
       for: 1m
       labels:
         severity: critical
-    - alert: ThreescaleApicastRequestTime
-      annotations:
-        description: High number of request taking more than a second to be processed
-        sop_url: https://github.com/3scale/3scale-Operations/blob/master/sops/alerts/apicast_request_time.adoc
-        summary: Request on instance {{ $labels.instance }} is taking more than one
-          second to process the requests
-      expr: sum(rate(total_response_time_seconds_bucket{namespace='__NAMESPACE__',
-        pod=~'apicast-production.*'}[1m])) - sum(rate(upstream_response_time_seconds_bucket{namespace='__NAMESPACE__',
-        pod=~'apicast-production.*'}[1m])) > 1
-      for: 2m
-      labels:
-        severity: warning
     - alert: ThreescaleApicastHttp4xxErrorRate
       annotations:
         description: The number of request with 4XX is bigger than the 5% of total

--- a/pkg/3scale/amp/component/apicast_monitoring.go
+++ b/pkg/3scale/amp/component/apicast_monitoring.go
@@ -114,19 +114,6 @@ func (apicast *Apicast) ApicastPrometheusRules() *monitoringv1.PrometheusRule {
 								"severity": "critical",
 							},
 						},
-						// {
-						// 	Alert: "ThreescaleApicastRequestTime",
-						// 	Annotations: map[string]string{
-						// 		"sop_url":     ThreescaleApicastRequestTimeURL,
-						// 		"summary":     "Request on instance {{ $labels.instance }} is taking more than one second to process the requests",
-						// 		"description": "High number of request taking more than a second to be processed",
-						// 	},
-						// 	Expr: intstr.FromString(fmt.Sprintf(`sum(rate(total_response_time_seconds_bucket{namespace='%s', pod=~'apicast-production.*'}[1m])) - sum(rate(upstream_response_time_seconds_bucket{namespace='%s', pod=~'apicast-production.*'}[1m])) > 1`, apicast.Options.Namespace, apicast.Options.Namespace)),
-						// 	For:  "2m",
-						// 	Labels: map[string]string{
-						// 		"severity": "warning",
-						// 	},
-						// },
 						{
 							Alert: "ThreescaleApicastHttp4xxErrorRate",
 							Annotations: map[string]string{

--- a/pkg/3scale/amp/component/apicast_monitoring.go
+++ b/pkg/3scale/amp/component/apicast_monitoring.go
@@ -114,19 +114,19 @@ func (apicast *Apicast) ApicastPrometheusRules() *monitoringv1.PrometheusRule {
 								"severity": "critical",
 							},
 						},
-						{
-							Alert: "ThreescaleApicastRequestTime",
-							Annotations: map[string]string{
-								"sop_url":     ThreescaleApicastRequestTimeURL,
-								"summary":     "Request on instance {{ $labels.instance }} is taking more than one second to process the requests",
-								"description": "High number of request taking more than a second to be processed",
-							},
-							Expr: intstr.FromString(fmt.Sprintf(`sum(rate(total_response_time_seconds_bucket{namespace='%s', pod=~'apicast-production.*'}[1m])) - sum(rate(upstream_response_time_seconds_bucket{namespace='%s', pod=~'apicast-production.*'}[1m])) > 1`, apicast.Options.Namespace, apicast.Options.Namespace)),
-							For:  "2m",
-							Labels: map[string]string{
-								"severity": "warning",
-							},
-						},
+						// {
+						// 	Alert: "ThreescaleApicastRequestTime",
+						// 	Annotations: map[string]string{
+						// 		"sop_url":     ThreescaleApicastRequestTimeURL,
+						// 		"summary":     "Request on instance {{ $labels.instance }} is taking more than one second to process the requests",
+						// 		"description": "High number of request taking more than a second to be processed",
+						// 	},
+						// 	Expr: intstr.FromString(fmt.Sprintf(`sum(rate(total_response_time_seconds_bucket{namespace='%s', pod=~'apicast-production.*'}[1m])) - sum(rate(upstream_response_time_seconds_bucket{namespace='%s', pod=~'apicast-production.*'}[1m])) > 1`, apicast.Options.Namespace, apicast.Options.Namespace)),
+						// 	For:  "2m",
+						// 	Labels: map[string]string{
+						// 		"severity": "warning",
+						// 	},
+						// },
 						{
 							Alert: "ThreescaleApicastHttp4xxErrorRate",
 							Annotations: map[string]string{

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -181,7 +181,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.UpdatePrometheusRulesMutator)
+	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.RemovePrometheusRulesMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -181,7 +181,12 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.UpdatePrometheusRulesMutator)
+	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.CreateOnlyMutator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.RemovePrometheusRulesMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -181,7 +181,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.UpdatePrometheusRulesMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -181,12 +181,7 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.CreateOnlyMutator)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.RemovePrometheusRulesMutator)
+	err = r.ReconcilePrometheusRules(apicast.ApicastPrometheusRules(), reconcilers.UpdatePrometheusRulesMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -3,6 +3,7 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/common"
@@ -28,6 +29,20 @@ var log = logf.Log.WithName("reconcilers")
 type MutateFn func(existing, desired common.KubernetesObject) (bool, error)
 
 func CreateOnlyMutator(existing, desired common.KubernetesObject) (bool, error) {
+	return false, nil
+}
+
+func UpdatePrometheusRulesMutator(existing, desired common.KubernetesObject) (bool, error) {
+	existingRules := existing.(*monitoringv1.PrometheusRule)
+	desiredRules := desired.(*monitoringv1.PrometheusRule)
+
+	if !reflect.DeepEqual(existingRules.Spec, desiredRules.Spec) {
+		log.Info("Updating PrometheusRules")
+		existingRules.Spec = desiredRules.Spec
+		return true, nil
+	}
+
+	log.Info("PrometheusRules equal no update required.")
 	return false, nil
 }
 

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -31,44 +31,6 @@ func CreateOnlyMutator(existing, desired common.KubernetesObject) (bool, error) 
 	return false, nil
 }
 
-// Remove 'ThreeScaleApicastRequestTime' alert
-func RemovePrometheusRulesMutator(existing, desired common.KubernetesObject) (bool, error) {
-	existingPrometheusRule := existing.(*monitoringv1.PrometheusRule)
-	removed := false
-	updatedRules := []monitoringv1.Rule{}
-	group := existingPrometheusRule.Spec.Groups[0]
-
-	for _, rule := range group.Rules {
-		if rule.Alert != "ThreescaleApicastRequestTime" {
-			updatedRules = append(updatedRules, rule)
-		} else {
-			removed = true
-		}
-	}
-	if removed {
-		group.Rules = updatedRules
-		existingPrometheusRule.Spec.Groups[0] = group
-
-		log.Info("Alert 'ThreescaleApicastRequestTime' removed from PrometheusRules")
-		return true, nil
-	}
-	log.Info("Alert 'ThreescaleApicastRequestTime' not found, no update required.")
-	return false, nil
-}
-
-func UpdatePrometheusRulesMutator(existing, desired common.KubernetesObject) (bool, error) {
-	created, err := CreateOnlyMutator(existing, desired)
-	if err != nil {
-		return false, err
-	}
-
-	removed, err := RemovePrometheusRulesMutator(existing, desired)
-	if err != nil {
-		return false, err
-	}
-	return created || removed, nil
-}
-
 type BaseReconciler struct {
 	client          client.Client
 	scheme          *runtime.Scheme

--- a/pkg/reconcilers/prometheus_rules.go
+++ b/pkg/reconcilers/prometheus_rules.go
@@ -6,7 +6,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
-// Remove 'ThreeScaleApicastRequestTime' alert
+// RemovePrometheusRulesMutator removes the 'ThreeScaleApicastRequestTime' alert
 func RemovePrometheusRulesMutator(existing, desired common.KubernetesObject) (bool, error) {
 	existingPrometheusRule := existing.(*monitoringv1.PrometheusRule)
 	removed := false

--- a/pkg/reconcilers/prometheus_rules.go
+++ b/pkg/reconcilers/prometheus_rules.go
@@ -1,0 +1,32 @@
+package reconcilers
+
+import (
+	"github.com/3scale/3scale-operator/pkg/common"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+// Remove 'ThreeScaleApicastRequestTime' alert
+func RemovePrometheusRulesMutator(existing, desired common.KubernetesObject) (bool, error) {
+	existingPrometheusRule := existing.(*monitoringv1.PrometheusRule)
+	removed := false
+	updatedRules := []monitoringv1.Rule{}
+	group := existingPrometheusRule.Spec.Groups[0]
+
+	for _, rule := range group.Rules {
+		if rule.Alert != "ThreescaleApicastRequestTime" {
+			updatedRules = append(updatedRules, rule)
+		} else {
+			removed = true
+		}
+	}
+	if removed {
+		group.Rules = updatedRules
+		existingPrometheusRule.Spec.Groups[0] = group
+
+		log.Info("Alert 'ThreescaleApicastRequestTime' removed from PrometheusRules")
+		return true, nil
+	}
+	log.Info("Alert 'ThreescaleApicastRequestTime' not found, no update required.")
+	return false, nil
+}

--- a/pkg/reconcilers/prometheus_rules_test.go
+++ b/pkg/reconcilers/prometheus_rules_test.go
@@ -1,0 +1,107 @@
+package reconcilers
+
+import (
+	"testing"
+
+	"github.com/3scale/3scale-operator/pkg/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func TestRemovePrometheusRulesMutator(t *testing.T) {
+	type args struct {
+		existing common.KubernetesObject
+		desired  common.KubernetesObject
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "ThreescaleApicastRequestTime alert exists",
+			args: args{
+				existing: &monitoringv1.PrometheusRule{
+					Spec: monitoringv1.PrometheusRuleSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Name: "test-group",
+								Rules: []monitoringv1.Rule{
+									{
+										Alert: "ThreescaleApicastRequestTime",
+									},
+									{
+										Alert: "TestAlert",
+									},
+								},
+							},
+						},
+					},
+				},
+				desired: &monitoringv1.PrometheusRule{
+					Spec: monitoringv1.PrometheusRuleSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Name: "test-group",
+								Rules: []monitoringv1.Rule{
+									{
+										Alert: "TestAlert",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "ThreescaleApicastRequestTime alert does not exist",
+			args: args{
+				existing: &monitoringv1.PrometheusRule{
+					Spec: monitoringv1.PrometheusRuleSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Name: "test-group",
+								Rules: []monitoringv1.Rule{
+									{
+										Alert: "TestAlert",
+									},
+								},
+							},
+						},
+					},
+				},
+				desired: &monitoringv1.PrometheusRule{
+					Spec: monitoringv1.PrometheusRuleSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Name: "test-group",
+								Rules: []monitoringv1.Rule{
+									{
+										Alert: "TestAlert",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RemovePrometheusRulesMutator(tt.args.existing, tt.args.desired)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemovePrometheusRulesMutator() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("RemovePrometheusRulesMutator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue Link

Jira: https://issues.redhat.com/browse/THREESCALE-10098

# What

The rule 'ThreescaleApicastRequestTime' will be removed in the next 3scale release.

# Verification Steps
- `checkout this branch`
- provision a cluster

when cluster is ready:
- set up 3scale operator locally, https://github.com/3scale/3scale-operator/blob/master/doc/development.md#run-3scale-operator-locally but don't  `make run` the operator yet.

- create a new `secret` resource

-  add an API Manager CR. In the spec, ensure to enable monitoring like so:
```
monitoring:
  enablePrometheusRules: true
  enabled: true
```

- now `make run` to start the operator

- open the `PrometheusRule` CRs & in the `apicast` YAML verify that the 'ThreescaleApicastRequestTime' rule does not exist.

- at this stage `stop` the operator

- go back into `apicast` and create your own rule, name it anything you like. Also, rename one of the existing rules to 'ThreescaleApicastRequestTime'.

- `make run` the operator again

- `apicast` YAML should now request a reload 

- after reload, verify that your own created rule has persisted & the 'ThreescaleApicastRequestTime' rule has been successfully removed.
