### PR TITLE
THREESCALE-10163 Fix ImageStream deletion error handling

### DIFF
--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -263,7 +263,7 @@ func (r *APIManagerReconciler) reconcileAPIManagerLogic(cr *appsv1alpha1.APIMana
 	}
 
 	// 3scale 2.14 -> 2.15
-	err = upgrade.DeleteImageStreams(r.WatchedNamespace, r.Client())
+	err = upgrade.DeleteImageStreams(cr.Namespace, r.Client())
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10163](https://issues.redhat.com/browse/THREESCALE-10163)

# What
This PR fixes the error handling during ImageStream deletion so it works when the operator is cluster scoped.

# Verification Steps
1. Provision a cluster and `oc login` to it
2. Checkout this PR
3. Run the e2e test and verify it passes
```bash
make test-e2e
```