### PR TITLE
THREESCALE-10678 - OIDC in OpenAPI CR ignores gatewayResponse and Sec…

### DIFF
--- a/controllers/capabilities/openapi_product_reconciler.go
+++ b/controllers/capabilities/openapi_product_reconciler.go
@@ -405,6 +405,7 @@ func (p *OpenAPIProductReconciler) desiredOIDCAuthentication(secReq *helper.Exte
 			JwtClaimWithClientID:     p.openapiCR.Spec.OIDC.JwtClaimWithClientID,
 			JwtClaimWithClientIDType: p.openapiCR.Spec.OIDC.JwtClaimWithClientIDType,
 			CredentialsLoc:           &tmpHeaders,
+			GatewayResponse:          p.openapiCR.Spec.OIDC.GatewayResponse,
 		},
 	}
 

--- a/doc/openapi-user-guide.md
+++ b/doc/openapi-user-guide.md
@@ -135,6 +135,7 @@ metadata:
 spec:
   openapiRef:
     url: "https://example.com/petstore.yaml"
+  privateAPISecretToken: "xxxx"
   oidc:
     issuerType: keycloak
     issuerEndpointRef:
@@ -146,6 +147,8 @@ spec:
       implicitFlowEnabled: true
       serviceAccountsEnabled: true
       directAccessGrantsEnabled: true
+    gatewayResponse:
+      errorStatusAuthFailed: 403
 ```
 - **oidc** is optional field in OpenAPI CR
 - Only for OIDC: 
@@ -158,11 +161,13 @@ spec:
 | jwtClaimWithClientID     | no           | JSON Web Token (JWT) Claim with ClientID that contains the clientID. Defaults to 'azp'.                                                                                                                                                                                                                                                                                                                                                               |
 | jwtClaimWithClientIDType | no           | JwtClaimWithClientIDType sets to process the ClientID Token Claim value as a string or as a liquid template. Valid values: plain, liquid. Defaults to 'plain'                                                                                                                                                                                                                                                                                         |
 | authenticationFlow       | no           | flows object. When the sec scheme is oauth2, the flows are provided by the OpenAPI doc. However, for openIdConnect security scheme, the OpenAPI doc does not provide the flows. In that case, the OpenAPI CR can provide those. There are 4 flows parameters (for OIDC only): `standardFlowEnabled`, `implicitFlowEnabled`, `serviceAccountsEnabled`, `directAccessGrantsEnabled`. See [3scale product reference](product-reference.md) for more info |
+| gatewayResponse          | no | Specifies custom gateway response on errors. See `GatewayResponseSpec` in [3scale product reference ](product-reference.md) for more info |
 
 - **One of IssuerEndpointRef or IssuerEndpoint must be defined in OIDC Spec** (both fields can be defined, see next note).
 - **If issuerEndpoint plain value is defined in CR - it will be used as precedence over issuerEndpointRef secret**.
 - The format of issuerEndpoint is determined on your OpenID Provider setup;
   see in 3scale portal - `Product/Integration/Settings/AUTHENTICATION SETTINGS/OpenID Connect Issuer`.  
+- **HostHeader and SecretToken should only be set at OpenApi CR .spec level instead of at the spec.OIDC level since the OIDC value is ignored.  OIDC Security is populated in the Product CR from the OpenApi CR PrivateAPISecretToken and PrivateAPIHostHeader parameters if one or both of them are defined in the OpenAPI CR.**  See OpenAPISpec in [openapi reference](openapi-reference.md), OODC specification in [product-reference.md](product-reference.md).
 
 OpenAPI CR example where issuerEndpoint defined both as plain value and in secret (plain value will be used):
 ```yaml

--- a/doc/product-reference.md
+++ b/doc/product-reference.md
@@ -127,6 +127,7 @@ Specifies product OIDC authentication mode
 
 - **One of IssuerEndpointRef or IssuerEndpoint must be defined in OIDC Spec** (both fields can be defined, see next note).
 - **If issuerEndpoint plain value is defined in CR - it will be used as precedence over issuerEndpointRef secret**.
+- **OIDC Security is populated in the CR from the OpenApi CR PrivateAPISecretToken and PrivateAPIHostHeader parameters if one or both of them are defined in the OpenAPI CR**. See OpenAPISpec in [openapi reference](openapi-reference.md).
 
 ##### IssuerEndpointRef  
 - Example of definition of IssuerEndpointRef in OIDCSpec 


### PR DESCRIPTION
## WHAT
Jira: https://issues.redhat.com/browse/THREESCALE-10678

PR provides the fix and documentation additions for issue:
`GatewayResponse and Security are not populated from OpanApi CR (OIDC) to Product CR`. See "parent" task for details: https://issues.redhat.com/browse/THREESCALE-10523

# Validation - Preparation
<details>
Validation preparation and testing process are similar to `THREESCALE-10523`.

Prepare cluster (could be OSD)

## Install RHSSO 
Create project rhsso-test
1. Install RHSSO from **OperatorHub** into project rhsso-test
2. Create Keycloak Instance of RHSSO
3. Open RHSSO portal
4. Create a realm for the ***petstore*** product 
In RH User SSO web console:
  - Click **Add realm**. Add realm page will be opened
  - Set name, as `petstore`
  - Click Create. Petstore realm page will be opened. No changes required.

5. Create a client for 3scale  

- In RH User SSO web console:
  - Choose **Petstore** realm (in top-left corner)
  - Select Configure -> Client
  - Click Create
  - Set `Client ID`: **3scale-zync**
  - Click Save. Clients->3scale-zync page will be opened
  
- Client Settings:

3scale-zync Client setting will be as in the table below 


| Parameter          | Value              |
|-----------------------|--------------------|
|Name|   3scale-zync   |
|Client Protocol |    openid-connect   |
|Access Type | confidential |
|Standard Flow Enabled |Off |
|Direct Access Grants Enabled |Off |
|Service Accounts Enabled |On |

- Click Save
- Provide Realm-Management - **manage-clients**:
  - Enter `Service Account Roles` tab -> **Client Roles**
    - Choose `realm-management` -> `manage-clients`
    - Click Add selected


## Install 3scale 

1. Install and run 3scale operator

```
cd 3scale-operator
make install
oc new-project 3scale-test
make download
make run
```

2. Apply s3 secret
- Secret example (s3-creds-secret.yaml):
```
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: QU12345
  AWS_SECRET_ACCESS_KEY: aU12345=
  AWS_BUCKET: dm12345=
  AWS_REGION: ZX1234==
type: Opaque
```
```
oc apply -f s3-creds-secret.yaml
```

3. Apply Apimanager CR
- Apimanager CR example (apimanagerCR.yaml),  
please place your wildcardDomain  
- apimanagerCR.yaml:
```
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
    name: example-apimanager
    namespace: 3scale-test
spec:
    wildcardDomain: apps.vmogilev01.xxx.s1.devshift.org
```
```
oc apply -f apimanagerCR.yaml
```

4. Apply oidc issuer client secret
This is the secret that contains URL for issuerEndpoint.
The secret is referenced in OpenApi CR - field issuerEndpointRef.
- issuerEndpoint meed to be encryupted; below - just for sample
- oidc-issuer-client-secret.yaml:
```
kind: Secret
apiVersion: v1
metadata:
  name: oidc-issuer-client-secret
  namespace: 3scale-test
data:
  issuerEndpoint: https://3scale-zync:some-secret@keycloak-rhsso-test.apps.xxxxx.xxxx.xx.xx.org/auth/realms/petstore
type: Opaque
```

```
oc apply -f oidc-issuer-client-secret.yaml
```



</details>

# Validation
<details>

## Test
- OpenAPI CR spec contains **OIDC** 
    - OIDC spec contains `gatewayResponse` and `security` definitions
- OAS v3, has securitySchemes type: **openIdConnect**
- Expected result: 
    - `gatewayResponse` and `security` will be populated in Product CR
    - Product OIDC Authentication Flows will be set as defined in OpenApiCR  
    - No warnings in OpenApi CR
 
```sh
$ oc apply  -f openapi-secret_oidc.yaml
secret/openapi-secret-oidc created
$ oc apply -f openapiCR_oidc.yaml
openapi.capabilities.3scale.net/openapi-example2 created
```
These are files below.
New Product will be created `Swagger Petstore 2`, that has OIDC Authentication flows as defined in CR.

### OpenApi CR
```yaml
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  annotations:
    insecure_skip_verify: 'true'
  name: openapi-example2
  namespace: 3scale-test
spec:
  privateAPISecretToken: "123"
  oidc:
    issuerType: keycloak
    issuerEndpointRef:
      name: oidc-issuer-client-secret
    jwtClaimWithClientID: azp
    jwtClaimWithClientIDType: plain
    authenticationFlow:
      standardFlowEnabled: true
      implicitFlowEnabled: false
      serviceAccountsEnabled: false
      directAccessGrantsEnabled: false
    gatewayResponse:
      errorStatusAuthFailed: 403
      errorAuthFailed: "test gatewayResponse"
  openapiRef:
    secretRef:
      name: openapi-secret-oidc
      namespace: 3scale-test
  prefixMatching: true
```

### Openapi Secret
Secret contains swagger for product `Swagger Petstore 2`.  
SecuritySchemes is openIdConnect (OIDC)

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: openapi-secret-oidc
  namespace: 3scale-test
type: Opaque
stringData:
  openapi-oidc.yaml: |
    ---
    components:
      schemas:
        Error:
          properties:
            code:
              format: int32
              type: integer
            message:
              type: string
          required:
          - code
          - message
          type: object
        NewPet:
          properties:
            name:
              type: string
            tag:
              type: string
          required:
          - name
          type: object
        Pet:
          allOf:
          - $ref: '#/components/schemas/NewPet'
          - properties:
              id:
                format: int64
                type: integer
            required:
            - id
            type: object
      securitySchemes:
        myOauth:
           type: openIdConnect
           openIdConnectUrl: https://example.com/.well-known/openid-configuration
    info:
      contact:
        email: apiteam@swagger.io
        name: Swagger API Team
        url: http://swagger.io
      description: A sample API that uses a petstore as an example to demonstrate features
        in the OpenAPI 3.0 specification
      license:
        name: Apache 2.0
        url: https://www.apache.org/licenses/LICENSE-2.0.html
      termsOfService: http://swagger.io/terms/
      title: Swagger Petstore 2
      version: 1.0.0
    openapi: 3.0.0
    paths:
      /pets:
        get:
          description: 'Returns all pets from the system that the user has access to

            Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
            sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
            lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
            ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer
            at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie
            imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis.
            Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend
            fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat
            id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum
            libero. Morbi euismod sagittis libero sed lacinia.


            Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum
            ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis
            elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque
            posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend
            nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce
            malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique,
            sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan
            tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend
            lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.

            '
          operationId: findPets
          parameters:
          - description: tags to filter by
            in: query
            name: tags
            required: false
            schema:
              items:
                type: string
              type: array
            style: form
          - description: maximum number of results to return
            in: query
            name: limit
            required: false
            schema:
              format: int32
              type: integer
          responses:
            '200':
              content:
                application/json:
                  schema:
                    items:
                      $ref: '#/components/schemas/Pet'
                    type: array
              description: pet response
            default:
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Error'
              description: unexpected error
          security:
          - myOauth:
            - read
            - write
        post:
          description: Creates a new pet in the store. Duplicates are allowed
          operationId: addPet
          requestBody:
            content:
              application/json:
                schema:
                  $ref: '#/components/schemas/NewPet'
            description: Pet to add to the store
            required: true
          responses:
            '200':
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Pet'
              description: pet response
            default:
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Error'
              description: unexpected error
          security:
          - myOauth:
            - read
            - write
      /pets/{id}:
        delete:
          description: deletes a single pet based on the ID supplied
          operationId: deletePet
          parameters:
          - description: ID of pet to delete
            in: path
            name: id
            required: true
            schema:
              format: int64
              type: integer
          responses:
            '204':
              description: pet deleted
            default:
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Error'
              description: unexpected error
          security:
          - myOauth:
            - read
            - write
        get:
          description: Returns a user based on a single ID, if the user does not have
            access to the pet
          operationId: find pet by id
          parameters:
          - description: ID of pet to fetch
            in: path
            name: id
            required: true
            schema:
              format: int64
              type: integer
          responses:
            '200':
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Pet'
              description: pet response
            default:
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Error'
              description: unexpected error
          security:
          - myOauth:
            - read
            - write
    security:
    - myOauth:
      - read
      - write
    servers:
    - url: http://petstore.swagger.io/v1
```

- Expected - GatewayResponse and Security fields populated in Product CR in Spec/Oidc as in example below:

```
$ oc describe product swaggerpetstore2-xxxxx |less


Name:         swaggerpetstore2-xxxx
Namespace:    3scale-test
Labels:       <none>
Annotations:  insecure_skip_verify: true
API Version:  capabilities.3scale.net/v1beta1
Kind:         Product
Metadata:
......
Spec:
  Backend Usages:
    Swagger_Petstore_2:
      Path:  /
  Deployment:
    Apicast Hosted:
      Authentication:
        Oidc:
          Authentication Flow:
            Direct Access Grants Enabled:  false
            Implicit Flow Enabled:         false
            Service Accounts Enabled:      false
            Standard Flow Enabled:         true
          Credentials:                     headers
          Gateway Response:
            Error Auth Failed:         test gatewayResponse
            Error Status Auth Failed:  403
          Issuer Endpoint Ref:
            Name:                         oidc-issuer-client-secret
          Issuer Type:                    keycloak
          Jwt Claim With Client ID:       azp
          Jwt Claim With Client ID Type:  plain
          Security:
            Secret Token:  123
.... 
```

**NOTES. There is no need to define the OIDC Security parameter in OpenApi CR; it will be populated in the product CR from the OpenApi CR if one or both of the PrivateAPISecretToken and PrivateAPIHostHeader parameters are defined in the OpenAPI CR**.

</details>

