### PR TITLE
THREESCALE-10390 Migrate memcache DeploymentConfig to Deployment

### DIFF
--- a/pkg/3scale/amp/component/memcached.go
+++ b/pkg/3scale/amp/component/memcached.go
@@ -3,7 +3,9 @@ package component
 import (
 	"fmt"
 
-	appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+
+	k8sappsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -21,52 +23,28 @@ func NewMemcached(options *MemcachedOptions) *Memcached {
 	return &Memcached{Options: options}
 }
 
-func (m *Memcached) DeploymentConfig() *appsv1.DeploymentConfig {
-	return &appsv1.DeploymentConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DeploymentConfig",
-			APIVersion: "apps.openshift.io/v1",
-		},
+func (m *Memcached) Deployment() *k8sappsv1.Deployment {
+	var memcachedReplicas int32 = 1
+
+	return &k8sappsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: reconcilers.DeploymentAPIVersion, Kind: reconcilers.DeploymentKind},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   SystemMemcachedDeploymentName,
-			Labels: m.Options.DeploymentLabels,
+			Name:        SystemMemcachedDeploymentName,
+			Labels:      m.Options.DeploymentLabels,
+			Annotations: m.memcacheDeploymentAnnotations(),
 		},
-		Spec: appsv1.DeploymentConfigSpec{
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.DeploymentStrategyTypeRolling,
-				RollingParams: &appsv1.RollingDeploymentStrategyParams{
-					UpdatePeriodSeconds: &[]int64{1}[0],
-					IntervalSeconds:     &[]int64{1}[0],
-					TimeoutSeconds:      &[]int64{600}[0],
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
-						StrVal: "25%",
-					},
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Type(intstr.String),
-						StrVal: "25%"}},
+		Spec: k8sappsv1.DeploymentSpec{
+			Strategy: k8sappsv1.DeploymentStrategy{
+				Type: k8sappsv1.RecreateDeploymentStrategyType,
 			},
 			MinReadySeconds: 0,
-			Triggers: appsv1.DeploymentTriggerPolicies{
-				appsv1.DeploymentTriggerPolicy{
-					Type: appsv1.DeploymentTriggerOnConfigChange},
-				appsv1.DeploymentTriggerPolicy{
-					Type: appsv1.DeploymentTriggerOnImageChange,
-					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
-						Automatic: true,
-						ContainerNames: []string{
-							"memcache",
-						},
-						From: v1.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: fmt.Sprintf("system-memcached:%s", m.Options.ImageTag),
-						},
-					},
+			Replicas:        &memcachedReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					reconcilers.DeploymentLabelSelector: SystemMemcachedDeploymentName,
 				},
 			},
-			Replicas: 1,
-			Selector: map[string]string{"deploymentConfig": SystemMemcachedDeploymentName},
-			Template: &v1.PodTemplateSpec{
+			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      m.Options.PodTemplateLabels,
 					Annotations: m.Options.PodTemplateAnnotations,
@@ -76,21 +54,24 @@ func (m *Memcached) DeploymentConfig() *appsv1.DeploymentConfig {
 					Tolerations:        m.Options.Tolerations,
 					ServiceAccountName: "amp", //TODO make this configurable via flag
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Name:    "memcache",
 							Image:   "system-memcached:latest",
 							Command: []string{"memcached", "-m", "64"},
 							Ports: []v1.ContainerPort{
-								v1.ContainerPort{HostPort: 0,
+								{HostPort: 0,
 									ContainerPort: 11211,
 									Protocol:      v1.ProtocolTCP},
 							},
 							Resources: m.Options.ResourceRequirements,
 							LivenessProbe: &v1.Probe{
-								ProbeHandler: v1.ProbeHandler{TCPSocket: &v1.TCPSocketAction{
-									Port: intstr.IntOrString{
-										Type:   intstr.Type(intstr.Int),
-										IntVal: 11211}},
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 11211,
+										},
+									},
 								},
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      0,
@@ -99,10 +80,13 @@ func (m *Memcached) DeploymentConfig() *appsv1.DeploymentConfig {
 								FailureThreshold:    0,
 							},
 							ReadinessProbe: &v1.Probe{
-								ProbeHandler: v1.ProbeHandler{TCPSocket: &v1.TCPSocketAction{
-									Port: intstr.IntOrString{
-										Type:   intstr.Type(intstr.Int),
-										IntVal: 11211}},
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 11211,
+										},
+									},
 								},
 								InitialDelaySeconds: 10,
 								TimeoutSeconds:      5,
@@ -115,7 +99,18 @@ func (m *Memcached) DeploymentConfig() *appsv1.DeploymentConfig {
 					},
 					PriorityClassName:         m.Options.PriorityClassName,
 					TopologySpreadConstraints: m.Options.TopologySpreadConstraints,
-				}},
+				},
+			},
 		},
 	}
+}
+
+func (m *Memcached) memcacheDeploymentAnnotations() map[string]string {
+	imageTriggerString := reconcilers.CreateImageTriggerAnnotationString([]reconcilers.ContainerImage{
+		{
+			Name: "memcache",
+			Tag:  fmt.Sprintf("system-memcached:%v", m.Options.ImageTag),
+		},
+	})
+	return map[string]string{reconcilers.DeploymentImageTriggerAnnotation: imageTriggerString}
 }

--- a/pkg/3scale/amp/operator/memcached_options_provider.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
@@ -80,7 +81,7 @@ func (m *MemcachedOptionsProvider) podTemplateLabels() map[string]string {
 		labels[k] = v
 	}
 
-	labels["deploymentConfig"] = "system-memcache"
+	labels[reconcilers.DeploymentLabelSelector] = "system-memcache"
 
 	return labels
 }

--- a/pkg/3scale/amp/operator/memcached_options_provider_test.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	"reflect"
 	"testing"
 
@@ -24,10 +25,10 @@ func testMemcachedDeploymentLabels() map[string]string {
 
 func testPodTemplateLabels() map[string]string {
 	labels := map[string]string{
-		"app":                          appLabel,
-		"threescale_component":         "system",
-		"threescale_component_element": "memcache",
-		"deploymentConfig":             "system-memcache",
+		"app":                               appLabel,
+		"threescale_component":              "system",
+		"threescale_component_element":      "memcache",
+		reconcilers.DeploymentLabelSelector: "system-memcache",
 	}
 	addExpectedMeteringLabels(labels, "system-memcache", helper.ApplicationType)
 

--- a/pkg/3scale/amp/operator/memcached_reconciler_test.go
+++ b/pkg/3scale/amp/operator/memcached_reconciler_test.go
@@ -7,7 +7,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
-	appsv1 "github.com/openshift/api/apps/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -18,13 +18,13 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func TestMemcachedDCReconciler(t *testing.T) {
+func TestMemcachedDeploymentReconciler(t *testing.T) {
 	log := logf.Log.WithName("operator_test")
 	ctx := context.TODO()
 	apimanager := basicApimanager()
 	s := scheme.Scheme
 	s.AddKnownTypes(appsv1alpha1.GroupVersion, apimanager)
-	err := appsv1.AddToScheme(s)
+	err := k8sappsv1.AddToScheme(s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestMemcachedDCReconciler(t *testing.T) {
 		objName  string
 		obj      client.Object
 	}{
-		{"memcachedDC", "system-memcache", &appsv1.DeploymentConfig{}},
+		{"memcachedDeployment", "system-memcache", &k8sappsv1.Deployment{}},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
# Issue link
JIRA: [THREESCALE-10390](https://issues.redhat.com/browse/THREESCALE-10390)

# What
This PR replaces the `system-memcache` DeploymentConfig with a Deployment.

# Verification steps
1. Provision a cluster
2. Install 3scale locally using master
3. Checkout this PR
4. Re-run 3scale locally
5. Verify that the new `system-memcache` Deployment is created
6. Verify that the `system-memcache` DeploymentConfig is deleted once the Deployment reports healthy