### PR TITLE
THREESCALE-10388 Migrate apicast DeploymentConfigs to Deployments

### DIFF
--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	k8sappsv1 "k8s.io/api/apps/v1"
 
-	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	v1 "k8s.io/api/core/v1"
@@ -153,7 +153,7 @@ func (r *APIManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(secretToApimanagerEventMapper.Map),
 			builder.WithPredicates(labelSelectorPredicate),
 		).
-		Owns(&appsv1.DeploymentConfig{}).
+		Owns(&k8sappsv1.Deployment{}).
 		Watches(&source.Kind{Type: &routev1.Route{}}, handler.EnqueueRequestsFromMapFunc(handlers.Map)).
 		Complete(r)
 }

--- a/pkg/3scale/amp/component/apicast.go
+++ b/pkg/3scale/amp/component/apicast.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	"github.com/3scale/3scale-operator/pkg/helper"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
-	appsv1 "github.com/openshift/api/apps/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,8 +19,9 @@ import (
 )
 
 const (
-	ApicastStagingName    = "apicast-staging"
-	ApicastProductionName = "apicast-production"
+	ApicastStagingName                 = "apicast-staging"
+	ApicastProductionName              = "apicast-production"
+	ApicastProductionInitContainerName = "system-master-svc"
 
 	CustomPoliciesMountBasePath               = "/opt/app-root/src/policies"
 	CustomPoliciesAnnotationNameSegmentPrefix = "apicast-policy-volume"
@@ -62,7 +64,7 @@ func (apicast *Apicast) StagingService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports:    apicast.stagingServicePorts(),
-			Selector: map[string]string{"deploymentConfig": ApicastStagingName},
+			Selector: map[string]string{reconcilers.DeploymentLabelSelector: ApicastStagingName},
 		},
 	}
 }
@@ -79,59 +81,40 @@ func (apicast *Apicast) ProductionService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports:    apicast.productionServicePorts(),
-			Selector: map[string]string{"deploymentConfig": ApicastProductionName},
+			Selector: map[string]string{reconcilers.DeploymentLabelSelector: ApicastProductionName},
 		},
 	}
 }
 
-func (apicast *Apicast) StagingDeploymentConfig() *appsv1.DeploymentConfig {
-	return &appsv1.DeploymentConfig{
-		TypeMeta: metav1.TypeMeta{APIVersion: "apps.openshift.io/v1", Kind: "DeploymentConfig"},
+func (apicast *Apicast) StagingDeployment() *k8sappsv1.Deployment {
+	return &k8sappsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: reconcilers.DeploymentAPIVersion, Kind: reconcilers.DeploymentKind},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ApicastStagingName,
 			Labels:      apicast.Options.CommonStagingLabels,
-			Annotations: apicast.stagingDeploymentConfigAnnotations(),
+			Annotations: apicast.stagingDeploymentAnnotations(),
 		},
-		Spec: appsv1.DeploymentConfigSpec{
-			Replicas: apicast.Options.StagingReplicas,
-			Selector: map[string]string{
-				"deploymentConfig": ApicastStagingName,
+		Spec: k8sappsv1.DeploymentSpec{
+			Replicas: &apicast.Options.StagingReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					reconcilers.DeploymentLabelSelector: ApicastStagingName,
+				},
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				RollingParams: &appsv1.RollingDeploymentStrategyParams{
-					IntervalSeconds: &[]int64{1}[0],
+			Strategy: k8sappsv1.DeploymentStrategy{
+				RollingUpdate: &k8sappsv1.RollingUpdateDeployment{
 					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
+						Type:   intstr.String,
 						StrVal: "25%",
 					},
 					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
+						Type:   intstr.String,
 						StrVal: "25%",
 					},
-					TimeoutSeconds:      &[]int64{1800}[0],
-					UpdatePeriodSeconds: &[]int64{1}[0],
 				},
-				Type: appsv1.DeploymentStrategyTypeRolling,
+				Type: k8sappsv1.RollingUpdateDeploymentStrategyType,
 			},
-			Triggers: appsv1.DeploymentTriggerPolicies{
-				appsv1.DeploymentTriggerPolicy{
-					Type: appsv1.DeploymentTriggerOnConfigChange,
-				},
-				appsv1.DeploymentTriggerPolicy{
-					Type: appsv1.DeploymentTriggerOnImageChange,
-					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
-						Automatic: true,
-						ContainerNames: []string{
-							ApicastStagingName,
-						},
-						From: v1.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: fmt.Sprintf("amp-apicast:%s", apicast.Options.ImageTag),
-						},
-					},
-				},
-			},
-			Template: &v1.PodTemplateSpec{
+			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      apicast.Options.StagingPodTemplateLabels,
 					Annotations: apicast.stagingPodAnnotations(),
@@ -142,7 +125,7 @@ func (apicast *Apicast) StagingDeploymentConfig() *appsv1.DeploymentConfig {
 					ServiceAccountName: "amp",
 					Volumes:            apicast.stagingVolumes(),
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Ports:           apicast.stagingContainerPorts(),
 							Env:             apicast.buildApicastStagingEnv(),
 							Image:           "amp-apicast:latest",
@@ -178,55 +161,35 @@ func (apicast *Apicast) StagingDeploymentConfig() *appsv1.DeploymentConfig {
 	}
 }
 
-func (apicast *Apicast) ProductionDeploymentConfig() *appsv1.DeploymentConfig {
-	return &appsv1.DeploymentConfig{
-		TypeMeta: metav1.TypeMeta{APIVersion: "apps.openshift.io/v1", Kind: "DeploymentConfig"},
+func (apicast *Apicast) ProductionDeployment() *k8sappsv1.Deployment {
+	return &k8sappsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: reconcilers.DeploymentAPIVersion, Kind: reconcilers.DeploymentKind},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ApicastProductionName,
 			Labels:      apicast.Options.CommonProductionLabels,
-			Annotations: apicast.productionDeploymentConfigAnnotations(),
+			Annotations: apicast.productionDeploymentAnnotations(),
 		},
-		Spec: appsv1.DeploymentConfigSpec{
-			Replicas: apicast.Options.ProductionReplicas,
-			Selector: map[string]string{
-				"deploymentConfig": ApicastProductionName,
+		Spec: k8sappsv1.DeploymentSpec{
+			Replicas: &apicast.Options.ProductionReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					reconcilers.DeploymentLabelSelector: ApicastProductionName,
+				},
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				RollingParams: &appsv1.RollingDeploymentStrategyParams{
-					IntervalSeconds: &[]int64{1}[0],
+			Strategy: k8sappsv1.DeploymentStrategy{
+				RollingUpdate: &k8sappsv1.RollingUpdateDeployment{
 					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
+						Type:   intstr.String,
 						StrVal: "25%",
 					},
 					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
+						Type:   intstr.String,
 						StrVal: "25%",
 					},
-					TimeoutSeconds:      &[]int64{1800}[0],
-					UpdatePeriodSeconds: &[]int64{1}[0],
 				},
-				Type: appsv1.DeploymentStrategyTypeRolling,
+				Type: k8sappsv1.RollingUpdateDeploymentStrategyType,
 			},
-			Triggers: appsv1.DeploymentTriggerPolicies{
-				appsv1.DeploymentTriggerPolicy{
-					Type: appsv1.DeploymentTriggerOnConfigChange,
-				},
-				appsv1.DeploymentTriggerPolicy{
-					Type: appsv1.DeploymentTriggerOnImageChange,
-					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
-						Automatic: true,
-						ContainerNames: []string{
-							"system-master-svc",
-							ApicastProductionName,
-						},
-						From: v1.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: fmt.Sprintf("amp-apicast:%s", apicast.Options.ImageTag),
-						},
-					},
-				},
-			},
-			Template: &v1.PodTemplateSpec{
+			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      apicast.Options.ProductionPodTemplateLabels,
 					Annotations: apicast.productionPodAnnotations(),
@@ -237,12 +200,12 @@ func (apicast *Apicast) ProductionDeploymentConfig() *appsv1.DeploymentConfig {
 					ServiceAccountName: "amp",
 					Volumes:            apicast.productionVolumes(),
 					InitContainers: []v1.Container{
-						v1.Container{
-							Name:    "system-master-svc",
+						{
+							Name:    ApicastProductionInitContainerName,
 							Image:   "amp-apicast:latest",
 							Command: []string{"sh", "-c", "until $(curl --output /dev/null --silent --fail --head http://system-master:3000/status); do sleep $SLEEP_SECONDS; done"},
 							Env: []v1.EnvVar{
-								v1.EnvVar{
+								{
 									Name:  "SLEEP_SECONDS",
 									Value: "1",
 								},
@@ -250,7 +213,7 @@ func (apicast *Apicast) ProductionDeploymentConfig() *appsv1.DeploymentConfig {
 						},
 					},
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Ports:           apicast.productionContainerPorts(),
 							Env:             apicast.buildApicastProductionEnv(),
 							Image:           "amp-apicast:latest",
@@ -481,7 +444,7 @@ func (apicast *Apicast) StagingPodDisruptionBudget() *policyv1.PodDisruptionBudg
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"deploymentConfig": ApicastStagingName},
+				MatchLabels: map[string]string{reconcilers.DeploymentLabelSelector: ApicastStagingName},
 			},
 			MaxUnavailable: &intstr.IntOrString{IntVal: PDB_MAX_UNAVAILABLE_POD_NUMBER},
 		},
@@ -500,7 +463,7 @@ func (apicast *Apicast) ProductionPodDisruptionBudget() *policyv1.PodDisruptionB
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"deploymentConfig": ApicastProductionName},
+				MatchLabels: map[string]string{reconcilers.DeploymentLabelSelector: ApicastProductionName},
 			},
 			MaxUnavailable: &intstr.IntOrString{IntVal: PDB_MAX_UNAVAILABLE_POD_NUMBER},
 		},
@@ -709,8 +672,21 @@ func (apicast *Apicast) stagingVolumes() []v1.Volume {
 	return volumes
 }
 
-func (apicast *Apicast) productionDeploymentConfigAnnotations() map[string]string {
+func (apicast *Apicast) productionDeploymentAnnotations() map[string]string {
 	annotations := map[string]string{}
+
+	// Image trigger annotation should always be present
+	imageTriggerString := reconcilers.CreateImageTriggerAnnotationString([]reconcilers.ContainerImage{
+		{
+			Name: ApicastProductionInitContainerName,
+			Tag:  fmt.Sprintf("amp-apicast:%v", apicast.Options.ImageTag),
+		},
+		{
+			Name: ApicastProductionName,
+			Tag:  fmt.Sprintf("amp-apicast:%v", apicast.Options.ImageTag),
+		},
+	})
+	annotations[reconcilers.DeploymentImageTriggerAnnotation] = imageTriggerString
 
 	for _, customPolicy := range apicast.Options.ProductionCustomPolicies {
 		annotations[customPolicy.AnnotationKey()] = customPolicy.AnnotationValue()
@@ -725,16 +701,20 @@ func (apicast *Apicast) productionDeploymentConfigAnnotations() map[string]strin
 		annotations[customEnvAnnotationKey(customEnvSecret)] = customEnvAnnotationValue(customEnvSecret)
 	}
 
-	// keep backward compat
-	if len(annotations) == 0 {
-		return nil
-	}
-
 	return annotations
 }
 
-func (apicast *Apicast) stagingDeploymentConfigAnnotations() map[string]string {
+func (apicast *Apicast) stagingDeploymentAnnotations() map[string]string {
 	annotations := map[string]string{}
+
+	// Image trigger annotation should always be present
+	imageTriggerString := reconcilers.CreateImageTriggerAnnotationString([]reconcilers.ContainerImage{
+		{
+			Name: ApicastStagingName,
+			Tag:  fmt.Sprintf("amp-apicast:%v", apicast.Options.ImageTag),
+		},
+	})
+	annotations[reconcilers.DeploymentImageTriggerAnnotation] = imageTriggerString
 
 	for _, customPolicy := range apicast.Options.StagingCustomPolicies {
 		annotations[customPolicy.AnnotationKey()] = customPolicy.AnnotationValue()
@@ -747,11 +727,6 @@ func (apicast *Apicast) stagingDeploymentConfigAnnotations() map[string]string {
 
 	for _, customEnvSecret := range apicast.Options.StagingCustomEnvironments {
 		annotations[customEnvAnnotationKey(customEnvSecret)] = customEnvAnnotationValue(customEnvSecret)
-	}
-
-	// keep backward compat
-	if len(annotations) == 0 {
-		return nil
 	}
 
 	return annotations

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
 )
 
 type ApicastOptionsProvider struct {
@@ -129,7 +130,7 @@ func (a *ApicastOptionsProvider) setResourceRequirementsOptions() {
 		a.apicastOptions.StagingResourceRequirements = v1.ResourceRequirements{}
 	}
 
-	// DeploymentConfig-level ResourceRequirements CR fields have priority over
+	// Deployment-level ResourceRequirements CR fields have priority over
 	// spec.resourceRequirementsEnabled, overwriting that setting when they are
 	// defined
 	if a.apimanager.Spec.Apicast.ProductionSpec.Resources != nil {
@@ -191,7 +192,7 @@ func (a *ApicastOptionsProvider) stagingPodTemplateLabels() map[string]string {
 		labels[k] = v
 	}
 
-	labels["deploymentConfig"] = "apicast-staging"
+	labels[reconcilers.DeploymentLabelSelector] = "apicast-staging"
 
 	return labels
 }
@@ -207,7 +208,7 @@ func (a *ApicastOptionsProvider) productionPodTemplateLabels() map[string]string
 		labels[k] = v
 	}
 
-	labels["deploymentConfig"] = "apicast-production"
+	labels[reconcilers.DeploymentLabelSelector] = "apicast-production"
 
 	return labels
 }

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	"reflect"
 	"strconv"
 	"testing"
@@ -52,10 +53,10 @@ func testApicastProductionLabels() map[string]string {
 
 func testApicastStagingPodLabels() map[string]string {
 	labels := map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "apicast",
-		"threescale_component_element": "staging",
-		"deploymentConfig":             "apicast-staging",
+		"app":                               appLabel,
+		"threescale_component":              "apicast",
+		"threescale_component_element":      "staging",
+		reconcilers.DeploymentLabelSelector: "apicast-staging",
 	}
 	addExpectedMeteringLabels(labels, "apicast-staging", helper.ApplicationType)
 
@@ -64,10 +65,10 @@ func testApicastStagingPodLabels() map[string]string {
 
 func testApicastProductionPodLabels() map[string]string {
 	labels := map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "apicast",
-		"threescale_component_element": "production",
-		"deploymentConfig":             "apicast-production",
+		"app":                               appLabel,
+		"threescale_component":              "apicast",
+		"threescale_component_element":      "production",
+		reconcilers.DeploymentLabelSelector: "apicast-production",
 	}
 	addExpectedMeteringLabels(labels, "apicast-production", helper.ApplicationType)
 

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	appsv1 "github.com/openshift/api/apps/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,6 +17,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/pkg/upgrade"
 )
 
 func ApicastEnvCMMutator(existingObj, desiredObj common.KubernetesObject) (bool, error) {
@@ -62,12 +63,12 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	stagingMutators := []reconcilers.DCMutateFn{
-		reconcilers.DeploymentConfigImageChangeTriggerMutator,
-		reconcilers.DeploymentConfigContainerResourcesMutator,
-		reconcilers.DeploymentConfigAffinityMutator,
-		reconcilers.DeploymentConfigTolerationsMutator,
-		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
+	stagingMutators := []reconcilers.DMutateFn{
+		reconcilers.DeploymentAnnotationsMutator,
+		reconcilers.DeploymentContainerResourcesMutator,
+		reconcilers.DeploymentAffinityMutator,
+		reconcilers.DeploymentTolerationsMutator,
+		reconcilers.DeploymentPodTemplateLabelsMutator,
 		apicastLogLevelEnvVarMutator,
 		apicastTracingConfigEnvVarsMutator,
 		apicastEnvironmentEnvVarMutator,
@@ -81,28 +82,37 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		apicastCustomEnvAnnotationsMutator,     // Should be always after volume mutator
 		portsMutator,
 		apicastPodTemplateEnvConfigMapAnnotationsMutator,
-		reconcilers.DeploymentConfigPriorityClassMutator,
-		reconcilers.DeploymentConfigTopologySpreadConstraintsMutator,
-		reconcilers.DeploymentConfigPodTemplateAnnotationsMutator,
+		reconcilers.DeploymentPriorityClassMutator,
+		reconcilers.DeploymentTopologySpreadConstraintsMutator,
+		reconcilers.DeploymentPodTemplateAnnotationsMutator,
 	}
 
 	if r.apiManager.Spec.Apicast.StagingSpec.Replicas != nil {
-		stagingMutators = append(stagingMutators, reconcilers.DeploymentConfigReplicasMutator)
+		stagingMutators = append(stagingMutators, reconcilers.DeploymentReplicasMutator)
 	}
 
-	// Staging DC
-	err = r.ReconcileDeploymentConfig(apicast.StagingDeploymentConfig(), reconcilers.DeploymentConfigMutator(stagingMutators...))
+	// Staging Deployment
+	err = r.ReconcileDeployment(apicast.StagingDeployment(), reconcilers.DeploymentMutator(stagingMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
+	// 3scale 2.14 -> 2.15
+	isMigrated, err := upgrade.MigrateDeploymentConfigToDeployment(component.ApicastStagingName, r.apiManager.GetNamespace(), r.Client())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !isMigrated {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// add apicast production env var mutator
-	productionMutators := []reconcilers.DCMutateFn{
-		reconcilers.DeploymentConfigImageChangeTriggerMutator,
-		reconcilers.DeploymentConfigContainerResourcesMutator,
-		reconcilers.DeploymentConfigAffinityMutator,
-		reconcilers.DeploymentConfigTolerationsMutator,
-		reconcilers.DeploymentConfigPodTemplateLabelsMutator,
+	productionMutators := []reconcilers.DMutateFn{
+		reconcilers.DeploymentAnnotationsMutator,
+		reconcilers.DeploymentContainerResourcesMutator,
+		reconcilers.DeploymentAffinityMutator,
+		reconcilers.DeploymentTolerationsMutator,
+		reconcilers.DeploymentPodTemplateLabelsMutator,
 		apicastProductionWorkersEnvVarMutator,
 		apicastLogLevelEnvVarMutator,
 		apicastTracingConfigEnvVarsMutator,
@@ -117,33 +127,43 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		apicastCustomEnvAnnotationsMutator,     // Should be always after volume
 		portsMutator,
 		apicastPodTemplateEnvConfigMapAnnotationsMutator,
-		reconcilers.DeploymentConfigPriorityClassMutator,
-		reconcilers.DeploymentConfigTopologySpreadConstraintsMutator,
-		reconcilers.DeploymentConfigPodTemplateAnnotationsMutator,
+		reconcilers.DeploymentPriorityClassMutator,
+		reconcilers.DeploymentTopologySpreadConstraintsMutator,
+		reconcilers.DeploymentPodTemplateAnnotationsMutator,
 	}
 
 	if r.apiManager.Spec.Apicast.ProductionSpec.Replicas != nil {
-		productionMutators = append(productionMutators, reconcilers.DeploymentConfigReplicasMutator)
+		productionMutators = append(productionMutators, reconcilers.DeploymentReplicasMutator)
 	}
 
-	// Production DC
-	productionDCMutator := reconcilers.DeploymentConfigMutator(
-		productionMutators...,
-	)
-
-	err = r.ReconcileDeploymentConfig(apicast.ProductionDeploymentConfig(), productionDCMutator)
+	// Production Deployment
+	err = r.ReconcileDeployment(apicast.ProductionDeployment(), reconcilers.DeploymentMutator(productionMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
+	// 3scale 2.14 -> 2.15
+	isMigrated, err = upgrade.MigrateDeploymentConfigToDeployment(component.ApicastProductionName, r.apiManager.GetNamespace(), r.Client())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !isMigrated {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	serviceMutators := []reconcilers.MutateFn{
+		getApiCastServiceMutator(r.apiManager.ObjectMeta.GetAnnotations()),
+		reconcilers.ServiceSelectorMutator,
+	}
+
 	// Staging Service
-	err = r.ReconcileService(apicast.StagingService(), getApiCastServiceMutator(r.apiManager.ObjectMeta.GetAnnotations()))
+	err = r.ReconcileService(apicast.StagingService(), reconcilers.ServiceMutator(serviceMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Production Service
-	err = r.ReconcileService(apicast.ProductionService(), getApiCastServiceMutator(r.apiManager.ObjectMeta.GetAnnotations()))
+	err = r.ReconcileService(apicast.ProductionService(), reconcilers.ServiceMutator(serviceMutators...))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -222,33 +242,33 @@ func getApiCastServiceMutator(apiManagerAnnotations map[string]string) reconcile
 	return reconcilers.ServicePortMutator
 }
 
-func apicastProductionWorkersEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastProductionWorkersEnvVarMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Reconcile EnvVar only for "APICAST_WORKERS"
-	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_WORKERS"), nil
+	return reconcilers.DeploymentEnvVarReconciler(desired, existing, "APICAST_WORKERS"), nil
 }
 
-func apicastLogLevelEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastLogLevelEnvVarMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Reconcile EnvVar only for "APICAST_LOG_LEVEL"
-	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_LOG_LEVEL"), nil
+	return reconcilers.DeploymentEnvVarReconciler(desired, existing, "APICAST_LOG_LEVEL"), nil
 }
 
-func apicastTracingConfigEnvVarsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastTracingConfigEnvVarsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Reconcile EnvVars related to opentracing
 	var changed bool
-	changed = reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "OPENTRACING_TRACER")
+	changed = reconcilers.DeploymentEnvVarReconciler(desired, existing, "OPENTRACING_TRACER")
 
-	tmpChanged := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "OPENTRACING_CONFIG")
+	tmpChanged := reconcilers.DeploymentEnvVarReconciler(desired, existing, "OPENTRACING_CONFIG")
 	changed = changed || tmpChanged
 
 	return changed, nil
 }
 
-func apicastEnvironmentEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastEnvironmentEnvVarMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Reconcile EnvVar only for "APICAST_ENVIRONMENT"
-	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_ENVIRONMENT"), nil
+	return reconcilers.DeploymentEnvVarReconciler(desired, existing, "APICAST_ENVIRONMENT"), nil
 }
 
-func apicastHTTPSEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastHTTPSEnvVarMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Reconcile EnvVars related to opentracing
 	var changed bool
 
@@ -258,14 +278,14 @@ func apicastHTTPSEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool
 		"APICAST_HTTPS_CERTIFICATE",
 		"APICAST_HTTPS_CERTIFICATE_KEY",
 	} {
-		tmpChanged := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, envVar)
+		tmpChanged := reconcilers.DeploymentEnvVarReconciler(desired, existing, envVar)
 		changed = changed || tmpChanged
 	}
 
 	return changed, nil
 }
 
-func apicastProxyConfigurationsEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastProxyConfigurationsEnvVarMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Reconcile EnvVars related to APIcast proxy-related configurations
 	var changed bool
 
@@ -275,18 +295,18 @@ func apicastProxyConfigurationsEnvVarMutator(desired, existing *appsv1.Deploymen
 		"HTTPS_PROXY",
 		"NO_PROXY",
 	} {
-		tmpChanged := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, envVar)
+		tmpChanged := reconcilers.DeploymentEnvVarReconciler(desired, existing, envVar)
 		changed = changed || tmpChanged
 	}
 
 	return changed, nil
 }
 
-func apicastServiceCacheSizeEnvVarMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
-	return reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_SERVICE_CACHE_SIZE"), nil
+func apicastServiceCacheSizeEnvVarMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	return reconcilers.DeploymentEnvVarReconciler(desired, existing, "APICAST_SERVICE_CACHE_SIZE"), nil
 }
 
-func portsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func portsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	changed := false
 
 	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Ports, desired.Spec.Template.Spec.Containers[0].Ports) {
@@ -297,11 +317,11 @@ func portsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
 	return changed, nil
 }
 
-// volumeMountsMutator implements basic VolumeMount reconcilliation
+// apicastVolumeMountsMutator implements basic VolumeMount reconciliation
 // Added when in desired and not in existing
 // Updated when in desired and in existing but not equal
 // Existing not in desired will NOT be removed. Allows manually added volumemounts
-func apicastVolumeMountsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastVolumeMountsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	changed := false
 	existingContainer := &existing.Spec.Template.Spec.Containers[0]
 	desiredContainer := &desired.Spec.Template.Spec.Containers[0]
@@ -380,11 +400,11 @@ func apicastVolumeMountsMutator(desired, existing *appsv1.DeploymentConfig) (boo
 	return changed, nil
 }
 
-// volumeMountsMutator implements basic VolumeMount reconcilliation
+// apicastVolumesMutator implements basic VolumeMount reconciliation
 // Added when in desired and not in existing
 // Updated when in desired and in existing but not equal
 // Existing not in desired will NOT be removed. Allows manually added volumemounts
-func apicastVolumesMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastVolumesMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	changed := false
 	existingSpec := &existing.Spec.Template.Spec
 	desiredSpec := &desired.Spec.Template.Spec
@@ -463,7 +483,7 @@ func apicastVolumesMutator(desired, existing *appsv1.DeploymentConfig) (bool, er
 	return changed, nil
 }
 
-func apicastCustomPolicyAnnotationsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastCustomPolicyAnnotationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// It is expected that APIManagerMutator has already added desired annotations to the existing annotations
 	// find existing custom policy annotations not in desired and delete them
 	updated := false
@@ -487,7 +507,7 @@ func apicastCustomPolicyAnnotationsMutator(desired, existing *appsv1.DeploymentC
 	return updated, nil
 }
 
-func apicastTracingConfigAnnotationsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastTracingConfigAnnotationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// It is expected that APIManagerMutator has already added desired annotations to the existing annotations
 	// find existing tracing config volume annotations not in desired and delete them
 	updated := false
@@ -511,7 +531,7 @@ func apicastTracingConfigAnnotationsMutator(desired, existing *appsv1.Deployment
 	return updated, nil
 }
 
-func apicastCustomEnvAnnotationsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastCustomEnvAnnotationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// It is expected that APIManagerMutator has already added desired annotations to the existing annotations
 	// find existing custom environments annotations not in desired and delete them
 	updated := false
@@ -535,7 +555,7 @@ func apicastCustomEnvAnnotationsMutator(desired, existing *appsv1.DeploymentConf
 	return updated, nil
 }
 
-func apicastPodTemplateEnvConfigMapAnnotationsMutator(desired, existing *appsv1.DeploymentConfig) (bool, error) {
+func apicastPodTemplateEnvConfigMapAnnotationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	// Only reconcile the pod annotation regarding apicast-environment hash
 	desiredVal, ok := desired.Spec.Template.Annotations[APIcastEnvironmentCMAnnotation]
 	if !ok {

--- a/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
+++ b/pkg/3scale/amp/operator/base_apimanager_logic_reconciler.go
@@ -14,6 +14,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -61,6 +62,10 @@ func (r *BaseAPIManagerLogicReconciler) ReconcileImagestream(desired *imagev1.Im
 
 func (r *BaseAPIManagerLogicReconciler) ReconcileDeploymentConfig(desired *appsv1.DeploymentConfig, mutatefn reconcilers.MutateFn) error {
 	return r.ReconcileResource(&appsv1.DeploymentConfig{}, desired, mutatefn)
+}
+
+func (r *BaseAPIManagerLogicReconciler) ReconcileDeployment(desired *k8sappsv1.Deployment, mutatefn reconcilers.MutateFn) error {
+	return r.ReconcileResource(&k8sappsv1.Deployment{}, desired, mutatefn)
 }
 
 func (r *BaseAPIManagerLogicReconciler) ReconcileService(desired *v1.Service, mutateFn reconcilers.MutateFn) error {

--- a/pkg/helper/deployment.go
+++ b/pkg/helper/deployment.go
@@ -1,0 +1,18 @@
+package helper
+
+import (
+	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// IsDeploymentAvailable returns true when the provided Deployment
+// has the "Available" condition set to true
+func IsDeploymentAvailable(d *k8sappsv1.Deployment) bool {
+	dConditions := d.Status.Conditions
+	for _, dCondition := range dConditions {
+		if dCondition.Type == k8sappsv1.DeploymentAvailable && dCondition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -1,0 +1,290 @@
+package reconcilers
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/3scale/3scale-operator/pkg/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
+)
+
+const (
+	DeploymentKind                   = "Deployment"
+	DeploymentAPIVersion             = "apps/v1"
+	DeploymentLabelSelector          = "deployment"
+	DeploymentImageTriggerAnnotation = "image.openshift.io/triggers"
+)
+
+type ContainerImage struct {
+	Name string
+	Tag  string
+}
+
+type ImageTriggerFrom struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+	// +optional
+	Namespace *string `json:"namespace,omitempty"`
+}
+
+type ImageTrigger struct {
+	From      ImageTriggerFrom `json:"from"`
+	FieldPath string           `json:"fieldPath"`
+	// +optional
+	Paused bool `json:"paused,omitempty"`
+}
+
+// DMutateFn is a function which mutates the existing Deployment into it's desired state.
+type DMutateFn func(desired, existing *k8sappsv1.Deployment) (bool, error)
+
+func DeploymentMutator(opts ...DMutateFn) MutateFn {
+	return func(existingObj, desiredObj common.KubernetesObject) (bool, error) {
+		existing, ok := existingObj.(*k8sappsv1.Deployment)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *k8sappsv1.Deployment", existingObj)
+		}
+		desired, ok := desiredObj.(*k8sappsv1.Deployment)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *k8sappsv1.Deployment", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate, err := opt(desired, existing)
+			if err != nil {
+				return false, err
+			}
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
+// GenericBackendDeploymentMutators returns the generic mutators for backend
+func GenericBackendDeploymentMutators() []DMutateFn {
+	return []DMutateFn{
+		DeploymentAnnotationsMutator,
+		DeploymentContainerResourcesMutator,
+		DeploymentAffinityMutator,
+		DeploymentTolerationsMutator,
+		DeploymentPodTemplateLabelsMutator,
+		DeploymentPriorityClassMutator,
+		DeploymentTopologySpreadConstraintsMutator,
+		DeploymentPodTemplateAnnotationsMutator,
+	}
+}
+
+// DeploymentAnnotationsMutator ensures Deployment Annotations are reconciled
+func DeploymentAnnotationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	helper.MergeMapStringString(&updated, &existing.ObjectMeta.Annotations, desired.ObjectMeta.Annotations)
+
+	return updated, nil
+}
+
+func DeploymentReplicasMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	update := false
+
+	if desired.Spec.Replicas != existing.Spec.Replicas {
+		existing.Spec.Replicas = desired.Spec.Replicas
+		update = true
+	}
+
+	return update, nil
+}
+
+func DeploymentAffinityMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Affinity, desired.Spec.Template.Spec.Affinity) {
+		diff := cmp.Diff(existing.Spec.Template.Spec.Affinity, desired.Spec.Template.Spec.Affinity)
+		log.Info(fmt.Sprintf("%s spec.template.spec.Affinity has changed: %s", common.ObjectInfo(desired), diff))
+		existing.Spec.Template.Spec.Affinity = desired.Spec.Template.Spec.Affinity
+		updated = true
+	}
+
+	return updated, nil
+}
+
+func DeploymentTolerationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Tolerations, desired.Spec.Template.Spec.Tolerations) {
+		diff := cmp.Diff(existing.Spec.Template.Spec.Tolerations, desired.Spec.Template.Spec.Tolerations)
+		log.Info(fmt.Sprintf("%s spec.template.spec.Tolerations has changed: %s", common.ObjectInfo(desired), diff))
+		existing.Spec.Template.Spec.Tolerations = desired.Spec.Template.Spec.Tolerations
+		updated = true
+	}
+
+	return updated, nil
+}
+
+func DeploymentContainerResourcesMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	desiredName := common.ObjectInfo(desired)
+	update := false
+
+	if len(desired.Spec.Template.Spec.Containers) != 1 {
+		return false, fmt.Errorf("%s desired spec.template.spec.containers length changed to '%d', should be 1", desiredName, len(desired.Spec.Template.Spec.Containers))
+	}
+
+	if len(existing.Spec.Template.Spec.Containers) != 1 {
+		log.Info(fmt.Sprintf("%s spec.template.spec.containers length changed to '%d', recreating dc", desiredName, len(existing.Spec.Template.Spec.Containers)))
+		existing.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+		update = true
+	}
+
+	if !helper.CmpResources(&existing.Spec.Template.Spec.Containers[0].Resources, &desired.Spec.Template.Spec.Containers[0].Resources) {
+		diff := cmp.Diff(existing.Spec.Template.Spec.Containers[0].Resources, desired.Spec.Template.Spec.Containers[0].Resources, cmpopts.IgnoreUnexported(resource.Quantity{}))
+		log.Info(fmt.Sprintf("%s spec.template.spec.containers[0].resources have changed: %s", desiredName, diff))
+		existing.Spec.Template.Spec.Containers[0].Resources = desired.Spec.Template.Spec.Containers[0].Resources
+		update = true
+	}
+
+	return update, nil
+}
+
+// DeploymentEnvVarReconciler implements basic env var reconciliation deployments.
+// Existing and desired DC must have same number of containers
+// Added when in desired and not in existing
+// Updated when in desired and in existing but not equal
+// Removed when not in desired and exists in existing DC
+func DeploymentEnvVarReconciler(desired, existing *k8sappsv1.Deployment, envVar string) bool {
+	updated := false
+
+	if len(desired.Spec.Template.Spec.Containers) != len(existing.Spec.Template.Spec.Containers) {
+		log.Info("[WARNING] not reconciling deployment",
+			"name", client.ObjectKeyFromObject(desired),
+			"reason", "existing and desired do not have same number of containers")
+		return false
+	}
+
+	if len(desired.Spec.Template.Spec.InitContainers) != len(existing.Spec.Template.Spec.InitContainers) {
+		log.Info("[WARNING] not reconciling deployment",
+			"name", client.ObjectKeyFromObject(desired),
+			"reason", "existing and desired do not have same number of init containers")
+		return false
+	}
+
+	// Init Containers
+	for idx := range existing.Spec.Template.Spec.InitContainers {
+		tmpChanged := helper.EnvVarReconciler(
+			desired.Spec.Template.Spec.InitContainers[idx].Env,
+			&existing.Spec.Template.Spec.InitContainers[idx].Env,
+			envVar)
+		updated = updated || tmpChanged
+	}
+
+	// Containers
+	for idx := range existing.Spec.Template.Spec.Containers {
+		tmpChanged := helper.EnvVarReconciler(
+			desired.Spec.Template.Spec.Containers[idx].Env,
+			&existing.Spec.Template.Spec.Containers[idx].Env,
+			envVar)
+		updated = updated || tmpChanged
+	}
+
+	return updated
+}
+
+// DeploymentPodTemplateLabelsMutator ensures pod template labels are reconciled
+func DeploymentPodTemplateLabelsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	helper.MergeMapStringString(&updated, &existing.Spec.Template.Labels, desired.Spec.Template.Labels)
+
+	return updated, nil
+}
+
+// DeploymentRemoveDuplicateEnvVarMutator ensures pod env vars are not duplicated
+func DeploymentRemoveDuplicateEnvVarMutator(_, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+	for idx := range existing.Spec.Template.Spec.Containers {
+		prunedEnvs := helper.RemoveDuplicateEnvVars(existing.Spec.Template.Spec.Containers[idx].Env)
+		if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[idx].Env, prunedEnvs) {
+			existing.Spec.Template.Spec.Containers[idx].Env = prunedEnvs
+			updated = true
+		}
+	}
+
+	return updated, nil
+}
+
+// DeploymentPriorityClassMutator ensures priorityclass is reconciled
+func DeploymentPriorityClassMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	if existing.Spec.Template.Spec.PriorityClassName != desired.Spec.Template.Spec.PriorityClassName {
+		existing.Spec.Template.Spec.PriorityClassName = desired.Spec.Template.Spec.PriorityClassName
+		updated = true
+	}
+
+	return updated, nil
+}
+
+// DeploymentStrategyMutator ensures desired strategy
+func DeploymentStrategyMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Strategy, desired.Spec.Strategy) {
+		existing.Spec.Strategy = desired.Spec.Strategy
+		updated = true
+	}
+
+	return updated, nil
+}
+
+// DeploymentTopologySpreadConstraintsMutator ensures TopologySpreadConstraints is reconciled
+func DeploymentTopologySpreadConstraintsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.TopologySpreadConstraints, desired.Spec.Template.Spec.TopologySpreadConstraints) {
+		diff := cmp.Diff(existing.Spec.Template.Spec.TopologySpreadConstraints, desired.Spec.Template.Spec.TopologySpreadConstraints)
+		log.Info(fmt.Sprintf("%s spec.template.spec.TopologySpreadConstraints has changed: %s", common.ObjectInfo(desired), diff))
+		existing.Spec.Template.Spec.TopologySpreadConstraints = desired.Spec.Template.Spec.TopologySpreadConstraints
+		updated = true
+	}
+
+	return updated, nil
+}
+
+// DeploymentPodTemplateAnnotationsMutator ensures Pod Template Annotations is reconciled
+func DeploymentPodTemplateAnnotationsMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	updated := false
+
+	helper.MergeMapStringString(&updated, &existing.Spec.Template.Annotations, desired.Spec.Template.Annotations)
+
+	return updated, nil
+}
+
+// CreateImageTriggerAnnotationString creates the annotation for Deployments to leverage existing ImageStreamTags
+func CreateImageTriggerAnnotationString(containers []ContainerImage) string {
+	var triggers []ImageTrigger
+
+	for _, container := range containers {
+		triggers = append(triggers, ImageTrigger{
+			From: ImageTriggerFrom{
+				Kind: "ImageStreamTag",
+				Name: container.Tag,
+			},
+			FieldPath: fmt.Sprintf(`spec.template.spec.containers[?(@.name=="%v")].image`, container.Name),
+		})
+	}
+
+	if len(triggers) > 0 {
+		jsonData, _ := json.Marshal(triggers)
+		return string(jsonData)
+	}
+
+	return ""
+}

--- a/pkg/reconcilers/deployment_test.go
+++ b/pkg/reconcilers/deployment_test.go
@@ -1,0 +1,916 @@
+package reconcilers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/3scale/3scale-operator/pkg/helper"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeploymentReplicasMutator(t *testing.T) {
+	numReplicas := int32(3)
+	dFactory := func() *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Replicas: &numReplicas,
+			},
+		}
+	}
+
+	cases := []struct {
+		testName       string
+		desired        func() *k8sappsv1.Deployment
+		expectedResult bool
+	}{
+		{"NothingToReconcile", func() *k8sappsv1.Deployment { return dFactory() }, false},
+		{"ReplicasReconcile",
+			func() *k8sappsv1.Deployment {
+				desired := dFactory()
+				newNumReplicas := *desired.Spec.Replicas + int32(1000)
+				desired.Spec.Replicas = &newNumReplicas
+				return desired
+			}, true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory()
+			update, err := DeploymentReplicasMutator(tc.desired(), existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if *existing.Spec.Replicas != *tc.desired().Spec.Replicas {
+				subT.Fatalf("replica reconciliation failed, existing: %d, desired: %d", existing.Spec.Replicas, tc.desired().Spec.Replicas)
+			}
+
+		})
+	}
+}
+
+func TestDeploymentContainerResourcesMutator(t *testing.T) {
+	emptyResourceRequirements := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+	notEmptyResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("110Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("220Mi"),
+		},
+	}
+	dFactory := func(resources corev1.ResourceRequirements) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:      "container1",
+								Resources: resources,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		testName          string
+		existingResources corev1.ResourceRequirements
+		desiredResources  corev1.ResourceRequirements
+		expectedResult    bool
+	}{
+		{"NothingToReconcile", emptyResourceRequirements, emptyResourceRequirements, false},
+		{"NothingToReconcileWithResources", notEmptyResources, notEmptyResources, false},
+		{"AddResources", emptyResourceRequirements, notEmptyResources, true},
+		{"RemoveResources", notEmptyResources, emptyResourceRequirements, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingResources)
+			desired := dFactory(tc.desiredResources)
+			update, err := DeploymentContainerResourcesMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !helper.CmpResources(&existing.Spec.Template.Spec.Containers[0].Resources, &desired.Spec.Template.Spec.Containers[0].Resources) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.Containers[0].Resources, desired.Spec.Template.Spec.Containers[0].Resources, cmpopts.IgnoreUnexported(resource.Quantity{})))
+			}
+		})
+	}
+}
+
+func TestDeploymentAffinityMutator(t *testing.T) {
+	testAffinity1 := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchFields: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "key1",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"val1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	testAffinity2 := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchFields: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "key2",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"val2"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	dFactory := func(affinity *corev1.Affinity) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Affinity: affinity,
+					},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		testName         string
+		existingAffinity *corev1.Affinity
+		desiredAffinity  *corev1.Affinity
+		expectedResult   bool
+	}{
+		{"NothingToReconcile", nil, nil, false},
+		{"EqualAffinities", testAffinity1, testAffinity1, false},
+		{"DifferentAffinities", testAffinity1, testAffinity2, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingAffinity)
+			desired := dFactory(tc.desiredAffinity)
+			update, err := DeploymentAffinityMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !reflect.DeepEqual(existing.Spec.Template.Spec.Affinity, desired.Spec.Template.Spec.Affinity) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.Affinity, desired.Spec.Template.Spec.Affinity))
+			}
+		})
+	}
+}
+
+func TestDeploymentTolerationsMutator(t *testing.T) {
+	testTolerations1 := []corev1.Toleration{
+		{
+			Key:      "key1",
+			Effect:   corev1.TaintEffectNoExecute,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "val1",
+		},
+		{
+			Key:      "key2",
+			Effect:   corev1.TaintEffectNoExecute,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "val2",
+		},
+	}
+	testTolerations2 := []corev1.Toleration{
+		{
+			Key:      "key3",
+			Effect:   corev1.TaintEffectNoExecute,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "val3",
+		},
+		{
+			Key:      "key4",
+			Effect:   corev1.TaintEffectNoExecute,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "val4",
+		},
+	}
+	dFactory := func(toleration []corev1.Toleration) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Tolerations: toleration,
+					},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		testName            string
+		existingTolerations []corev1.Toleration
+		desiredTolerations  []corev1.Toleration
+		expectedResult      bool
+	}{
+		{"NothingToReconcile", nil, nil, false},
+		{"EqualAffinities", testTolerations1, testTolerations1, false},
+		{"DifferentAffinities", testTolerations1, testTolerations2, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingTolerations)
+			desired := dFactory(tc.desiredTolerations)
+			update, err := DeploymentTolerationsMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !reflect.DeepEqual(existing.Spec.Template.Spec.Tolerations, desired.Spec.Template.Spec.Tolerations) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.Tolerations, desired.Spec.Template.Spec.Tolerations))
+			}
+		})
+	}
+
+}
+
+func TestDeploymentEnvVarReconciler(t *testing.T) {
+	t.Run("DifferentNumberOfContainers", func(subT *testing.T) {
+		desired := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+							},
+						},
+					},
+				},
+			},
+		}
+		existing := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+							},
+							{
+								Name: "container2",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		update := DeploymentEnvVarReconciler(desired, existing, "A")
+		if update {
+			subT.Fatal("expected not to be updated")
+		}
+	})
+
+	t.Run("DifferentNumberOfInitContainers", func(subT *testing.T) {
+		desired := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name: "initcontainer1",
+							},
+						},
+					},
+				},
+			},
+		}
+		existing := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name: "initcontainer1",
+							},
+							{
+								Name: "initcontainer2",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		update := DeploymentEnvVarReconciler(desired, existing, "A")
+		if update {
+			subT.Fatal("expected not to be updated")
+		}
+	})
+
+	t.Run("ContainersEnvVarReconciled", func(subT *testing.T) {
+		desired := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+								Env: []corev1.EnvVar{
+									{Name: "A", Value: "valueA"},
+								},
+							},
+							{
+								Name: "container2",
+								Env:  []corev1.EnvVar{},
+							},
+						},
+					},
+				},
+			},
+		}
+		existing := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+								Env:  []corev1.EnvVar{},
+							},
+							{
+								Name: "container2",
+								Env: []corev1.EnvVar{
+									{Name: "A", Value: "valueA"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		update := DeploymentEnvVarReconciler(desired, existing, "A")
+		if !update {
+			subT.Fatal("expected not be updated")
+		}
+
+		for i := range []int{0, 1} {
+			if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[i].Env, desired.Spec.Template.Spec.Containers[i].Env) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.Containers[i].Env, desired.Spec.Template.Spec.Containers[i].Env))
+			}
+		}
+
+	})
+
+	t.Run("InitContainersEnvVarReconciled", func(subT *testing.T) {
+		desired := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name: "intcontainer1",
+								Env: []corev1.EnvVar{
+									{Name: "A", Value: "valueA"},
+								},
+							},
+							{
+								Name: "intcontainer2",
+								Env:  []corev1.EnvVar{},
+							},
+						},
+					},
+				},
+			},
+		}
+		existing := &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "myDeployment", Namespace: "myNS"},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name: "initcontainer1",
+								Env:  []corev1.EnvVar{},
+							},
+							{
+								Name: "initcontainer2",
+								Env: []corev1.EnvVar{
+									{Name: "A", Value: "valueA"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		update := DeploymentEnvVarReconciler(desired, existing, "A")
+		if !update {
+			subT.Fatal("expected not be updated")
+		}
+
+		for i := range []int{0, 1} {
+			if !reflect.DeepEqual(existing.Spec.Template.Spec.InitContainers[i].Env, desired.Spec.Template.Spec.InitContainers[i].Env) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.InitContainers[i].Env, desired.Spec.Template.Spec.InitContainers[i].Env))
+			}
+		}
+	})
+}
+
+func TestDeploymentPodTemplateLabelsMutator(t *testing.T) {
+	dFactory := func(labels map[string]string) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+				},
+			},
+		}
+	}
+
+	mapCopy := func(originalMap map[string]string) map[string]string {
+		// Create the target map
+		targetMap := make(map[string]string)
+
+		// Copy from the original map to the target map
+		for key, value := range originalMap {
+			targetMap[key] = value
+		}
+
+		return targetMap
+	}
+
+	labelsA := map[string]string{"a": "1", "a2": "2"}
+	labelsB := map[string]string{"a": "other", "b": "1"}
+
+	cases := []struct {
+		testName          string
+		existingLabels    map[string]string
+		desiredLabels     map[string]string
+		expectedResult    bool
+		expectedNewLabels map[string]string
+	}{
+		{"NothingToReconcile", mapCopy(labelsA), mapCopy(labelsA), false, mapCopy(labelsA)},
+		{"LabelsReconciled", mapCopy(labelsB), mapCopy(labelsA), true, map[string]string{
+			"a": "1", "a2": "2", "b": "1",
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingLabels)
+			desired := dFactory(tc.desiredLabels)
+			update, err := DeploymentPodTemplateLabelsMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !reflect.DeepEqual(existing.Spec.Template.Labels, tc.expectedNewLabels) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Labels, tc.expectedNewLabels))
+			}
+		})
+	}
+}
+
+func TestDeploymentRemoveDuplicateEnvVarMutator(t *testing.T) {
+	dFactory := func(envs []corev1.EnvVar) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container1",
+								Env:  envs,
+							},
+							{
+								Name: "container2",
+								Env:  envs,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	envsA := []corev1.EnvVar{{Name: "a", Value: "1"}, {Name: "b", Value: "2"}}
+	envsB := []corev1.EnvVar{{Name: "a", Value: "1"}, {Name: "a", Value: "1"}, {Name: "b", Value: "2"}}
+
+	cases := []struct {
+		testName        string
+		existingEnvs    []corev1.EnvVar
+		expectedResult  bool
+		expectedNewEnvs []corev1.EnvVar
+	}{
+		{"NothingToReconcile", envsA, false, envsA},
+		{"EnvsReconciled", envsB, true, envsA},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingEnvs)
+			update, err := DeploymentRemoveDuplicateEnvVarMutator(nil, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			for idx := range existing.Spec.Template.Spec.Containers {
+				if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[idx].Env, tc.expectedNewEnvs) {
+					subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.Containers[idx].Env, tc.expectedNewEnvs))
+				}
+			}
+		})
+	}
+}
+
+func TestDeploymentTopologySpreadConstraintsMutator(t *testing.T) {
+	testTopologySpreadConstraint1 := []corev1.TopologySpreadConstraint{
+		{
+			TopologyKey:       "topologyKey1",
+			WhenUnsatisfiable: "DoNotSchedule",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "3scale-api-management"},
+			},
+		},
+	}
+	testTopologySpreadConstraint2 := []corev1.TopologySpreadConstraint{
+		{
+			TopologyKey:       "topologyKey2",
+			WhenUnsatisfiable: "ScheduleAnyway",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "3scale-api-management", "threescale_component": "system"},
+			},
+		},
+	}
+
+	dFactory := func(topologySpreadConstraint []corev1.TopologySpreadConstraint) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						TopologySpreadConstraints: topologySpreadConstraint,
+					},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		testName                          string
+		existingTopologySpreadConstraints []corev1.TopologySpreadConstraint
+		desiredTopologySpreadConstraints  []corev1.TopologySpreadConstraint
+		expectedResult                    bool
+	}{
+		{"NothingToReconcile", nil, nil, false},
+		{"EqualTopologies", testTopologySpreadConstraint1, testTopologySpreadConstraint1, false},
+		{"DifferentTopologie", testTopologySpreadConstraint1, testTopologySpreadConstraint2, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingTopologySpreadConstraints)
+			desired := dFactory(tc.desiredTopologySpreadConstraints)
+			update, err := DeploymentTopologySpreadConstraintsMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !reflect.DeepEqual(existing.Spec.Template.Spec.TopologySpreadConstraints, desired.Spec.Template.Spec.TopologySpreadConstraints) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Spec.TopologySpreadConstraints, desired.Spec.Template.Spec.TopologySpreadConstraints))
+			}
+		})
+	}
+
+}
+
+func TestDeploymentPodTemplateAnnotationsMutator(t *testing.T) {
+	dFactory := func(annotations map[string]string) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myDeployment",
+				Namespace: "myNS",
+			},
+			Spec: k8sappsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: annotations,
+					},
+				},
+			},
+		}
+	}
+
+	mapCopy := func(originalMap map[string]string) map[string]string {
+		// Create the target map
+		targetMap := make(map[string]string)
+
+		// Copy from the original map to the target map
+		for key, value := range originalMap {
+			targetMap[key] = value
+		}
+
+		return targetMap
+	}
+
+	annotationsA := map[string]string{"a": "1", "a2": "2"}
+	annotationsB := map[string]string{"a": "other", "b": "1"}
+
+	cases := []struct {
+		testName               string
+		existingAnnotations    map[string]string
+		desiredAnnotations     map[string]string
+		expectedResult         bool
+		expectedNewAnnotations map[string]string
+	}{
+		{"NothingToReconcile", mapCopy(annotationsA), mapCopy(annotationsA), false, mapCopy(annotationsA)},
+		{"AnnotationsReconciled", mapCopy(annotationsB), mapCopy(annotationsA), true, map[string]string{
+			"a": "1", "a2": "2", "b": "1",
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingAnnotations)
+			desired := dFactory(tc.desiredAnnotations)
+			update, err := DeploymentPodTemplateAnnotationsMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !reflect.DeepEqual(existing.Spec.Template.Annotations, tc.expectedNewAnnotations) {
+				subT.Fatal(cmp.Diff(existing.Spec.Template.Annotations, tc.expectedNewAnnotations))
+			}
+		})
+	}
+}
+
+func TestDeploymentAnnotationsMutator(t *testing.T) {
+	dFactory := func(annotations map[string]string) *k8sappsv1.Deployment {
+		return &k8sappsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "myDeployment",
+				Namespace:   "myNS",
+				Annotations: annotations,
+			},
+		}
+	}
+
+	mapCopy := func(originalMap map[string]string) map[string]string {
+		// Create the target map
+		targetMap := make(map[string]string)
+
+		// Copy from the original map to the target map
+		for key, value := range originalMap {
+			targetMap[key] = value
+		}
+
+		return targetMap
+	}
+
+	annotationsA := map[string]string{"a": "1", "a2": "2"}
+	annotationsB := map[string]string{"a": "other", "b": "1"}
+
+	cases := []struct {
+		testName               string
+		existingAnnotations    map[string]string
+		desiredAnnotations     map[string]string
+		expectedResult         bool
+		expectedNewAnnotations map[string]string
+	}{
+		{"NothingToReconcile", mapCopy(annotationsA), mapCopy(annotationsA), false, mapCopy(annotationsA)},
+		{"AnnotationsReconciled", mapCopy(annotationsB), mapCopy(annotationsA), true, map[string]string{
+			"a": "1", "a2": "2", "b": "1",
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			existing := dFactory(tc.existingAnnotations)
+			desired := dFactory(tc.desiredAnnotations)
+			update, err := DeploymentAnnotationsMutator(desired, existing)
+			if err != nil {
+				subT.Fatal(err)
+			}
+			if update != tc.expectedResult {
+				subT.Fatalf("result failed, expected: %t, got: %t", tc.expectedResult, update)
+			}
+			if !reflect.DeepEqual(existing.ObjectMeta.Annotations, tc.expectedNewAnnotations) {
+				subT.Fatal(cmp.Diff(existing.ObjectMeta.Annotations, tc.expectedNewAnnotations))
+			}
+		})
+	}
+}
+
+func TestCreateImageTriggerAnnotationString(t *testing.T) {
+	type args struct {
+		containers []ContainerImage
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "NoContainers",
+			args: args{
+				containers: []ContainerImage{},
+			},
+			want: "",
+		},
+		{
+			name: "OneContainer",
+			args: args{
+				containers: []ContainerImage{
+					{
+						Name: "container1",
+						Tag:  "test-image:1.1",
+					},
+				},
+			},
+			want: `[{"from":{"kind":"ImageStreamTag","name":"test-image:1.1"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container1\")].image"}]`,
+		},
+		{
+			name: "TwoContainers",
+			args: args{
+				containers: []ContainerImage{
+					{
+						Name: "container1",
+						Tag:  "test-image:1.1",
+					},
+					{
+						Name: "container2",
+						Tag:  "test-image:2.2",
+					},
+				},
+			},
+			want: `[{"from":{"kind":"ImageStreamTag","name":"test-image:1.1"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container1\")].image"},{"from":{"kind":"ImageStreamTag","name":"test-image:2.2"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container2\")].image"}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CreateImageTriggerAnnotationString(tt.args.containers); got != tt.want {
+				t.Errorf("CreateImageTriggerAnnotationString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconcilers/service.go
+++ b/pkg/reconcilers/service.go
@@ -8,6 +8,32 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func ServiceMutator(opts ...MutateFn) MutateFn {
+	return func(existingObj, desiredObj common.KubernetesObject) (bool, error) {
+		existing, ok := existingObj.(*v1.Service)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.Service", existingObj)
+		}
+		desired, ok := desiredObj.(*v1.Service)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.Service", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate, err := opt(existing, desired)
+			if err != nil {
+				return false, err
+			}
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
 func ServicePortMutator(existingObj, desiredObj common.KubernetesObject) (bool, error) {
 	existing, ok := existingObj.(*v1.Service)
 	if !ok {
@@ -23,6 +49,26 @@ func ServicePortMutator(existingObj, desiredObj common.KubernetesObject) (bool, 
 	if !reflect.DeepEqual(existing.Spec.Ports, desired.Spec.Ports) {
 		updated = true
 		existing.Spec.Ports = desired.Spec.Ports
+	}
+
+	return updated, nil
+}
+
+func ServiceSelectorMutator(existingObj, desiredObj common.KubernetesObject) (bool, error) {
+	existing, ok := existingObj.(*v1.Service)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1.Service", existingObj)
+	}
+	desired, ok := desiredObj.(*v1.Service)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1.Service", desiredObj)
+	}
+
+	updated := false
+
+	if !reflect.DeepEqual(existing.Spec.Selector, desired.Spec.Selector) {
+		updated = true
+		existing.Spec.Selector = desired.Spec.Selector
 	}
 
 	return updated, nil

--- a/pkg/upgrade/migrate_deployment_config_2.15.go
+++ b/pkg/upgrade/migrate_deployment_config_2.15.go
@@ -1,0 +1,57 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"github.com/3scale/3scale-operator/pkg/helper"
+	appsv1 "github.com/openshift/api/apps/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MigrateDeploymentConfigToDeployment verifies the Deployment is healthy and then deletes the corresponding DeploymentConfig
+// 3scale 2.14 -> 2.15
+func MigrateDeploymentConfigToDeployment(dName string, dNamespace string, client k8sclient.Client) (bool, error) {
+	deploymentConfig := &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dName,
+			Namespace: dNamespace,
+		},
+	}
+	err := client.Get(context.TODO(), k8sclient.ObjectKey{Name: deploymentConfig.Name, Namespace: deploymentConfig.Namespace}, deploymentConfig)
+
+	// Breakout if the DeploymentConfig has already been deleted
+	if k8serr.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("error getting deploymentconfig %s: %v", deploymentConfig.Name, err)
+	}
+
+	// Verify that the Deployment is healthy
+	deployment := &k8sappsv1.Deployment{}
+	err = client.Get(context.TODO(), k8sclient.ObjectKey{
+		Namespace: dNamespace,
+		Name:      dName,
+	}, deployment)
+	if err != nil {
+		return false, fmt.Errorf("error getting deployment %s: %v", deployment.Name, err)
+	}
+	if !helper.IsDeploymentAvailable(deployment) {
+		log.V(1).Info(fmt.Sprintf("deployment %s is not yet available", deployment.Name))
+		return false, nil
+	}
+
+	// Delete the DeploymentConfig because the Deployment replacing it is healthy
+	err = client.Delete(context.TODO(), deploymentConfig)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return false, fmt.Errorf("error deleting deploymentconfig %s: %v", deploymentConfig.Name, err)
+		}
+	}
+
+	log.Info(fmt.Sprintf("%s Deployment has replaced its corresponding DeploymentConfig", deployment.Name))
+	return true, nil
+}


### PR DESCRIPTION
# Issue link
JIRA: [THREESCALE-10388](https://issues.redhat.com/browse/THREESCALE-10388)

# What
This is the first PR against the new feature branch `threescale-10163` that will be used while implementing the changes needed to migrate each of 3scale-operator's DeploymentConfigs to Deployments - see [epic](https://issues.redhat.com/browse/THREESCALE-10163).

This PR replaces the `apicast-staging` and `apicast-production` DeploymentConfigs with Deployments. The PR also provides the upgrade scaffolding that will be used by the remaining DeploymentConfigs.

# Verification steps

1. Provision a cluster
2. Install 3scale locally using master
3. Checkout this PR
4. Re-run 3scale locally
5. Verify that the new `apicast-staging` and `apicast-production` Deployments are created
6. Verify that the `apicast-staging` and `apicast-production` DeploymentConfigs are deleted once the Deployments report healthy
7. Login to admin portal and create dummy product/backend.
8. Promote the APIcast configuration to Staging APIcast and curl the staging endpoint with a valid user_key to confirm it's working
9. Promote the APIcast configuration to Production APIcast and curl the production endpoint with a valid user_key to confirm it's working