### PR TITLE
THREESCALE-10771 add opentracing deprecation message

### DIFF
--- a/controllers/apps/apimanager_status_reconciler.go
+++ b/controllers/apps/apimanager_status_reconciler.go
@@ -313,6 +313,6 @@ func apicastOpenTracingCondition(apicast string) common.Condition {
 		Type:    appsv1alpha1.APIManagerWarningConditionType,
 		Status:  v1.ConditionStatus(metav1.ConditionTrue),
 		Reason:  common.ConditionReason(fmt.Sprintf("%s OpenTracing Deprecation", apicast)),
-		Message: "OpenTracing is deperacated, please use OpenTelemetry instead",
+		Message: "OpenTracing is deprecated, please use OpenTelemetry instead",
 	}
 }

--- a/pkg/apispkg/common/status_conditions.go
+++ b/pkg/apispkg/common/status_conditions.go
@@ -181,6 +181,18 @@ func (conditions Conditions) GetConditionByMessage(message string) *Condition {
 	return nil
 }
 
+// GetConditionByReason searches the set of conditions for the condition reason with the given
+// ConditionType and returns it. If the matching condition is not found,
+// GetCondition returns nil.
+func (conditions Conditions) GetConditionByReason(reason ConditionReason) *Condition {
+	for _, condition := range conditions {
+		if condition.Reason == reason {
+			return &condition
+		}
+	}
+	return nil
+}
+
 // RemoveCondition removes the condition with the given ConditionType from
 // the conditions set. If no condition with that type is found, RemoveCondition
 // returns without performing any action. If the passed condition type is not
@@ -208,6 +220,23 @@ func (conditions *Conditions) RemoveConditionByMessage(message string) bool {
 	}
 	for i, condition := range *conditions {
 		if condition.Message == message {
+			*conditions = append((*conditions)[:i], (*conditions)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveConditionByReason removes the condition with the given Condition Reason from
+// the conditions set. If no condition with that type is found, RemoveConditionByReason
+// returns without performing any action. If the passed condition type is not
+// found in the set of conditions, RemoveConditionByReason returns false.
+func (conditions *Conditions) RemoveConditionByReason(reason ConditionReason) bool {
+	if conditions == nil {
+		return false
+	}
+	for i, condition := range *conditions {
+		if condition.Reason == reason {
 			*conditions = append((*conditions)[:i], (*conditions)[i+1:]...)
 			return true
 		}


### PR DESCRIPTION
**Description**
OpenTracing deprecation warning messages

**Jira**
https://issues.redhat.com/browse/THREESCALE-10771

**Verification**

**Installation**

- Create namespace

```
oc new-project threescale
```

- Install CRDs

```
make install
```

- Run the operator

```
make run
```

- Create new secret to be consumed by APIM

```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: s3-credentials
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```

- Fetch cluster domain

```
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
```

- Create APIM

```
kubectl apply -f - <<EOF                                                        
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: threescale
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```

- Confirm 3scale is fully installed

```
oc wait --for=condition=available apimanager/apimanager-sample --timeout=-1s
```
- Enable opentracing on apicast production by adding:
```
    productionSpec:
      openTracing:
        enabled: true
```
A warning message should appear on APIManager
- after a while (after apicast prod restarts and reports ready) do same for staging apicast.

Both warning messages should now be present.
- remove one of the opentracing configuration, the relevant warning message should disappear
- do same for the other one, both warning should now be gone.
