### PR TITLE
[WIP] THREESCALE-10110 - Investigation - Unit Tests - test Reconciler()

### DIFF
--- a/controllers/capabilities/proxyconfigpromote_controller.go
+++ b/controllers/capabilities/proxyconfigpromote_controller.go
@@ -38,6 +38,8 @@ type ProxyConfigPromoteReconciler struct {
 	*reconcilers.BaseReconciler
 }
 
+var proxyConfigPromoteReconcilerNew = (*ProxyConfigPromoteReconciler).proxyConfigPromoteReconciler
+
 // +kubebuilder:rbac:groups=capabilities.3scale.net,resources=proxyconfigpromotes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=capabilities.3scale.net,resources=proxyconfigpromotes/status,verbs=get;update;patch
 
@@ -103,7 +105,8 @@ func (r *ProxyConfigPromoteReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// reconcile spec of the proxyConfigPromote only if the CR isn't already marked as "Completed" since the CR is a one off update.
 	if !proxyConfigPromote.Status.Conditions.IsTrueFor(capabilitiesv1beta1.ProxyPromoteConfigReadyConditionType) {
-		statusReconciler, reconcileErr := r.proxyConfigPromoteReconciler(proxyConfigPromote, reqLogger, threescaleAPIClient, product)
+		f := &ProxyConfigPromoteReconciler{}
+		statusReconciler, reconcileErr := proxyConfigPromoteReconcilerNew(f, proxyConfigPromote, reqLogger, threescaleAPIClient, product)
 
 		// If status reconciler is not nil, proceed with reconciling the status
 		if statusReconciler != nil {


### PR DESCRIPTION
##  PR is NOT for Merge
_**For discussion only**_

Jira: https://issues.redhat.com/browse/THREESCALE-10110
Improve unit tests around the proxyConfigPromote controller

This PR was attempt to see how to test Reconciler()  method, main flow.
- The problem found - looks like need mock **inner functions** in Reconciler(), but this require changes in main code and not Unit tests (UT) only.
- The approach used in this PR - create alias vars for inner function(s).  Another approache, like "Interfaces", also require changes in main code to mock inner functions.
- If this is the only way to test main flow in some controllers,  - for existing project will be more reliable to check methods of controllers separately and not impact on main flow, that can be validated in **E2E tests**.
- In some cases, like for example `ProxyConfigPromoteStatusReconciler` - the changes in main code is not required (  already was implemented in ProxyConfigPromoteStatusReconciler Unit tests). 
