### PR TITLE
THREESCALE-10949 Preserve DC annotations, labels, and env vars

### DIFF
--- a/pkg/upgrade/migrate_deployment_config_2.15.go
+++ b/pkg/upgrade/migrate_deployment_config_2.15.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +55,24 @@ func MigrateDeploymentConfigToDeployment(dName string, dNamespace string, overri
 		return false, nil
 	}
 
+	// Copy any custom labels from the DeploymentConfig to the Deployment
+	err = transferDeploymentConfigLabels(deploymentConfig, deployment, client)
+	if err != nil {
+		return false, fmt.Errorf("error transferring deploymentconfig labels to deployment %s: %v", deployment.Name, err)
+	}
+
+	// Copy any custom annotations from the DeploymentConfig to the Deployment
+	err = transferDeploymentConfigAnnotations(deploymentConfig, deployment, client)
+	if err != nil {
+		return false, fmt.Errorf("error transferring deploymentconfig annotations to deployment %s: %v", deployment.Name, err)
+	}
+
+	// Copy any custom container env vars from the DeploymentConfig to the Deployment
+	err = transferDeploymentConfigEnvVars(deploymentConfig, deployment, client)
+	if err != nil {
+		return false, fmt.Errorf("error transferring deploymentconfig env vars to deployment %s: %v", deployment.Name, err)
+	}
+
 	// Requeue if Deployment isn't healthy and override is set to false, otherwise proceed
 	if !helper.IsDeploymentAvailable(deployment) && !overrideDeploymentHealth {
 		log.V(1).Info(fmt.Sprintf("deployment %s is not yet available and overrideDeploymentHealth is set to %t", deployment.Name, overrideDeploymentHealth))
@@ -78,6 +97,172 @@ func MigrateDeploymentConfigToDeployment(dName string, dNamespace string, overri
 
 	log.Info(fmt.Sprintf("%s Deployment has replaced its corresponding DeploymentConfig", deployment.Name))
 	return true, nil
+}
+
+func transferDeploymentConfigLabels(dc *appsv1.DeploymentConfig, deployment *k8sappsv1.Deployment, client k8sclient.Client) error {
+	// Get the DeploymentConfig-level labels from the DeploymentConfig and Deployment
+	dcLabels := dc.ObjectMeta.Labels
+	dLabels := deployment.ObjectMeta.Labels
+
+	// Determine which DeploymentConfig-level labels exist in dc but not in deployment
+	missingLabels := make(map[string]string)
+	for key, value := range dcLabels {
+		if _, exists := dLabels[key]; !exists {
+			missingLabels[key] = value
+		}
+	}
+
+	// Add the missing DeploymentConfig-level labels to deployment
+	if len(missingLabels) > 0 {
+		for key, value := range missingLabels {
+			if deployment.ObjectMeta.Labels == nil {
+				deployment.ObjectMeta.Labels = map[string]string{}
+			}
+			deployment.ObjectMeta.Labels[key] = value
+		}
+	}
+
+	// Extract the Pod-level labels from the DeploymentConfig and Deployment
+	dcPodLabels := dc.Spec.Template.Labels
+	dPodLabels := deployment.Spec.Template.Labels
+
+	// Determine which Pod-level labels exist in dc but not in deployment
+	missingPodLabels := make(map[string]string)
+	for key, value := range dcPodLabels {
+		if _, exists := dPodLabels[key]; !exists {
+			// Skip adding the old deploymentConfig label
+			if key != "deploymentConfig" {
+				missingPodLabels[key] = value
+			}
+		}
+	}
+
+	// Add any missing Pod-level labels to deployment
+	if len(missingPodLabels) > 0 {
+		for key, value := range missingPodLabels {
+			if deployment.Spec.Template.Labels == nil {
+				deployment.Spec.Template.Labels = map[string]string{}
+			}
+			deployment.Spec.Template.Labels[key] = value
+		}
+	}
+
+	if len(missingLabels) > 0 || len(missingPodLabels) > 0 {
+		// Update the deployment
+		err := client.Update(context.TODO(), deployment)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func transferDeploymentConfigAnnotations(dc *appsv1.DeploymentConfig, deployment *k8sappsv1.Deployment, client k8sclient.Client) error {
+	// Get the DeploymentConfig-level annotations from the DeploymentConfig and Deployment
+	dcAnnotations := dc.ObjectMeta.Annotations
+	dAnnotations := deployment.ObjectMeta.Annotations
+
+	// Determine which DeploymentConfig-level annotations exist in dc but not in deployment
+	missingAnnotations := make(map[string]string)
+	for key, value := range dcAnnotations {
+		if _, exists := dAnnotations[key]; !exists {
+			missingAnnotations[key] = value
+		}
+	}
+
+	// Add the missing DeploymentConfig-level annotations to deployment
+	if len(missingAnnotations) > 0 {
+		for key, value := range missingAnnotations {
+			if deployment.ObjectMeta.Annotations == nil {
+				deployment.ObjectMeta.Annotations = map[string]string{}
+			}
+			deployment.ObjectMeta.Annotations[key] = value
+		}
+	}
+
+	// Extract the Pod-level annotations from the DeploymentConfig and Deployment
+	dcPodAnnotations := dc.Spec.Template.Annotations
+	dPodAnnotations := deployment.Spec.Template.Annotations
+
+	// Determine which Pod-level annotations exist in dc but not in deployment
+	missingPodAnnotations := make(map[string]string)
+	for key, value := range dcPodAnnotations {
+		if _, exists := dPodAnnotations[key]; !exists {
+			missingPodAnnotations[key] = value
+		}
+	}
+
+	// Add any missing Pod-level annotations to deployment
+	if len(missingPodAnnotations) > 0 {
+		for key, value := range missingPodAnnotations {
+			if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+				deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+			}
+			deployment.Spec.Template.Annotations[key] = value
+		}
+	}
+
+	if len(missingAnnotations) > 0 || len(missingPodAnnotations) > 0 {
+		// Update the deployment
+		err := client.Update(context.TODO(), deployment)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func transferDeploymentConfigEnvVars(dc *appsv1.DeploymentConfig, deployment *k8sappsv1.Deployment, client k8sclient.Client) error {
+	envVarsAdded := false
+
+	// Loop through each container in dc
+	for _, dcContainer := range dc.Spec.Template.Spec.Containers {
+		// Find corresponding container in deployment
+		var dContainer *corev1.Container
+		for i, container := range deployment.Spec.Template.Spec.Containers {
+			if dcContainer.Name == container.Name {
+				dContainer = &deployment.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+
+		if dContainer == nil {
+			return fmt.Errorf("the deployment %s is missing the container %s", deployment.Name, dcContainer.Name)
+		}
+
+		// Determine which env vars exist in dc's container but not in deployment's container
+		var missingEnvVars []corev1.EnvVar
+		for _, dcEnvVar := range dcContainer.Env {
+			found := false
+			for _, deploymentEnvVar := range dContainer.Env {
+				if dcEnvVar.Name == deploymentEnvVar.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				missingEnvVars = append(missingEnvVars, dcEnvVar)
+			}
+		}
+
+		// Add any missing env vars to deployment's container
+		if len(missingEnvVars) > 0 {
+			dContainer.Env = append(dContainer.Env, missingEnvVars...)
+			envVarsAdded = true
+		}
+	}
+
+	if envVarsAdded {
+		// Update the deployment
+		err := client.Update(context.TODO(), deployment)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func transferZyncRoutesOwnership(deployment *k8sappsv1.Deployment, client k8sclient.Client, scheme *runtime.Scheme) error {


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10949](https://issues.redhat.com/browse/THREESCALE-10949)

# What
This updates the DeploymentConfig to Deployment migration code to preserve the following custom, user-defined values:
* Deployment Labels
* Deployment Annotations
* Pod Labels
* Pod Annotations
* Container Environment Variables
* Volumes
* Volume Mounts
* Replicas

# Verification Steps
1. Checkout this PR

2. Prepare the cluster
```bash
make install
make download
```

3. Create the Namespace and `s3-credentials` Secret
```bash
export NAMESPACE=3scale-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF
```

4. Create the APIManager CR (make sure to replace `<REPLACE_WITH_CLUSTER_NAME>` with the name of your cluster)
```bash
export CLUSTER_NAME=<REPLACE_WITH_CLUSTER_NAME>
```
```bash
export WILDCARD_DOMAIN=$(ocm get /api/clusters_mgmt/v1/clusters --parameter search="name is '$CLUSTER_NAME'" | jq -r '.items[].console.url' | cut -d'.' -f2-)

cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $WILDCARD_DOMAIN
  monitoring:
    enabled: true
  system:
    database:
      postgresql: {}
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```

5. Login to the cluster UI and navigate to Operators->OperatorHub. Search for "3scale" and install Red Hat Integration - 3scale using the Channel "threescale-2.14" into the 3scale-test namespace.

6. Wait for the installation to complete
```bash
oc get apimanager 3scale -n 3scale-test -oyaml -w
```

7. Patch a test _DeploymentConfig_ label into each of the DeploymentConfigs
<details>

```bash
oc patch dc/apicast-production -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/apicast-staging -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/backend-cron -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/backend-listener -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/backend-redis -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/backend-worker -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/system-app -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/system-memcache -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/system-postgresql -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/system-redis -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/system-searchd -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/system-sidekiq -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/zync -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/zync-database -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
oc patch dc/zync-que -n 3scale-test --type merge -p '{"metadata":{"labels":{"test_deployment_label":"test"}}}'
```
</details>

8. Patch a test _Pod_ label into each of the DeploymentConfigs
<details>

```bash
oc patch dc/apicast-production -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/apicast-staging -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/backend-cron -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/backend-listener -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/backend-redis -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/backend-worker -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/system-app -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/system-memcache -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/system-postgresql -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/system-redis -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/system-searchd -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/system-sidekiq -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/zync -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/zync-database -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
oc patch dc/zync-que -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"labels":{"test_pod_label":"test"}}}}}'
```
</details>

9. Patch a test _DeploymentConfig_ annotation into each of the DeploymentConfigs
<details>

```bash
oc patch dc/apicast-production -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/apicast-staging -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/backend-cron -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/backend-listener -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/backend-redis -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/backend-worker -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/system-app -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/system-memcache -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/system-postgresql -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/system-redis -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/system-searchd -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/system-sidekiq -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/zync -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/zync-database -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
oc patch dc/zync-que -n 3scale-test --type merge -p '{"metadata":{"annotations":{"test_deployment_annotation":"test"}}}'
```
</details>

10. Patch a test _Pod_ annotation into each of the DeploymentConfigs
<details>

```bash
oc patch dc/apicast-production -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/apicast-staging -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/backend-cron -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/backend-listener -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/backend-redis -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/backend-worker -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/system-app -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/system-memcache -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/system-postgresql -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/system-redis -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/system-searchd -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/system-sidekiq -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/zync -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/zync-database -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
oc patch dc/zync-que -n 3scale-test --type merge -p '{"spec":{"template":{"metadata":{"annotations":{"test_pod_annotation":"test"}}}}}'
```
</details>

11. Add an environment variable to the `system-master` container in the `system-app` DeploymentConfig
```bash
oc set env dc/system-app --containers=system-master TEST_CONTAINER_ENV_VAR=test 
```

12. Create a test Secret then add a volume and volumeMount to the `apicast-staging` DeploymentConfig to inject it into the Pod
```bash
cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: test-volume-secret
  namespace: 3scale-test
data:
  test-key.yaml: dGVzdC12YWx1ZQo=
type: Opaque
EOF

oc set volumes dc/apicast-staging --add --name=test-volume --type=secret --secret-name=test-volume-secret --mount-path=/tmp/test -n 3scale-test
```

13. Bump the `system-sidekiq` DeploymentConfig's replica count to `3`
```bash
oc scale --replicas=3 dc/system-sidekiq -n 3scale-test
```

14. Wait for the installation to complete
```bash
oc get apimanager 3scale -n 3scale-test -oyaml -w
```

15. Verify that all the DeploymentConfigs have the `test_deployment_label: test` label
```bash
oc get dc -n 3scale-test --selector=test_deployment_label=test
```

16. Verify that all the running Pods have the `test_pod_label: test` label
```bash
oc get pods -n 3scale-test --selector=test_pod_label=test
```

17. Verify that all the DeploymentConfigs have the `test_deployment_annotation: test` annotation
```bash
oc get dc -n 3scale-test -o yaml | yq eval '.items[] | select(.metadata.annotations."test_deployment_annotation" == "test") | .metadata.name' -
```

18. Verify that all the running Pods have the `test_pod_annotation: test` annotation
```bash
oc get pods -n 3scale-test -o yaml | yq eval '.items[] | select(.metadata.annotations."test_pod_annotation" == "test") | .metadata.name' -
```

19. Verify that the test env var was injected into the `system-master` container in the `system-app` DeploymentConfig
```bash
oc get dc/system-app -n 3scale-test -o yaml | yq eval '.spec.template.spec.containers[] | select(.name == "system-master") | .env' - | grep -A 1 TEST_CONTAINER_ENV_VAR
```

20. Verify that the test-volume-secret was properly mounted into the `apicast-staging` container in the `apicast-staging` DeploymentConfig
```bash
oc rsh $(oc get pods | grep apicast-staging | grep Running | awk '{print $1}') cat /tmp/test/test-key.yaml
```

21. Verify that there are `3` running `system-sidekiq` Pods
```bash
oc get pods | grep system-sidekiq | grep Running
```

22. Scale down the 3scale-operator
```bash
oc scale deployment threescale-operator-controller-manager-v2 -n 3scale-test --replicas=0
```

23. Run the operator locally
```bash
make run
```

24. Wait for the installation to complete
```bash
oc get apimanager 3scale -n 3scale-test -oyaml -w
```

25. Verify that all the Deployments have the `test_deployment_label: test` label:
```bash
oc get deployments -n 3scale-test --selector=test_deployment_label=test
```

26. Verify that all the running Pods have the `test_pod_label: test` label:
```bash
oc get pods -n 3scale-test --selector=test_pod_label=test
```

27. Verify that all the Deployments have the `test_deployment_annotation: test` annotation
```bash
oc get deployments -n 3scale-test -o yaml | yq eval '.items[] | select(.metadata.annotations."test_deployment_annotation" == "test") | .metadata.name' -
```

28. Verify that all the running Pods have the `test_pod_annotation: test` annotation:
```bash
oc get pods -n 3scale-test -o yaml | yq eval '.items[] | select(.metadata.annotations."test_pod_annotation" == "test") | .metadata.name' -
```

29. Verify that the test env var was added to the `system-master` container in the `system-app` Deployment
```bash
oc get deployment/system-app -n 3scale-test -o yaml | yq eval '.spec.template.spec.containers[] | select(.name == "system-master") | .env' - | grep -A 1 TEST_CONTAINER_ENV_VAR
```

30. Verify that the test-volume-secret was properly mounted into the `apicast-staging` container in the `apicast-staging` Deployment
```bash
oc rsh $(oc get pods | grep apicast-staging | grep Running | awk '{print $1}') cat /tmp/test/test-key.yaml
```

31. Verify that there are `3` running `system-sidekiq` Pods
```bash
oc get pods | grep system-sidekiq | grep Running
```
