### PR TITLE
THREESCALE-10709 update monitoring stack deployment to use THANOS_QUERIER_BEARER_TOKEN

### DIFF
--- a/doc/monitoring-stack-deployment/3scale-scrape-configs.yaml
+++ b/doc/monitoring-stack-deployment/3scale-scrape-configs.yaml
@@ -19,9 +19,7 @@
   scheme: https
   tls_config:
     insecure_skip_verify: true
-  basic_auth:
-    username: "internal"
-    password: "<BASIC_AUTH_PASSWD>"
+  bearer_token: "<THANOS_QUERIER_BEARER_TOKEN>"
   metric_relabel_configs:
   - action: labeldrop
     regex: prometheus_replica

--- a/doc/monitoring-stack-deployment/README.md
+++ b/doc/monitoring-stack-deployment/README.md
@@ -1,22 +1,39 @@
-1. Install Prometheus operator v0.37.0 from the Operator Hub.
+1. Enable monitoring in the APIManager CR
+```yaml
+apiVersion: apps.3scale.net/v1alpha1
+kind: APIManager
+metadata: ...
+spec:
+  monitoring:
+    enabled: true # <------ here
+  ...
+```
+2. Install Prometheus operator v4.10.0 from the Operator Hub.
 
-1. Install Grafana operator v3.6.0 from the Operator Hub.
+3. Install Grafana operator v4.10.1 from the Operator Hub.
 
-1. Create additional-scrape-configs secret with 3scale scrape config
+4. Create additional-scrape-configs secret with 3scale scrape config
 
-Get basic auth password `basicAuthPassword` from `ns/openshift-monitoring/secrets/grafana-datasources-v2/prometheus.yaml` and update `3scale-scrape-configs.yaml` basic auth field.
+```bash
+# Get the SECRET name that contains the THANOS_QUERIER_BEARER_TOKEN
+$ SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
+# Get the THANOS_QUERIER_BEARER_TOKEN using the SECRET name
+$ oc get secret $SECRET -n openshift-user-workload-monitoring -o jsonpath="{.data.token}" | base64 -d
+
+```
+Update the file `3scale-scrape-configs.yaml` bearer_token field with the THANOS_QUERIER_BEARER_TOKEN.
 
 Then create secret:
 
-```
+```bash
 kubectl create secret generic additional-scrape-configs --from-file=3scale-scrape-configs.yaml=./3scale-scrape-configs.yaml
 ```
 
-1. Deploy prometheus
+5. Deploy prometheus
 
 In `prometheus.yaml` file provided, fill the `spec.externalUrl` field with the external URL. The URL template should be:
 
-```
+```yaml
 spec:
   ...
   externalUrl: https://prometheus.NAMESPACE_NAME.apps.CLUSTER_DOMAIN
@@ -24,24 +41,24 @@ spec:
 
 Then deploy prometheus server:
 
-```
+```bash
 oc apply -f prometheus.yaml
 ```
 
-1. Create Prometheus route
+6. Create Prometheus route
 
-```
+```bash
 oc expose service prometheus-operated --hostname prometheus.NAMESPACE_NAME.apps.CLUSTER_DOMAIN
 ```
 
-1. Deploy grafana datasource
+7. Deploy grafana datasource
 
-```
+```bash
 oc apply -f datasource.yaml
 ```
 
-1. Deploy grafana
+8. Deploy grafana
 
-```
+```bash
 oc apply -f grafana.yaml
 ```

--- a/doc/monitoring-stack-deployment/README.md
+++ b/doc/monitoring-stack-deployment/README.md
@@ -16,17 +16,16 @@ spec:
 
 ```bash
 # Get the SECRET name that contains the THANOS_QUERIER_BEARER_TOKEN
-$ SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
+SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
 # Get the THANOS_QUERIER_BEARER_TOKEN using the SECRET name
-$ oc get secret $SECRET -n openshift-user-workload-monitoring -o jsonpath="{.data.token}" | base64 -d
-
+oc get secret $SECRET -n openshift-user-workload-monitoring -o jsonpath="{.data.token}" | base64 -d
 ```
 Update the file `3scale-scrape-configs.yaml` bearer_token field with the THANOS_QUERIER_BEARER_TOKEN.
 
 Then create secret:
 
 ```bash
-kubectl create secret generic additional-scrape-configs --from-file=3scale-scrape-configs.yaml=./3scale-scrape-configs.yaml
+oc create secret generic additional-scrape-configs --from-file=3scale-scrape-configs.yaml=./3scale-scrape-configs.yaml
 ```
 
 5. Deploy prometheus


### PR DESCRIPTION
# Issue
https://issues.redhat.com/browse/THREESCALE-10709

# What
The steps for getting openshift monitoring data in the readme have been out of date for some time
You can no longer use basic auth to scrape data from openshift-monitoring see OCP docs for more information [here](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/monitoring/enabling-monitoring-for-user-defined-projects#accessing-metrics-from-outside-cluster_enabling-monitoring-for-user-defined-projects)

updated the 3scale-scrape-configs.yaml to use bearer token
added steps to the Readme to get the THANOS_QUERIER_BEARER_TOKEN

# Verification
Provision a 3scale instance from this branch and follow the readme to test the monitoring stack installation.


