### PR TITLE
THREESCALE-10921 disable async mode if sentinels require authentication

### DIFF
--- a/controllers/apps/apimanager_status_reconciler.go
+++ b/controllers/apps/apimanager_status_reconciler.go
@@ -238,8 +238,8 @@ func (s *APIManagerStatusReconciler) defaultRoutesReady() (bool, error) {
 func (s *APIManagerStatusReconciler) reconcileHpaWarningMessages(conditions *common.Conditions, cr *appsv1alpha1.APIManager) {
 
 	// get url's to confirm if logical Redis DB or sentinels with auth used
-	redisQueuesUrl, redisStorageUrl, redisQueuesSentinelHost, redisStorageSentinelHost := operator.GetBackendRedisSecret(cr.Namespace, context.TODO(), s.Client())
-	redisSystemSentinelHost := operator.GetSystemRedisSecret(cr.Namespace, context.TODO(), s.Client())
+	redisQueuesUrl, redisStorageUrl, redisQueuesSentinelHost, redisStorageSentinelHost := operator.GetBackendRedisSecret(cr.Namespace, context.TODO(), s.Client(), s.logger)
+	redisSystemSentinelHost := operator.GetSystemRedisSecret(cr.Namespace, context.TODO(), s.Client(), s.logger)
 
 	cond := common.Condition{
 		Type:    appsv1alpha1.APIManagerWarningConditionType,

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -57,10 +57,13 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 	}
 
 	// Listener Deployment
-	RedisQueuesUrl, RedisStorageUrl := GetBackendRedisSecret(r.apiManager.Namespace, r.Context(), r.Client())
+	RedisQueuesUrl, RedisStorageUrl, RedisQueuesSentinelHost, RedisStorageSentinelHost := GetBackendRedisSecret(r.apiManager.Namespace, r.Context(), r.Client())
 
 	listenerDeploymentMutator := reconcilers.GenericBackendDeploymentMutators()
-	if RedisStorageUrl != RedisQueuesUrl {
+	// this checks for logical redis exists
+	// this checks if SentinelHost are configured with passwords
+	if RedisStorageUrl != RedisQueuesUrl && !RedisQueuesSentinelHost && !RedisStorageSentinelHost {
+		// this checks if SentinelHost are configured with passwords
 		listenerDeploymentMutator = append(listenerDeploymentMutator, reconcilers.DeploymentListenerEnvMutator)
 		listenerDeploymentMutator = append(listenerDeploymentMutator, reconcilers.DeploymentListenerArgsMutator)
 	}
@@ -101,9 +104,10 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Worker Deployment
 	workerDeploymentMutator := reconcilers.GenericBackendDeploymentMutators()
-	if RedisStorageUrl != RedisQueuesUrl {
+	if RedisStorageUrl != RedisQueuesUrl && !RedisQueuesSentinelHost && !RedisStorageSentinelHost {
 		workerDeploymentMutator = append(workerDeploymentMutator, reconcilers.DeploymentWorkerEnvMutator)
 	}
+
 	if r.apiManager.Spec.Backend.WorkerSpec.Replicas != nil {
 		workerDeploymentMutator = append(workerDeploymentMutator, reconcilers.DeploymentReplicasMutator)
 	}
@@ -187,7 +191,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if RedisStorageUrl != RedisQueuesUrl {
+	if RedisStorageUrl != RedisQueuesUrl && !RedisQueuesSentinelHost && !RedisStorageSentinelHost {
 		err = r.ReconcileHpa(component.DefaultHpa(component.BackendListenerName, r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -199,7 +203,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 	} else {
 		// set log message if logical redis db are detected in the backend
 		if r.apiManager.Spec.Backend.ListenerSpec.Hpa || r.apiManager.Spec.Backend.WorkerSpec.Hpa {
-			message := "logical redis instances found in the backend, which is blocking redis async mode, horizontal pod autoscaling for backend cannot be enabled without async mode"
+			message := "logical redis instances or SentinelHost with authentication found in the backend, which is blocking redis async mode, horizontal pod autoscaling for backend cannot be enabled without async mode"
 			r.logger.Info(message)
 		}
 	}
@@ -216,7 +220,7 @@ func Backend(apimanager *appsv1alpha1.APIManager, client client.Client) (*compon
 	return component.NewBackend(opts), nil
 }
 
-func GetBackendRedisSecret(apimanagerNs string, ctx context.Context, client client.Client) (string, string) {
+func GetBackendRedisSecret(apimanagerNs string, ctx context.Context, client client.Client) (string, string, bool, bool) {
 	backendRedisSecret := &v1.Secret{}
 	client.Get(ctx, types.NamespacedName{
 		Name:      "backend-redis",
@@ -224,5 +228,8 @@ func GetBackendRedisSecret(apimanagerNs string, ctx context.Context, client clie
 	}, backendRedisSecret)
 	RedisQueuesUrl := strings.TrimSuffix(string(backendRedisSecret.Data["REDIS_QUEUES_URL"]), "1")
 	RedisStorageUrl := strings.TrimSuffix(string(backendRedisSecret.Data["REDIS_STORAGE_URL"]), "0")
-	return RedisQueuesUrl, RedisStorageUrl
+	RedisQueuesSentinelHost := strings.Contains(string(backendRedisSecret.Data["REDIS_QUEUES_SENTINEL_HOSTS"]), "@")
+	RedisStorageSentinelHost := strings.Contains(string(backendRedisSecret.Data["REDIS_STORAGE_SENTINEL_HOSTS"]), "@")
+
+	return RedisQueuesUrl, RedisStorageUrl, RedisQueuesSentinelHost, RedisStorageSentinelHost
 }


### PR DESCRIPTION
# What
issue: [THREESCALE-10921](https://issues.redhat.com//browse/THREESCALE-10921)

Disable async mode if redis sentinels have authentication enabled


# Verification

- install the operator without logical databases  following scripts will do this
[setup_db.sh](https://github.com/3scale-labs/3scale-perf-setup/blob/main/setup_db.sh)
[setup_apimanger.sh](https://github.com/3scale-labs/3scale-perf-setup/blob/main/setup_apimanager.sh)
- once finished remove hpa from apicast/productionspec, backend/listenerspec and backend/workerspec
- confirm no hpa set in 3scale-test namespace
```bash
oc get hpa --namespace 3scale-test
```
- scale down the operator deployment
-  we can mock a authenticated sentinel setup by editing the following secrets
- edit system-redis secret and add an @ symbol for `SENTINEL_HOSTS` 
- edit backend-redis secret and add an @ symbol for `REDIS_QUEUES_SENTINEL_HOSTS` and `REDIS_STORAGE_SENTINEL_HOSTS`
-  enable hpa again
```yaml
  backend:
    listenerSpec:
      hpa: true
    workerSpec:
      hpa: true
```
```yaml
  apicast:
    productionSpec:
      hpa: true
```
- from this branch do a `make install` and `make run`
- confirm that no hpa are created and that the status has the following warnings
```yaml
status:
  conditions:
    - lastTransitionTime: '2024-03-25T10:00:08Z'
      status: 'True'
      type: Available
    - message: 'HorizontalPodAutoscaling (Hpa) enabled overrides values applied to request, limits and replicas'
      reason: HPA
      status: 'True'
      type: Warning
    - message: 'Redis Sentinels with Authentication detected, these are not compatible with async mode, HPA requires async mode in order for HPA to function, HPA currently disabled'
      reason: HPA
      status: 'True'
      type: Warning
```
You may see some deployments failing to come up but this is because we haven't configured Sentinels correctly and they are having issues connecting to redis. 
