### PR TITLE
THREESCALE-10754 Fix APIManager status to reconcile until Available

### DIFF
--- a/controllers/apps/apimanager_status_reconciler.go
+++ b/controllers/apps/apimanager_status_reconciler.go
@@ -43,9 +43,16 @@ func (s *APIManagerStatusReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, fmt.Errorf("failed to calculate status: %w", err)
 	}
 
+	apiManagerAvailable := false
+	for _, s := range s.apimanagerResource.Status.Conditions {
+		if s.Type == appsv1alpha1.APIManagerAvailableConditionType && s.IsTrue() {
+			apiManagerAvailable = true
+		}
+	}
+
 	equalStatus := s.apimanagerResource.Status.Equals(newStatus, s.logger)
 	s.logger.V(1).Info("Status", "status is different", !equalStatus)
-	if equalStatus {
+	if equalStatus && apiManagerAvailable {
 		// Steady state
 		s.logger.V(1).Info("Status was not updated")
 		return reconcile.Result{}, nil


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10754](https://issues.redhat.com/browse/THREESCALE-10754)

# What
This fixes the APIManager status behavior so that it will continuously reconcile until it has the condition `Available=True`. This addresses some flaky behavior where the APIManager CR would never report as Available even though the installation was complete. 

# Verification Steps
Eye review and passing the PROW checks should be sufficient.