### PR TITLE
THREESCALE-10722 Refactored system-app Jobs to be recreated for each image change

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -931,7 +931,7 @@ func (system *System) SidekiqDeployment(containerImage string) *k8sappsv1.Deploy
 					Volumes:     system.SidekiqPodVolumes(),
 					InitContainers: []v1.Container{
 						{
-							Name:  "check-svc",
+							Name:  SystemSideKiqInitContainerName,
 							Image: containerImage,
 							Command: []string{
 								"bash",

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -746,7 +746,7 @@ func (system *System) AppDeployment(containerImage string) *k8sappsv1.Deployment
 	}
 }
 
-func (system *System) AppPreHookJob(containerImage string) *batchv1.Job {
+func (system *System) AppPreHookJob(containerImage string, currentSystemAppGeneration int64) *batchv1.Job {
 	var completions int32 = 1
 
 	return &batchv1.Job{
@@ -757,6 +757,9 @@ func (system *System) AppPreHookJob(containerImage string) *batchv1.Job {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   SystemAppPreHookJobName,
 			Labels: system.Options.CommonAppLabels,
+			Annotations: map[string]string{
+				helper.SystemAppGenerationAnnotation: strconv.FormatInt(currentSystemAppGeneration, 10),
+			},
 		},
 		Spec: batchv1.JobSpec{
 			Completions: &completions,
@@ -783,7 +786,7 @@ func (system *System) AppPreHookJob(containerImage string) *batchv1.Job {
 	}
 }
 
-func (system *System) AppPostHookJob(containerImage string) *batchv1.Job {
+func (system *System) AppPostHookJob(containerImage string, currentSystemAppGeneration int64) *batchv1.Job {
 	var completions int32 = 1
 
 	return &batchv1.Job{
@@ -794,6 +797,9 @@ func (system *System) AppPostHookJob(containerImage string) *batchv1.Job {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   SystemAppPostHookJobName,
 			Labels: system.Options.CommonAppLabels,
+			Annotations: map[string]string{
+				helper.SystemAppGenerationAnnotation: strconv.FormatInt(currentSystemAppGeneration, 10),
+			},
 		},
 		Spec: batchv1.JobSpec{
 			Completions: &completions,

--- a/pkg/3scale/amp/operator/apicast_reconciler_test.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler_test.go
@@ -876,7 +876,7 @@ func TestReplicaApicastReconciler(t *testing.T) {
 			}
 
 			if tc.expectedAmountOfReplicas != *deployment.Spec.Replicas {
-				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, deployment.Spec.Replicas)
+				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, *deployment.Spec.Replicas)
 			}
 		})
 	}

--- a/pkg/3scale/amp/operator/backend_reconciler_test.go
+++ b/pkg/3scale/amp/operator/backend_reconciler_test.go
@@ -240,7 +240,7 @@ func TestReplicaBackendReconciler(t *testing.T) {
 			}
 
 			if tc.expectedAmountOfReplicas != *deployment.Spec.Replicas {
-				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, deployment.Spec.Replicas)
+				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, *deployment.Spec.Replicas)
 			}
 		})
 	}

--- a/pkg/3scale/amp/operator/system_reconciler_test.go
+++ b/pkg/3scale/amp/operator/system_reconciler_test.go
@@ -245,6 +245,7 @@ func TestReplicaSystemReconciler(t *testing.T) {
 
 			// bump the amount of replicas in the deployment
 			deployment.Spec.Replicas = &twoValue
+			deployment.Generation = oneValue64
 			err = cl.Update(context.TODO(), deployment)
 			if err != nil {
 				subT.Errorf("error updating deployment of %s: %v", tc.objName, err)

--- a/pkg/3scale/amp/operator/system_reconciler_test.go
+++ b/pkg/3scale/amp/operator/system_reconciler_test.go
@@ -39,6 +39,17 @@ func TestSystemReconcilerCreate(t *testing.T) {
 	apimanager := basicApimanagerSpecTestSystemOptions()
 	appPreHookJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: component.SystemAppPreHookJobName, Namespace: apimanager.Namespace},
+		Spec: batchv1.JobSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: SystemImageURL(),
+						},
+					},
+				},
+			},
+		},
 		Status: batchv1.JobStatus{
 			Conditions: []batchv1.JobCondition{
 				{
@@ -149,6 +160,17 @@ func TestReplicaSystemReconciler(t *testing.T) {
 
 	appPreHookJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: component.SystemAppPreHookJobName, Namespace: namespace},
+		Spec: batchv1.JobSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: SystemImageURL(),
+						},
+					},
+				},
+			},
+		},
 		Status: batchv1.JobStatus{
 			Conditions: []batchv1.JobCondition{
 				{

--- a/pkg/3scale/amp/operator/system_reconciler_test.go
+++ b/pkg/3scale/amp/operator/system_reconciler_test.go
@@ -263,7 +263,7 @@ func TestReplicaSystemReconciler(t *testing.T) {
 			}
 
 			if tc.expectedAmountOfReplicas != *deployment.Spec.Replicas {
-				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, deployment.Spec.Replicas)
+				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, *deployment.Spec.Replicas)
 			}
 		})
 	}

--- a/pkg/3scale/amp/operator/zync_reconciler_test.go
+++ b/pkg/3scale/amp/operator/zync_reconciler_test.go
@@ -367,7 +367,7 @@ func TestReplicaZyncReconciler(t *testing.T) {
 			}
 
 			if tc.expectedAmountOfReplicas != *deployment.Spec.Replicas {
-				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, deployment.Spec.Replicas)
+				subT.Errorf("expected replicas do not match. expected: %d actual: %d", tc.expectedAmountOfReplicas, *deployment.Spec.Replicas)
 			}
 		})
 	}

--- a/pkg/helper/deployment.go
+++ b/pkg/helper/deployment.go
@@ -5,8 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// IsDeploymentAvailable returns true when the provided Deployment
-// has the "Available" condition set to true
+// IsDeploymentAvailable returns true when the provided Deployment has the "Available" condition set to true
 func IsDeploymentAvailable(d *k8sappsv1.Deployment) bool {
 	dConditions := d.Status.Conditions
 	for _, dCondition := range dConditions {
@@ -14,5 +13,20 @@ func IsDeploymentAvailable(d *k8sappsv1.Deployment) bool {
 			return true
 		}
 	}
+	return false
+}
+
+// IsDeploymentProgressing returns true when the provided Deployment is progressing with new ReplicaSet
+func IsDeploymentProgressing(d *k8sappsv1.Deployment) bool {
+	if d.Status.UnavailableReplicas > 0 {
+		return true
+	}
+
+	for _, dCondition := range d.Status.Conditions {
+		if dCondition.Type == k8sappsv1.DeploymentProgressing && dCondition.Reason == "ReplicaSetUpdated" {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/helper/job.go
+++ b/pkg/helper/job.go
@@ -7,6 +7,8 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,4 +55,66 @@ func HasJobCompleted(jName string, jNamespace string, client k8sclient.Client) b
 	}
 
 	return false
+}
+
+// HasJobImageChanged returns true if the Job's existing image is different from the provided image
+func HasJobImageChanged(jName string, jNamespace string, desiredImage string, client k8sclient.Client) (bool, error) {
+	job := &batchv1.Job{}
+	err := client.Get(context.TODO(), k8sclient.ObjectKey{
+		Namespace: jNamespace,
+		Name:      jName,
+	}, job)
+
+	// Return error if can't get Job
+	if err != nil && !k8serr.IsNotFound(err) {
+		return false, fmt.Errorf("error getting job %s: %w", job.Name, err)
+	}
+
+	// Return false if the Job doesn't exist yet
+	if k8serr.IsNotFound(err) {
+		return false, nil
+	}
+
+	// Return true if the Job is using the old image
+	if job.Spec.Template.Spec.Containers[0].Image != desiredImage {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func DeleteJob(jName string, jNamespace string, client k8sclient.Client) error {
+	job := &batchv1.Job{}
+	err := client.Get(context.TODO(), k8sclient.ObjectKey{
+		Namespace: jNamespace,
+		Name:      jName,
+	}, job)
+
+	// Breakout if the Job has already been deleted
+	if k8serr.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error getting job %s: %v", job.Name, err)
+	}
+
+	// Return error if Job is currently running
+	if !HasJobCompleted(job.Name, job.Namespace, client) {
+		return fmt.Errorf("won't delete job %s because it's still running", job.Name)
+	}
+
+	deleteOptions := []k8sclient.DeleteOption{
+		k8sclient.GracePeriodSeconds(int64(0)),
+		k8sclient.PropagationPolicy(metav1.DeletePropagationForeground),
+	}
+
+	// Delete the Job
+	err = client.Delete(context.TODO(), job, deleteOptions...)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("error deleting job %s: %v", job.Name, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10722](https://issues.redhat.com/browse/THREESCALE-10722)

# What
This PR improves upon the existing PreHook and PostHook Jobs so that they are deleted and recreated whenever there is an image change.

# Verification Steps

1. Provision a cluster
2. Checkout this PR
3. Prepare to run the operator locally:
```bash
make install
make download
```
4. Create the Namespace, `s3-credentials` Secret, and the APIManager CR:
```bash
export NAMESPACE=3scale-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $REPLACE_ME_WITH_WILDCARD_DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```
5. Run the operator locally:
```bash
make run
```
6. Wait for the installation to complete
```bash
oc get apimanager 3scale -n 3scale-test -ojson | jq '.status'
```
7. Update the system-app Deployment to trigger the Job deletion/re-creation:
```bash
oc patch deployment system-app -n 3scale-test --type=json -p='[{"op": "replace", "path": "/spec/template/spec/terminationGracePeriodSeconds", "value": 29}]'
```
8. Verify that the following occurs in order:
a. The old PreHook Job and the old PostHook Job are deleted
b. A new PreHook Job is created which runs to completion
c. Once the new `system-app` Pod is healthy (Ready = 3/3), the old `system-app` Pod is removed
d. A new PostHook Job is created which runs to completion