### PR TITLE
THREESCALE-10519 - OAS without security section, while OpenAPI CR contains oidc section

### DIFF
--- a/controllers/capabilities/openapi_controller.go
+++ b/controllers/capabilities/openapi_controller.go
@@ -403,6 +403,7 @@ func (r *OpenAPIReconciler) validateOIDCSettingsInCR(openapiCR *capabilitiesv1be
 	globalSecRequirements := helper.OpenAPIGlobalSecurityRequirements(openapiObj)
 	if len(globalSecRequirements) == 0 && openapiCR.Spec.OIDC != nil {
 		logger.Info("OIDC definitions in CR will be ignored, as no security requirements are found. Default to UserKey authentication")
+		r.EventRecorder().Eventf(openapiCR, corev1.EventTypeWarning, "No security requirements are found in OAS", "%v", "OIDC definitions in CR will be ignored, as no security requirements are found. Default to UserKey authentication")
 	}
 
 	if len(globalSecRequirements) == 1 {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10519

This is a minor fix for OIDC PR https://github.com/3scale/3scale-operator/pull/837

**Before** -   if OpenAPI CR contains oidc section , but OAS (swagger produc source file) is without security section - Info message appear in Operator log, as implemented here:
https://github.com/3scale/3scale-operator/blob/master/controllers/capabilities/openapi_controller.go#L403-L406
Fix: add 
**Now** - added warning to Openapi CR, as in log below:
```
$ oc describe openapis openapi-example 
Name:         openapi-example
Namespace:    3scale-test
Labels:       <none>
Annotations:  <none>
API Version:  capabilities.3scale.net/v1beta1
Kind:         OpenAPI
Metadata:
  Creation Timestamp:  2023-11-29T10:57:00Z
  Generation:          1
  Managed Fields:
    API Version:  capabilities.3scale.net/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
    .......
........
    Time:            2023-11-29T10:57:07Z
  Resource Version:  2413952
  UID:               93e91922-fd97-4393-943f-40fd0426c855
Spec:
  Oidc:
    Issuer Type:  keycloak
  Openapi Ref:
    URL:            https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
  Prefix Matching:  true
Status:
  Backend Resource Names:
    Name:  swaggerpetstore-93e91922-fd97-4393-943f-40fd0426c855
  Conditions:
......
    Last Transition Time:  2023-11-29T10:57:07Z
    Status:                True
    Type:                  Ready
  Observed Generation:     1
  Product Resource Name:
    Name:                 swaggerpetstore-93e91922-fd97-4393-943f-40fd0426c855
  Provider Account Host:  https://3scale-admin.apps.vmo01.mjhc.s1.devshift.org
Events:
  Type     Reason                                     Age    From     Message
  ----     ------                                     ----   ----     -------
  Warning  No security requirements are found in OAS  8m57s  OpenAPI  OIDC definitions in CR will be ignored, as no security requirements are found. Default to UserKey authentication

```

## Validation
- For Validation steps please see Validation section of PR of 9884 task - https://github.com/3scale/3scale-operator/pull/837  . 
- Use following Openapi CR, that have OAS (swagger file / petstore.yaml) without security section.
```
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  generation: 1
  name: openapi-example
spec:
  oidc:
    issuerType: keycloak
  openapiRef:
    url: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
  prefixMatching: true
```

