### PR TITLE
THREESCALE-10792 - fix - Method is used by the latest gateway configuration and cannot be deleted

### DIFF
--- a/controllers/capabilities/methods.go
+++ b/controllers/capabilities/methods.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"fmt"
-	"strings"
 
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
 	"github.com/3scale/3scale-operator/pkg/helper"
@@ -108,9 +107,6 @@ func (t *ProductThreescaleReconciler) processNotDesiredMethods(notDesiredMap map
 	for _, notDesiredMethod := range notDesiredMap {
 		err := t.productEntity.DeleteMethod(notDesiredMethod.ID)
 		if err != nil {
-			if strings.Contains(err.Error(), "Method is used by the latest gateway configuration and cannot be deleted") {
-				return fmt.Errorf("Please check Mapping Rules in UI and delete those rules that not in Product CR, or add them to Product CR. Check Mapping Rules in UI that use Method [%s].  %w", notDesiredMethod.SystemName, err)
-			}
 			return err
 		}
 	}

--- a/controllers/capabilities/methods.go
+++ b/controllers/capabilities/methods.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"strings"
 
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
 	"github.com/3scale/3scale-operator/pkg/helper"
@@ -107,6 +108,9 @@ func (t *ProductThreescaleReconciler) processNotDesiredMethods(notDesiredMap map
 	for _, notDesiredMethod := range notDesiredMap {
 		err := t.productEntity.DeleteMethod(notDesiredMethod.ID)
 		if err != nil {
+			if strings.Contains(err.Error(), "Method is used by the latest gateway configuration and cannot be deleted") {
+				return fmt.Errorf("Please check Mapping Rules in UI and delete those rules that not in Product CR, or add them to Product CR. Check Mapping Rules in UI that use Method [%s].  %w", notDesiredMethod.SystemName, err)
+			}
 			return err
 		}
 	}

--- a/doc/operator-application-capabilities.md
+++ b/doc/operator-application-capabilities.md
@@ -558,6 +558,19 @@ spec:
 
 * **NOTE 1**: `httpMethod`, `pattern`, `increment` and `metricMethodRef` fields are required.
 * **NOTE 2**: `metricMethodRef` holds a reference to the existing metric or method map key name `system_name`. In the example, `hits`.
+* **NOTE 3**: It's recommended to add Mapping Rules via CR, to have the list of Rules  in UI and CR always consistent.
+If rules added in UI only and  promoted - the warning message appears in Product CR like below. 
+The same message appears if you delete at one time Method and Mapping Rule(s) using this method in CR.
+
+```
+Product  Task failed SyncMethods: Error sync product methods [operatedproduct1]:   
+Please check Mapping rules in UI and delete those Rules that not in Product CR, or add them to Product CR.   
+Check rules in UI using method [method2].  product [operatedproduct1] delete method:   
+error calling 3scale system - reason: {"errors":{"base":["Method is used by the latest gateway configuration and cannot be deleted"]}} - code: 403"
+```
+
+To avoid these warnings, please follow the recommenations in the warning message: `Please check Mapping rules in UI and delete those Rules that not in Product CR, or add them to Product CR.`  
+If you deleted both Method and Rule in CR - it's enough to delete only Rule in UI (and promote); the method will disappear. 
 
 ### Product application plans
 

--- a/doc/operator-application-capabilities.md
+++ b/doc/operator-application-capabilities.md
@@ -558,19 +558,9 @@ spec:
 
 * **NOTE 1**: `httpMethod`, `pattern`, `increment` and `metricMethodRef` fields are required.
 * **NOTE 2**: `metricMethodRef` holds a reference to the existing metric or method map key name `system_name`. In the example, `hits`.
-* **NOTE 3**: It's recommended to add Mapping Rules via CR, to have the list of Rules  in UI and CR always consistent.
-If rules added in UI only and  promoted - the warning message appears in Product CR like below. 
-The same message appears if you delete at one time Method and Mapping Rule(s) using this method in CR.
-
-```
-Product  Task failed SyncMethods: Error sync product methods [operatedproduct1]:   
-Please check Mapping rules in UI and delete those Rules that not in Product CR, or add them to Product CR.   
-Check rules in UI using method [method2].  product [operatedproduct1] delete method:   
-error calling 3scale system - reason: {"errors":{"base":["Method is used by the latest gateway configuration and cannot be deleted"]}} - code: 403"
-```
-
-To avoid these warnings, please follow the recommenations in the warning message: `Please check Mapping rules in UI and delete those Rules that not in Product CR, or add them to Product CR.`  
-If you deleted both Method and Rule in CR - it's enough to delete only Rule in UI (and promote); the method will disappear. 
+* **NOTE 3**: If you update Product CR and delete both Method and Mapping Rule using this method - please expect following behavior:
+  - the Mapping Rule will be deleted immediately in 3scale Portal - Product/Integration/Mapping Rules 
+  - If the configuration was promoted to stage or/and production a warning appears in Product CR informing that the Method is used by the latest gateway configuration, it will be removed from 3scale only once the promotion without the mapping rule that uses the deleted method is done.
 
 ### Product application plans
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10792

## Tests Preparation - files
<details>

- s3-creds-secret.yaml

```
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: QUtJQVY2SVcccc
  AWS_SECRET_ACCESS_KEY: aU5VbWdZY3hjSDFccc
  AWS_BUCKET: dm1vY2NzZjZxOGxyZWRoYXRyaGccccc
  AWS_REGION: ZXUtd2Vcccc
type: Opaque
```

- apimanagerCR.yaml

```
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: example-apimanager
spec:
  system: 
    fileStorage: 
      simpleStorageService: 
        configurationSecretRef: 
          name: s3-credentials
  wildcardDomain: apps.xxxxxx.axxxx.xxx.xxxxx.org

```

- backend.yml

```
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend1
spec:
  name: "Operated Backend 1"
  systemName: "backend1"
  description: "Operated Backend 1 for reconciliation testing"
  privateBaseURL: "https://example.3scale.net"
  mappingRules:
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api1
      pattern: /v1/api1
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api2
      pattern: /v1/api2
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api3
      pattern: /v1/api3
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api4
      pattern: /v1/api4  
  methods:
    api1:
      description: api1
      friendlyName: Get api1
    api2:
      description: api2
      friendlyName: Get api2
    api3:
      description: api3
      friendlyName: Get api3
    api4:
      description: api4
      friendlyName: Get api4
```

- product.yml

```
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1
spec:
  name: "OperatedProduct 1"
  systemName: "operatedproduct1"
  description: "Operated Product 1 for reconciliation testing"
  backendUsages:
    backend1:
      path: /
  mappingRules:
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api1
      pattern: /v1/api1
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api2
      pattern: /v1/api2
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api3
      pattern: /v1/api3
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api4
      pattern: /v1/api4
  methods:
    api1:
      description: api1
      friendlyName: Get api1
    api2:
      description: api2
      friendlyName: Get api2
    api3:
      description: api3
      friendlyName: Get api3
    api4:
      description: api4
      friendlyName: Get api4
```

- product2.yml

```
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product2
spec:
  name: "OperatedProduct 2"
  systemName: "operatedproduct2"
  description: "Operated Product 2 for reconciliation testing"
  backendUsages:
    backend1:
      path: /
  mappingRules:
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api1
      pattern: /v1/api1
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api2
      pattern: /v1/api2
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api3
      pattern: /v1/api3
    - httpMethod: GET
      increment: 1
      last: false
      metricMethodRef: api4
      pattern: /v1/api4
  methods:
    api1:
      description: api1
      friendlyName: Get api1
    api2:
      description: api2
      friendlyName: Get api2
    api3:
      description: api3
      friendlyName: Get api3
    api4:
      description: api4
      friendlyName: Get api4
```
</details>

## Validation

**Validation Results briefly**
- Working as expected
- *Mapping Rules & Methods that Not defined in CR - will be removed by operator from 3scale, to have CR and 3scale to be always in sync*

**Below are the tested Validation Scenarios**

#### 1. 3scale has "old" mapping rules that not exist in Product CR
- Create Product CR without mapping rules (no rules in 3scale)
- Add two methods and two mapping rules via 3scale Portal (UI), and Promote Configuration
    - Warning in Product CR: "Warning  ReconcileError  45s (x14 over 94s)  Product  Task failed SyncMappingRules: Error sync product [operatedproduct1] mappingrules: product metric method ref for mapping rule not found"
- Update Product CR, that contains 4 methods and 4 mapping rules, that differ from existing rule in UI.

**Test Result**
- 3scale rules that not in CR - removed.
- *CR and 3scale UI Mapping Rules - are in sync*

#### 2. CR is in sync with 3scale. Add new Mapping Rule and method via UI. 
- Create new method and Mapping rule in UI, 
- Promote configuration
- *Restart operator*

**Test Result**

- Mapping Rule that added via UI (and not exist in CR) - removed by operator immediately.
- CR warning - Method is used by the latest gateway configuration....
- Configuration warning (promotion is available)
- Method removed after promotion
- *CR and 3scale rules and methods are in sync*

**Note** *if not restart operator, - UI-added mapping rule is not removed, CR and 3scale rules are not in sync*

#### 3.  Remove Mapping Rule from CR 
 
- Remore Mapping Rule from CR; don't remove method 
- Do promotion in Configuration
- NO need restart Operator

**Test Result**

- Configuration warning - promotion
- Rule removed, method not removed
- No warning in CR
- *CR and 3scale rules and methods are in sync*

#### 4. Remove both Mapping Rule & Method from CR.

**Test Result**
- Mapping rule removed in 3scale immediately
- Configuration warning - promotion
- Method removed.
- *CR and UI rules and methods are in sync*

#### 5. Remove Rule defined by CR in UI, and promote

**Test Result**
- if Restart operator - rule and method will be again in sync *CR and UI rules and methods are in sync*
- Before operator restart - rules exist in CR but missing in UI. *Not in sync*
