### PR TITLE
THREESCALE-10713  add hpa rbac list and watch

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -649,6 +649,8 @@ spec:
           verbs:
           - create
           - delete
+          - list
+          - watch
         - apiGroups:
           - batch
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -206,6 +206,8 @@ rules:
   verbs:
   - create
   - delete
+  - list
+  - watch
 - apiGroups:
   - batch
   resources:

--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -73,7 +73,7 @@ var _ reconcile.Reconciler = &APIManagerReconciler{}
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace=placeholder,resources=podmonitors;servicemonitors;prometheusrules,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=integreatly.org,namespace=placeholder,resources=grafanadashboards,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=autoscaling,namespace=placeholder,resources=horizontalpodautoscaler,verbs=create;delete
+// +kubebuilder:rbac:groups=autoscaling,namespace=placeholder,resources=horizontalpodautoscaler,verbs=create;delete;list;watch
 
 func (r *APIManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.BaseReconciler.Logger().WithValues("apimanager", req.NamespacedName)


### PR DESCRIPTION
# What
Permissions missing for HPA branch when run as a container from an olm deployment
```
W0227 07:57:58.819129       1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/reflector.go:167: failed to list *v2.HorizontalPodAutoscaler: horizontalpodautoscalers.autoscaling is forbidden: User "system:serviceaccount:3scale-test:3scale-operator" cannot list resource "horizontalpodautoscalers" in API group "autoscaling" in the namespace "3scale-test"
E0227 07:57:58.819149       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/reflector.go:167: Failed to watch *v2.HorizontalPodAutoscaler: failed to list *v2.HorizontalPodAutoscaler: horizontalpodautoscalers.autoscaling is forbidden: User "system:serviceaccount:3scale-test:3scale-operator" cannot list resource "horizontalpodautoscalers" in API group "autoscaling" in the namespace "3scale-test"
```

Added the missing premissions