### PR TITLE
Do not fetch metrics from /yabeda-metrics on System

### DIFF
--- a/pkg/3scale/amp/component/system_monitoring.go
+++ b/pkg/3scale/amp/component/system_monitoring.go
@@ -46,28 +46,13 @@ func (system *System) SystemAppPodMonitor() *monitoringv1.PodMonitor {
 					Scheme: "http",
 				},
 				{
-					Port:   SystemAppMasterContainerMetricsPortName,
-					Path:   "/yabeda-metrics",
-					Scheme: "http",
-				},
-				{
 					Port:   SystemAppProviderContainerMetricsPortName,
 					Path:   "/metrics",
 					Scheme: "http",
 				},
 				{
-					Port:   SystemAppProviderContainerMetricsPortName,
-					Path:   "/yabeda-metrics",
-					Scheme: "http",
-				},
-				{
 					Port:   SystemAppDeveloperContainerMetricsPortName,
 					Path:   "/metrics",
-					Scheme: "http",
-				},
-				{
-					Port:   SystemAppDeveloperContainerMetricsPortName,
-					Path:   "/yabeda-metrics",
 					Scheme: "http",
 				},
 			},


### PR DESCRIPTION
`/yabeda-metrics` is being removed from System, only `/metrics` will remain: https://github.com/3scale/porta/pull/3680