### PR TITLE
THREESCALE-10163 Add error handling to ImageStream deletion

### DIFF
--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -264,6 +264,9 @@ func (r *APIManagerReconciler) reconcileAPIManagerLogic(cr *appsv1alpha1.APIMana
 
 	// 3scale 2.14 -> 2.15
 	err = upgrade.DeleteImageStreams(r.WatchedNamespace, r.Client())
+	if err != nil {
+		return ctrl.Result{Requeue: true}, err
+	}
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10163](https://issues.redhat.com/browse/THREESCALE-10163)

# What
This PR adds error handling to the ImageStream deletion which should have been included in #929

# Verification Steps
An eye review and passing the PR checks should be sufficient.