### PR TITLE
THREESCALE-10937-2 update redis image

### DIFF
--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -21,11 +21,11 @@ func ZyncImageURL() string {
 }
 
 func BackendRedisImageURL() string {
-	return "quay.io/sclorg/redis-6-c8s"
+	return "quay.io/fedora/redis-6"
 }
 
 func SystemRedisImageURL() string {
-	return "quay.io/sclorg/redis-6-c8s"
+	return "quay.io/fedora/redis-6"
 }
 
 func SystemMySQLImageURL() string {

--- a/pkg/helper/podHelper.go
+++ b/pkg/helper/podHelper.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	redisDefaultImage      = "quay.io/sclorg/redis-6-c8s"
+	redisDefaultImage      = "quay.io/fedora/redis-6"
 	mySqlDefaultImage      = "quay.io/sclorg/mysql-80-c8s"
 	postgreSqlDefaultImage = "quay.io/sclorg/postgresql-10-c8s"
 )


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10937

centos streams 8 and 9 for Redis got removed.

Verification
E2e passing is sufficient