### PR TITLE
THREESCALE-9556 Add liveness/readyness probes to pods

### DIFF
--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -129,6 +129,20 @@ func (backend *Backend) WorkerDeploymentConfig() *appsv1.DeploymentConfig {
 							Resources:       backend.Options.WorkerResourceRequirements,
 							ImagePullPolicy: v1.PullIfNotPresent,
 							Ports:           backend.workerPorts(),
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Port:   intstr.FromInt(9421),
+										Path:   "/metrics",
+										Scheme: v1.URISchemeHTTP,
+									},
+								},
+								FailureThreshold:    3,
+								InitialDelaySeconds: 30,
+								PeriodSeconds:       30,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      60,
+							},
 						},
 					},
 					ServiceAccountName:        "amp",
@@ -202,10 +216,19 @@ func (backend *Backend) CronDeploymentConfig() *appsv1.DeploymentConfig {
 						v1.Container{
 							Name:            "backend-cron",
 							Image:           "amp-backend:latest",
-							Args:            []string{"backend-cron"},
+							Args:            []string{"touch /tmp/healthy && backend-cron"},
 							Env:             backend.buildBackendCronEnv(),
 							Resources:       backend.Options.CronResourceRequirements,
 							ImagePullPolicy: v1.PullIfNotPresent,
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/healthy"},
+									},
+								},
+								InitialDelaySeconds: 30,
+								PeriodSeconds:       5,
+							},
 						},
 					},
 					ServiceAccountName:        "amp",

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -890,6 +890,18 @@ func (system *System) SidekiqDeploymentConfig() *appsv1.DeploymentConfig {
 							VolumeMounts:    system.sidekiqContainerVolumeMounts(),
 							ImagePullPolicy: v1.PullIfNotPresent,
 							Ports:           system.sideKiqPorts(),
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.FromInt(9394),
+									},
+								},
+								FailureThreshold:    40,
+								InitialDelaySeconds: 30,
+								PeriodSeconds:       30,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      30,
+							},
 						},
 					},
 					ServiceAccountName:        "amp",

--- a/pkg/3scale/amp/component/system_searchd.go
+++ b/pkg/3scale/amp/component/system_searchd.go
@@ -123,6 +123,18 @@ func (s *SystemSearchd) DeploymentConfig() *appsv1.DeploymentConfig {
 								InitialDelaySeconds: 60,
 								PeriodSeconds:       10,
 							},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.FromInt(9306),
+									},
+								},
+								InitialDelaySeconds: 30,
+								TimeoutSeconds:      10,
+								PeriodSeconds:       30,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
 							Resources: s.Options.ContainerResourceRequirements,
 						},
 					},

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -110,6 +110,8 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigTolerationsMutator,
 		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
 		reconcilers.DeploymentConfigRemoveDuplicateEnvVarMutator,
+		reconcilers.DeploymentConfigArgsMutator,
+		reconcilers.DeploymentConfigProbesMutator,
 		// 3scale 2.13 -> 2.14
 		upgrade.SphinxAddressReference,
 		reconcilers.DeploymentConfigPriorityClassMutator,

--- a/pkg/3scale/amp/operator/system_searchd_reconciler.go
+++ b/pkg/3scale/amp/operator/system_searchd_reconciler.go
@@ -57,6 +57,8 @@ func (r *SystemSearchdReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigStrategyMutator,
 		reconcilers.DeploymentConfigTopologySpreadConstraintsMutator,
 		reconcilers.DeploymentConfigPodTemplateAnnotationsMutator,
+		reconcilers.DeploymentConfigProbesMutator,
+		reconcilers.DeploymentConfigArgsMutator,
 	)
 	err = r.ReconcileDeploymentConfig(searchd.DeploymentConfig(), searchdDCmutator)
 	if err != nil {

--- a/pkg/reconcilers/deploymentconfig.go
+++ b/pkg/reconcilers/deploymentconfig.go
@@ -54,6 +54,8 @@ func GenericBackendMutators() []DCMutateFn {
 		DeploymentConfigPriorityClassMutator,
 		DeploymentConfigTopologySpreadConstraintsMutator,
 		DeploymentConfigPodTemplateAnnotationsMutator,
+		DeploymentConfigArgsMutator,
+		DeploymentConfigProbesMutator,
 	}
 }
 
@@ -280,6 +282,43 @@ func DeploymentConfigPodTemplateAnnotationsMutator(desired, existing *appsv1.Dep
 	updated := false
 
 	helper.MergeMapStringString(&updated, &existing.Spec.Template.Annotations, desired.Spec.Template.Annotations)
+
+	return updated, nil
+}
+
+// DeploymentConfigArgsMutator ensures Args are reconciled
+func DeploymentConfigArgsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	updated := false
+
+	for i, desiredContainer := range desired.Spec.Template.Spec.Containers {
+		existingContainer := &existing.Spec.Template.Spec.Containers[i]
+
+		if !reflect.DeepEqual(existingContainer.Args, desiredContainer.Args) {
+			existingContainer.Args = desiredContainer.Args
+			updated = true
+		}
+	}
+
+	return updated, nil
+}
+
+// DeploymentConfigProbesMutator ensures probes are reconciled
+func DeploymentConfigProbesMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+	updated := false
+
+	for i, desiredContainer := range desired.Spec.Template.Spec.Containers {
+		existingContainer := &existing.Spec.Template.Spec.Containers[i]
+
+		if !reflect.DeepEqual(existingContainer.LivenessProbe, desiredContainer.LivenessProbe) {
+			existingContainer.LivenessProbe = desiredContainer.LivenessProbe
+			updated = true
+		}
+
+		if !reflect.DeepEqual(existingContainer.ReadinessProbe, desiredContainer.ReadinessProbe) {
+			existingContainer.ReadinessProbe = desiredContainer.ReadinessProbe
+			updated = true
+		}
+	}
 
 	return updated, nil
 }


### PR DESCRIPTION
# Issue Link

Jira: https://issues.redhat.com/browse/THREESCALE-9556

# What

Probes are required in the following DeploymentConfigs:  

- `backend-cron` Liveness probe  

- `backend-worker` Liveness probe  

- `system-sidekiq` Liveness probe  

- `system-searchd` Readiness probe

# Verification

- Provision a cluster.
- Once ready, log in to your cluster via CLI.
- Checkout master branch (ensure its up to date with upstream):
```
git checkout master
```
- Installs CRDs:
```
make install
```
- Create a new project:
```
oc new-project 3scale-test
```
- Create a new secret:
```
oc apply -f - <<EOF   

kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: 3scale-test
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Create a new API Manager CR using your own Openshift console route as the wildcardDomain:
```
oc apply -f - <<EOF   

apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: 3scale-test
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: apps.comalley.ip84.s1.devshift.org<CHANGE TO YOUR OWN OPENSHIFT CONSOLE ROUTE>
EOF
```
- Install dependencies:
```
make download
```
- Run the master branch:
```
make run
```
- Wait until all resources are ready, you can check this with the following command:
```
oc get apimanager apimanager-sample -oyaml | yq '.status'
```
- Once ready, log into the cluster web console:
    - Navigate to `Deployment Configs` in the `3scale-test` namespace
    - For `backend-cron` `backend-worker` & `system-sidekiq` DCs in `Actions` dropdown, there should be `Add Health Checks` option which confirms no probes are created yet.
    - For `system-searchd` DC in `Actions` dropdown, there should be `Edit Health Checks` option. Click this and verify there is only a `Liveness Probe` created.

## Verify New Probes

- Stop the operator
- `checkout this branch`
- Restart the operator:
```
make run
```
- This time, the expected outcome is:
 - Navigate to `Deployment Configs` in the `3scale-test` namespace:
    - For `backend-cron` `backend-worker` & `system-sidekiq` DCs in `Actions` dropdown, there should be `Edit Health Checks` option. Click this and verify there is a `Liveness Probe` created.
    - For `system-searchd` DC in `Actions` dropdown, there should be `Edit Health Checks` option. Click this and verify there is a `Readinessess Probe` created.

This confirms the new probes will take effect for the customer once 3scale is updated.



