### PR TITLE
THREESCALE-10835 Add support for manticore

### DIFF
--- a/pkg/3scale/amp/component/system_searchd.go
+++ b/pkg/3scale/amp/component/system_searchd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 
 	k8sappsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -11,9 +12,12 @@ import (
 
 const (
 	SystemSearchdDeploymentName = "system-searchd"
-	SystemSearchdPVCName        = "system-searchd"
+	SystemSearchdPVCName        = "system-searchd-manticore"
 	SystemSearchdServiceName    = "system-searchd"
 	SystemSearchdDBVolumeName   = "system-searchd-database"
+
+	// 3scale 2.14 -> 2.15 (manticore)
+	SystemSearchdReindexJobName = "system-searchd-manticore-reindex"
 )
 
 type SystemSearchd struct {
@@ -150,6 +154,43 @@ func (s *SystemSearchd) PVC() *v1.PersistentVolumeClaim {
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceStorage: s.Options.PVCOptions.StorageRequests,
+				},
+			},
+		},
+	}
+}
+
+// ReindexingJob returns the job to run manticore reindexing command. This will be removed for 2.16.
+// 3scale 2.14 -> 2.15 (manticore)
+func (s *SystemSearchd) ReindexingJob(containerImage string, system *System) *batchv1.Job {
+	var completions int32 = 1
+
+	return &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   SystemSearchdReindexJobName,
+			Labels: s.Options.Labels,
+		},
+		Spec: batchv1.JobSpec{
+			Completions: &completions,
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            SystemSearchdReindexJobName,
+							Image:           containerImage,
+							Args:            []string{"bash", "-c", "bundle exec rake searchd:optimal_index"},
+							Env:             system.buildSystemBaseEnv(),
+							Resources:       s.Options.ContainerResourceRequirements,
+							ImagePullPolicy: v1.PullIfNotPresent,
+						},
+					},
+					RestartPolicy:      v1.RestartPolicyNever,
+					ServiceAccountName: "amp",
+					PriorityClassName:  s.Options.PriorityClassName,
 				},
 			},
 		},

--- a/pkg/3scale/amp/operator/system_searchd_reconciler.go
+++ b/pkg/3scale/amp/operator/system_searchd_reconciler.go
@@ -1,10 +1,18 @@
 package operator
 
 import (
+	"context"
+
+	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+	"github.com/3scale/3scale-operator/pkg/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	"github.com/3scale/3scale-operator/pkg/upgrade"
 )
@@ -26,6 +34,12 @@ func (r *SystemSearchdReconciler) Reconcile() (reconcile.Result, error) {
 	}
 
 	searchd, err := SystemSearchd(r.apiManager)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// 3scale 2.14 -> 2.15 (manticore)
+	err = r.supportManticore()
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -67,8 +81,7 @@ func (r *SystemSearchdReconciler) Reconcile() (reconcile.Result, error) {
 	}
 
 	// 3scale 2.14 -> 2.15
-	// Overriding the Deployment health check because the system-searchd PVC is ReadWriteOnce and so it can't be assigned across multiple nodes (pods)
-	isMigrated, err := upgrade.MigrateDeploymentConfigToDeployment(component.SystemSearchdDeploymentName, r.apiManager.GetNamespace(), true, r.Client(), nil)
+	isMigrated, err := upgrade.MigrateDeploymentConfigToDeployment(component.SystemSearchdDeploymentName, r.apiManager.GetNamespace(), false, r.Client(), nil)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -76,7 +89,46 @@ func (r *SystemSearchdReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// 3scale 2.14 -> 2.15 (manticore)
+	// Create Manticore re-indexing Job only after the system-searchd Deployment is ready
+	searchdDeployment := &k8sappsv1.Deployment{}
+	err = r.Client().Get(context.TODO(), k8sclient.ObjectKey{
+		Namespace: r.apiManager.GetNamespace(),
+		Name:      component.SystemSearchdDeploymentName,
+	}, searchdDeployment)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if helper.IsDeploymentAvailable(searchdDeployment) && !helper.IsDeploymentProgressing(searchdDeployment) {
+		system, err := System(r.apiManager, r.Client())
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		reindexingJob := searchd.ReindexingJob(ampImages.Options.SystemImage, system)
+		err = r.ReconcileJob(reindexingJob, reconcilers.CreateOnlyMutator)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	} else {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	return reconcile.Result{}, nil
+}
+
+func (r *SystemSearchdReconciler) supportManticore() error {
+	// The upgrade procedure deletes the old PVC called "system-searchd"; it will be removed when the searchd DC is deleted
+	// The normal reconcile loop will create a new PVC called "system-searchd-manticore" for the new searchd Deployment
+	oldPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "system-searchd", Namespace: r.apiManager.Namespace},
+	}
+	common.TagObjectToDelete(oldPVC)
+	err := r.ReconcileResource(&corev1.PersistentVolumeClaim{}, oldPVC, reconcilers.CreateOnlyMutator)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func SystemSearchd(cr *appsv1alpha1.APIManager) (*component.SystemSearchd, error) {


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10835](https://issues.redhat.com/browse/THREESCALE-10835)

# What
This PR adds the required code needed for the 3scale-operator to support the manticore version of system-searchd - the required steps are:
1. Delete the old `system-searchd` PVC (which is associated with the old `system-searchd` _DeploymentConfig_)
2. Create a new `system-searchd-manticore` PVC (which is used by the new `system-searchd` _Deployment_)
3. Once the `system-searchd` Deployment is running, create a one-off k8s Job that runs a reindexing command required by manticore

# Verification Steps
## Upgrade Scenario
1. Provision a cluster and `oc` login to it

2. Checkout the `3scale-2.14-stable` branch

3. Run `go mod vendor && go mod tidy`

4. Prepare the cluster for a local install:
```bash
make install
make download
```

5. Create a Namespace and `s3-credentials` Secret:
```bash
export NAMESPACE=3scale-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF
```

6. Create the APIManager CR (make sure to replace `<REPLACE_WITH_CLUSTER_NAME>` with the name of your cluster):
```bash
export CLUSTER_NAME=<REPLACE_WITH_CLUSTER_NAME>
```
```bash
export WILDCARD_DOMAIN=$(ocm get /api/clusters_mgmt/v1/clusters --parameter search="name is '$CLUSTER_NAME'" | jq -r '.items[].console.url' | cut -d'.' -f2-)

cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $WILDCARD_DOMAIN
  monitoring:
    enabled: true
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```

7. Verify the installation completes successfully:
```bash
oc get apimanager -n $NAMESPACE -o yaml -w
```

8. Stop running the operator locally

9. Checkout this PR

10. Run `go mod vendor && go mod tidy`

11. Re-run the operator:
```bash
make run
```

12. Verify the upgrade completes successfully:
```bash
oc get apimanager -n $NAMESPACE -o yaml -w
```

13. Verify that the old PVC called `system-searchd` is deleted and the new PVC called `system-searchd-manticore` is created:
```bash
oc get pvc -n $NAMESPACE
```

14. Verify that a k8s Job called `system-searchd-manticore-reindex` was created and passed successfully:
```bash
oc get jobs -n $NAMESPACE
```

15. Stop the operator locally and delete the namespace to prepare for the fresh install scenario:
```bash
oc delete project $NAMESPACE
```

## Fresh Install Scenario
1. Create a fresh Namespace and `s3-credentials` Secret:
```bash
export NAMESPACE=3scale-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF
```

2. Create the APIManager CR (make sure to replace `<REPLACE_WITH_CLUSTER_NAME>` with the name of your cluster):
```bash
export CLUSTER_NAME=<REPLACE_WITH_CLUSTER_NAME>
```
```bash
export WILDCARD_DOMAIN=$(ocm get /api/clusters_mgmt/v1/clusters --parameter search="name is '$CLUSTER_NAME'" | jq -r '.items[].console.url' | cut -d'.' -f2-)

cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $WILDCARD_DOMAIN
  monitoring:
    enabled: true
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```

3. Verify the installation completes successfully:
```bash
oc get apimanager -n $NAMESPACE -o yaml -w
```

4. Verify that the PVC `system-searchd-manticore` was created:
```bash
oc get pvc -n $NAMESPACE
```

5. Verify that the k8s Job `system-searchd-manticore-reindex` was created and passed successfully:
```bash
oc get jobs -n $NAMESPACE
```
