### PR TITLE
THREESCALE-9711 include patch release of 3scale in APIM

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/3scale/3scale-operator/apis/apps"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/apispkg/common"
 	"github.com/3scale/3scale-operator/version"
 )
@@ -952,7 +951,7 @@ func (apimanager *APIManager) IsMultiMinorHopDetected() (bool, error) {
 	}
 
 	if currentlyInstalledVersion != "" {
-		multiMinorHop, err := common.CompareMinorVersions(currentlyInstalledVersion, product.ThreescaleRelease)
+		multiMinorHop, err := common.CompareMinorVersions(currentlyInstalledVersion, version.ThreescaleVersionMajorMinor())
 		if err != nil {
 			return true, err
 		}
@@ -975,8 +974,8 @@ func (apimanager *APIManager) setAPIManagerAnnotationsDefaults() bool {
 		changed = true
 	}
 
-	if v, ok := apimanager.Annotations[ThreescaleVersionAnnotation]; !ok || v != product.ThreescaleRelease {
-		apimanager.Annotations[ThreescaleVersionAnnotation] = product.ThreescaleRelease
+	if v, ok := apimanager.Annotations[ThreescaleVersionAnnotation]; !ok || v != version.ThreescaleVersionMajorMinorPatch() {
+		apimanager.Annotations[ThreescaleVersionAnnotation] = version.ThreescaleVersionMajorMinorPatch()
 		changed = true
 	}
 

--- a/apis/apps/v1alpha1/apimanager_types_test.go
+++ b/apis/apps/v1alpha1/apimanager_types_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -26,7 +25,7 @@ func TestSetDefaults(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				OperatorVersionAnnotation:   version.Version,
-				ThreescaleVersionAnnotation: product.ThreescaleRelease,
+				ThreescaleVersionAnnotation: version.ThreescaleVersionMajorMinorPatch(),
 			},
 		},
 		Spec: APIManagerSpec{

--- a/controllers/apps/apimanager_status_reconciler.go
+++ b/controllers/apps/apimanager_status_reconciler.go
@@ -7,10 +7,10 @@ import (
 	subController "github.com/3scale/3scale-operator/controllers/subscription"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/operator"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/apispkg/common"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
@@ -103,7 +103,7 @@ func (s *APIManagerStatusReconciler) calculateStatus() (*appsv1alpha1.APIManager
 	}
 
 	if !helper.IsPreflightBypassed() {
-		err = s.reconcilePreflightsError(&newStatus.Conditions, s.apimanagerResource)
+		err = s.reconcilePreflightsStatus(&newStatus.Conditions, s.apimanagerResource)
 		if err != nil {
 			return nil, err
 		}
@@ -358,7 +358,7 @@ func apicastOpenTracingCondition(apicast string) common.Condition {
 	}
 }
 
-func (s *APIManagerStatusReconciler) reconcilePreflightsError(conditions *common.Conditions, cr *appsv1alpha1.APIManager) error {
+func (s *APIManagerStatusReconciler) reconcilePreflightsStatus(conditions *common.Conditions, cr *appsv1alpha1.APIManager) error {
 	prefligtsCondition := common.Condition{
 		Type:    appsv1alpha1.APIManagerPreflightsConditionType,
 		Status:  v1.ConditionStatus(metav1.ConditionTrue),
@@ -401,7 +401,7 @@ func (s *APIManagerStatusReconciler) reconcilePreflightsError(conditions *common
 		prefligtsCondition.Message = upgradePreflightsErrorMessage
 	}
 
-	if !cr.IsInFreshInstallationScenario() && s.preflightsErr == nil && (product.ThreescaleRelease != reqConfigMap.Data[helper.RHTThreescaleVersion]) && !isMultiHopDetected {
+	if !cr.IsInFreshInstallationScenario() && s.preflightsErr == nil && (version.ThreescaleVersionMajorMinor() != reqConfigMap.Data[helper.RHTThreescaleVersion]) && !isMultiHopDetected {
 		prefligtsCondition.Status = v1.ConditionStatus(metav1.ConditionTrue)
 		prefligtsCondition.Message = upgradeSuccessfulPreflight
 	}

--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/3scale/3scale-operator/controllers/subscription/csvlocator"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
@@ -74,7 +73,7 @@ const (
 
 func (r *SubscriptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.BaseReconciler.Logger().WithValues("subscription", req.NamespacedName)
-	logger.Info("ReconcileSubscription", "Operator version", version.Version, "3scale release", product.ThreescaleRelease)
+	logger.Info("ReconcileSubscription", "Operator version", version.Version, "3scale release", version.ThreescaleVersionMajorMinor())
 
 	// Retrieve the subscription from the operator namespace
 	subscription := &operatorsv1alpha1.Subscription{}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
 	appscontroller "github.com/3scale/3scale-operator/controllers/apps"
 	capabilitiescontroller "github.com/3scale/3scale-operator/controllers/capabilities"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	"github.com/3scale/3scale-operator/version"
 	"github.com/getkin/kin-openapi/openapi3"
@@ -479,7 +478,7 @@ func register3scaleVersionInfoMetric() {
 			Help: "3scale Operator version and product version",
 			ConstLabels: prometheus.Labels{
 				"operator_version": version.Version,
-				"version":          product.ThreescaleRelease,
+				"version":          version.ThreescaleVersionMajorMinor(),
 			},
 		},
 	)

--- a/pkg/3scale/amp/operator/ampimages_options_provider.go
+++ b/pkg/3scale/amp/operator/ampimages_options_provider.go
@@ -3,7 +3,7 @@ package operator
 import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type AmpImagesOptionsProvider struct {
@@ -20,7 +20,7 @@ func NewAmpImagesOptionsProvider(apimanager *appsv1alpha1.APIManager) *AmpImages
 
 func (a *AmpImagesOptionsProvider) GetAmpImagesOptions() (*component.AmpImagesOptions, error) {
 	a.ampImagesOptions.AppLabel = *a.apimanager.Spec.AppLabel
-	a.ampImagesOptions.AmpRelease = product.ThreescaleRelease
+	a.ampImagesOptions.AmpRelease = version.ThreescaleVersionMajorMinor()
 
 	a.ampImagesOptions.ApicastImage = ApicastImageURL()
 	if a.apimanager.Spec.Apicast != nil && a.apimanager.Spec.Apicast.Image != nil {

--- a/pkg/3scale/amp/operator/ampimages_options_provider_test.go
+++ b/pkg/3scale/amp/operator/ampimages_options_provider_test.go
@@ -6,7 +6,7 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -26,7 +26,7 @@ const (
 func defaultAmpImageOptions() *component.AmpImagesOptions {
 	return &component.AmpImagesOptions{
 		AppLabel:                    appLabel,
-		AmpRelease:                  product.ThreescaleRelease,
+		AmpRelease:                  version.ThreescaleVersionMajorMinor(),
 		ApicastImage:                ApicastImageURL(),
 		BackendImage:                BackendImageURL(),
 		SystemImage:                 SystemImageURL(),

--- a/pkg/3scale/amp/operator/apicast_options_provider.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider.go
@@ -17,9 +17,9 @@ import (
 	"github.com/3scale/3scale-operator/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type ApicastOptionsProvider struct {
@@ -47,7 +47,7 @@ func NewApicastOptionsProvider(apimanager *appsv1alpha1.APIManager, client clien
 
 func (a *ApicastOptionsProvider) GetApicastOptions() (*component.ApicastOptions, error) {
 	a.apicastOptions.ManagementAPI = *a.apimanager.Spec.Apicast.ApicastManagementAPI
-	a.apicastOptions.ImageTag = product.ThreescaleRelease
+	a.apicastOptions.ImageTag = version.ThreescaleVersionMajorMinor()
 	a.apicastOptions.OpenSSLVerify = strconv.FormatBool(*a.apimanager.Spec.Apicast.OpenSSLVerify)
 	a.apicastOptions.ResponseCodes = strconv.FormatBool(*a.apimanager.Spec.Apicast.IncludeResponseCodes)
 	a.apicastOptions.ExtendedMetrics = true

--- a/pkg/3scale/amp/operator/apicast_options_provider_test.go
+++ b/pkg/3scale/amp/operator/apicast_options_provider_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/3scale/3scale-operator/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 )
 
 const (
@@ -147,7 +147,7 @@ func defaultApicastOptions() *component.ApicastOptions {
 		ManagementAPI:                      apicastManagementAPI,
 		OpenSSLVerify:                      strconv.FormatBool(openSSLVerify),
 		ResponseCodes:                      strconv.FormatBool(responseCodes),
-		ImageTag:                           product.ThreescaleRelease,
+		ImageTag:                           version.ThreescaleVersionMajorMinor(),
 		ExtendedMetrics:                    true,
 		ProductionResourceRequirements:     component.DefaultProductionResourceRequirements(),
 		StagingResourceRequirements:        component.DefaultStagingResourceRequirements(),

--- a/pkg/3scale/amp/operator/backend_options_provider.go
+++ b/pkg/3scale/amp/operator/backend_options_provider.go
@@ -5,9 +5,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +34,7 @@ func NewOperatorBackendOptionsProvider(apimanager *appsv1alpha1.APIManager, name
 func (o *OperatorBackendOptionsProvider) GetBackendOptions() (*component.BackendOptions, error) {
 	o.backendOptions.TenantName = *o.apimanager.Spec.TenantName
 	o.backendOptions.WildcardDomain = o.apimanager.Spec.WildcardDomain
-	o.backendOptions.ImageTag = product.ThreescaleRelease
+	o.backendOptions.ImageTag = version.ThreescaleVersionMajorMinor()
 
 	err := o.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/backend_options_provider_test.go
+++ b/pkg/3scale/amp/operator/backend_options_provider_test.go
@@ -7,9 +7,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
@@ -198,7 +198,7 @@ func defaultBackendOptions(opts *component.BackendOptions) *component.BackendOpt
 		SystemBackendPassword:        opts.SystemBackendPassword,
 		TenantName:                   tenantName,
 		WildcardDomain:               wildcardDomain,
-		ImageTag:                     product.ThreescaleRelease,
+		ImageTag:                     version.ThreescaleVersionMajorMinor(),
 		CommonLabels:                 testBackendCommonLabels(),
 		CommonListenerLabels:         testBackendCommonListenerLabels(),
 		CommonWorkerLabels:           testBackendCommonWorkerLabels(),

--- a/pkg/3scale/amp/operator/helper_test.go
+++ b/pkg/3scale/amp/operator/helper_test.go
@@ -8,8 +8,8 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
+	"github.com/3scale/3scale-operator/version"
 )
 
 const (
@@ -30,7 +30,7 @@ func addExpectedMeteringLabels(src map[string]string, componentName string, comp
 		{"rht.prod_name", "Red_Hat_Integration"},
 		{"rht.prod_ver", "master"},
 		{"rht.comp", "3scale"},
-		{"rht.comp_ver", product.ThreescaleRelease},
+		{"rht.comp_ver", version.ThreescaleVersionMajorMinor()},
 		{"rht.subcomp", componentName},
 		{"rht.subcomp_t", string(componentType)},
 	}

--- a/pkg/3scale/amp/operator/memcached_options_provider.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider.go
@@ -5,9 +5,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	v1 "k8s.io/api/core/v1"
 )
@@ -25,7 +25,7 @@ func NewMemcachedOptionsProvider(apimanager *appsv1alpha1.APIManager) *Memcached
 }
 
 func (m *MemcachedOptionsProvider) GetMemcachedOptions() (*component.MemcachedOptions, error) {
-	m.memcachedOptions.ImageTag = product.ThreescaleRelease
+	m.memcachedOptions.ImageTag = version.ThreescaleVersionMajorMinor()
 	m.memcachedOptions.DeploymentLabels = m.deploymentLabels()
 	m.memcachedOptions.PodTemplateLabels = m.podTemplateLabels()
 	m.memcachedOptions.PodTemplateAnnotations = m.apimanager.Spec.System.MemcachedAnnotations

--- a/pkg/3scale/amp/operator/memcached_options_provider_test.go
+++ b/pkg/3scale/amp/operator/memcached_options_provider_test.go
@@ -6,9 +6,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -59,7 +59,7 @@ func testSystemMemcachedCustomResourceRequirements() *v1.ResourceRequirements {
 
 func defaultMemcachedOptions() *component.MemcachedOptions {
 	return &component.MemcachedOptions{
-		ImageTag:             product.ThreescaleRelease,
+		ImageTag:             version.ThreescaleVersionMajorMinor(),
 		ResourceRequirements: component.DefaultMemcachedResourceRequirements(),
 		DeploymentLabels:     testMemcachedDeploymentLabels(),
 		PodTemplateLabels:    testPodTemplateLabels(),

--- a/pkg/3scale/amp/operator/redis_options_provider.go
+++ b/pkg/3scale/amp/operator/redis_options_provider.go
@@ -5,9 +5,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,9 +32,9 @@ func NewRedisOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace stri
 }
 
 func (r *RedisOptionsProvider) GetRedisOptions() (*component.RedisOptions, error) {
-	r.options.AmpRelease = product.ThreescaleRelease
-	r.options.BackendImageTag = product.ThreescaleRelease
-	r.options.SystemImageTag = product.ThreescaleRelease
+	r.options.AmpRelease = version.ThreescaleVersionMajorMinor()
+	r.options.BackendImageTag = version.ThreescaleVersionMajorMinor()
+	r.options.SystemImageTag = version.ThreescaleVersionMajorMinor()
 
 	r.options.BackendImage = BackendRedisImageURL()
 	if r.apimanager.Spec.Backend != nil && r.apimanager.Spec.Backend.RedisImage != nil {

--- a/pkg/3scale/amp/operator/redis_options_provider_test.go
+++ b/pkg/3scale/amp/operator/redis_options_provider_test.go
@@ -6,9 +6,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -138,9 +138,9 @@ func testSystemRedisSecret() *v1.Secret {
 
 func defaultRedisOptions() *component.RedisOptions {
 	return &component.RedisOptions{
-		AmpRelease:      product.ThreescaleRelease,
-		BackendImageTag: product.ThreescaleRelease,
-		SystemImageTag:  product.ThreescaleRelease,
+		AmpRelease:      version.ThreescaleVersionMajorMinor(),
+		BackendImageTag: version.ThreescaleVersionMajorMinor(),
+		SystemImageTag:  version.ThreescaleVersionMajorMinor(),
 		BackendImage:    component.BackendRedisImageURL(),
 		SystemImage:     component.SystemRedisImageURL(),
 		BackendRedisContainerResourceRequirements: component.DefaultBackendRedisContainerResourceRequirements(),

--- a/pkg/3scale/amp/operator/system_mysql_image_options_provider.go
+++ b/pkg/3scale/amp/operator/system_mysql_image_options_provider.go
@@ -3,7 +3,7 @@ package operator
 import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type SystemMysqlImageOptionsProvider struct {
@@ -20,7 +20,7 @@ func NewSystemMysqlImageOptionsProvider(apimanager *appsv1alpha1.APIManager) *Sy
 
 func (s *SystemMysqlImageOptionsProvider) GetSystemMySQLImageOptions() (*component.SystemMySQLImageOptions, error) {
 	s.mysqlImageOptions.AppLabel = *s.apimanager.Spec.AppLabel
-	s.mysqlImageOptions.AmpRelease = product.ThreescaleRelease
+	s.mysqlImageOptions.AmpRelease = version.ThreescaleVersionMajorMinor()
 
 	s.mysqlImageOptions.Image = SystemMySQLImageURL()
 	if s.apimanager.Spec.System.DatabaseSpec != nil &&

--- a/pkg/3scale/amp/operator/system_mysql_image_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_mysql_image_options_provider_test.go
@@ -6,7 +6,7 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -17,7 +17,7 @@ const (
 func defaultSystemMySQLImageOptions() *component.SystemMySQLImageOptions {
 	return &component.SystemMySQLImageOptions{
 		AppLabel:   appLabel,
-		AmpRelease: product.ThreescaleRelease,
+		AmpRelease: version.ThreescaleVersionMajorMinor(),
 		Image:      component.SystemMySQLImageURL(),
 	}
 }

--- a/pkg/3scale/amp/operator/system_mysql_options_provider.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider.go
@@ -8,8 +8,8 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
+	"github.com/3scale/3scale-operator/version"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +34,7 @@ func NewSystemMysqlOptionsProvider(apimanager *appsv1alpha1.APIManager, namespac
 }
 
 func (s *SystemMysqlOptionsProvider) GetMysqlOptions() (*component.SystemMysqlOptions, error) {
-	s.mysqlOptions.ImageTag = product.ThreescaleRelease
+	s.mysqlOptions.ImageTag = version.ThreescaleVersionMajorMinor()
 	s.mysqlOptions.CommonLabels = s.commonLabels()
 	s.mysqlOptions.DeploymentLabels = s.deploymentLabels()
 	s.mysqlOptions.PodTemplateLabels = s.podTemplateLabels()

--- a/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_mysql_options_provider_test.go
@@ -8,9 +8,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -75,7 +75,7 @@ func testSystemMySQLCustomResourceRequirements() *v1.ResourceRequirements {
 
 func defaultSystemMysqlOptions(opts *component.SystemMysqlOptions) *component.SystemMysqlOptions {
 	return &component.SystemMysqlOptions{
-		ImageTag:                      product.ThreescaleRelease,
+		ImageTag:                      version.ThreescaleVersionMajorMinor(),
 		DatabaseName:                  component.DefaultSystemMysqlDatabaseName(),
 		User:                          component.DefaultSystemMysqlUser(),
 		Password:                      opts.Password,

--- a/pkg/3scale/amp/operator/system_options_provider.go
+++ b/pkg/3scale/amp/operator/system_options_provider.go
@@ -10,9 +10,9 @@ import (
 	appscommon "github.com/3scale/3scale-operator/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type SystemOptionsProvider struct {
@@ -34,7 +34,7 @@ func NewSystemOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace str
 }
 
 func (s *SystemOptionsProvider) GetSystemOptions() (*component.SystemOptions, error) {
-	s.options.ImageTag = product.ThreescaleRelease
+	s.options.ImageTag = version.ThreescaleVersionMajorMinor()
 	s.options.ApicastRegistryURL = *s.apimanager.Spec.Apicast.RegistryURL
 	s.options.TenantName = *s.apimanager.Spec.TenantName
 	s.options.WildcardDomain = s.apimanager.Spec.WildcardDomain

--- a/pkg/3scale/amp/operator/system_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_options_provider_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/3scale/3scale-operator/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -290,7 +290,7 @@ func defaultSystemOptions(opts *component.SystemOptions) *component.SystemOption
 	expectedOpts := &component.SystemOptions{
 		TenantName:                                tenantName,
 		WildcardDomain:                            wildcardDomain,
-		ImageTag:                                  product.ThreescaleRelease,
+		ImageTag:                                  version.ThreescaleVersionMajorMinor(),
 		ApicastRegistryURL:                        apicastRegistryURL,
 		AppMasterContainerResourceRequirements:    component.DefaultAppMasterContainerResourceRequirements(),
 		AppProviderContainerResourceRequirements:  component.DefaultAppProviderContainerResourceRequirements(),

--- a/pkg/3scale/amp/operator/system_postgresql_image_options_provider.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image_options_provider.go
@@ -3,7 +3,7 @@ package operator
 import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type SystemPostgreSQLImageOptionsProvider struct {
@@ -20,7 +20,7 @@ func NewSystemPostgreSQLImageOptionsProvider(apimanager *appsv1alpha1.APIManager
 
 func (s *SystemPostgreSQLImageOptionsProvider) GetSystemPostgreSQLImageOptions() (*component.SystemPostgreSQLImageOptions, error) {
 	s.options.AppLabel = *s.apimanager.Spec.AppLabel
-	s.options.AmpRelease = product.ThreescaleRelease
+	s.options.AmpRelease = version.ThreescaleVersionMajorMinor()
 
 	s.options.Image = SystemPostgreSQLImageURL()
 	if s.apimanager.Spec.System.DatabaseSpec != nil &&

--- a/pkg/3scale/amp/operator/system_postgresql_image_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_postgresql_image_options_provider_test.go
@@ -6,7 +6,7 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -17,7 +17,7 @@ const (
 func defaultSystemPostgreSQLImageOptions() *component.SystemPostgreSQLImageOptions {
 	return &component.SystemPostgreSQLImageOptions{
 		AppLabel:   appLabel,
-		AmpRelease: product.ThreescaleRelease,
+		AmpRelease: version.ThreescaleVersionMajorMinor(),
 		Image:      component.SystemPostgreSQLImageURL(),
 	}
 }

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider.go
@@ -7,9 +7,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +34,7 @@ func NewSystemPostgresqlOptionsProvider(apimanager *appsv1alpha1.APIManager, nam
 }
 
 func (s *SystemPostgresqlOptionsProvider) GetSystemPostgreSQLOptions() (*component.SystemPostgreSQLOptions, error) {
-	s.options.ImageTag = product.ThreescaleRelease
+	s.options.ImageTag = version.ThreescaleVersionMajorMinor()
 	s.options.CommonLabels = s.commonLabels()
 	s.options.DeploymentLabels = s.deploymentLabels()
 	s.options.PodTemplateLabels = s.podTemplateLabels()

--- a/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_postgresql_options_provider_test.go
@@ -8,9 +8,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -76,7 +76,7 @@ func testSystemPostgreSQLCustomResourceRequirements() *v1.ResourceRequirements {
 
 func defaultSystemPostgreSQLOptions(opts *component.SystemPostgreSQLOptions) *component.SystemPostgreSQLOptions {
 	return &component.SystemPostgreSQLOptions{
-		ImageTag:                      product.ThreescaleRelease,
+		ImageTag:                      version.ThreescaleVersionMajorMinor(),
 		DatabaseName:                  component.DefaultSystemPostgresqlDatabaseName(),
 		User:                          component.DefaultSystemPostgresqlUser(),
 		Password:                      opts.Password,

--- a/pkg/3scale/amp/operator/system_searchd_options_provider.go
+++ b/pkg/3scale/amp/operator/system_searchd_options_provider.go
@@ -8,9 +8,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type SystemSearchdOptionsProvider struct {
@@ -26,7 +26,7 @@ func NewSystemSearchdOptionsProvider(apimanager *appsv1alpha1.APIManager) *Syste
 }
 
 func (s *SystemSearchdOptionsProvider) GetOptions() (*component.SystemSearchdOptions, error) {
-	s.options.ImageTag = product.ThreescaleRelease
+	s.options.ImageTag = version.ThreescaleVersionMajorMinor()
 	s.options.Labels = s.labels()
 	s.options.PodTemplateLabels = s.podTemplateLabels()
 	s.options.PodTemplateAnnotations = s.apimanager.Spec.System.SearchdSpec.Annotations

--- a/pkg/3scale/amp/operator/system_searchd_options_provider_test.go
+++ b/pkg/3scale/amp/operator/system_searchd_options_provider_test.go
@@ -7,9 +7,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -90,7 +90,7 @@ func testSystemSearchdCustomResourceRequirements() *v1.ResourceRequirements {
 
 func testDefaultExpectedSystemSearchdOptions() *component.SystemSearchdOptions {
 	return &component.SystemSearchdOptions{
-		ImageTag:                      product.ThreescaleRelease,
+		ImageTag:                      version.ThreescaleVersionMajorMinor(),
 		ContainerResourceRequirements: component.DefaultSearchdContainerResourceRequirements(),
 		Affinity:                      nil,
 		Tolerations:                   nil,

--- a/pkg/3scale/amp/operator/zync_options_provider.go
+++ b/pkg/3scale/amp/operator/zync_options_provider.go
@@ -6,9 +6,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,8 +33,8 @@ func NewZyncOptionsProvider(apimanager *appsv1alpha1.APIManager, namespace strin
 }
 
 func (z *ZyncOptionsProvider) GetZyncOptions() (*component.ZyncOptions, error) {
-	z.zyncOptions.ImageTag = product.ThreescaleRelease
-	z.zyncOptions.DatabaseImageTag = product.ThreescaleRelease
+	z.zyncOptions.ImageTag = version.ThreescaleVersionMajorMinor()
+	z.zyncOptions.DatabaseImageTag = version.ThreescaleVersionMajorMinor()
 
 	err := z.setSecretBasedOptions()
 	if err != nil {

--- a/pkg/3scale/amp/operator/zync_options_provider_test.go
+++ b/pkg/3scale/amp/operator/zync_options_provider_test.go
@@ -14,9 +14,9 @@ import (
 
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
 )
 
 const (
@@ -216,8 +216,8 @@ func basicApimanagerWithExternalZyncDatabaseSpecTestZyncOptions() *appsv1alpha1.
 
 func defaultZyncOptions(opts *component.ZyncOptions) *component.ZyncOptions {
 	expectedOpts := &component.ZyncOptions{
-		ImageTag:                              product.ThreescaleRelease,
-		DatabaseImageTag:                      product.ThreescaleRelease,
+		ImageTag:                              version.ThreescaleVersionMajorMinor(),
+		DatabaseImageTag:                      version.ThreescaleVersionMajorMinor(),
 		ContainerResourceRequirements:         component.DefaultZyncContainerResourceRequirements(),
 		QueContainerResourceRequirements:      component.DefaultZyncQueContainerResourceRequirements(),
 		DatabaseContainerResourceRequirements: component.DefaultZyncDatabaseContainerResourceRequirements(),

--- a/pkg/3scale/amp/product/3scale_release.go
+++ b/pkg/3scale/amp/product/3scale_release.go
@@ -1,5 +1,0 @@
-package product
-
-var (
-	ThreescaleRelease = "2.14"
-)

--- a/pkg/helper/labels.go
+++ b/pkg/helper/labels.go
@@ -1,7 +1,7 @@
 package helper
 
 import (
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 )
 
 type ComponentType string
@@ -18,7 +18,7 @@ func MeteringLabels(componentName string, componentType ComponentType) map[strin
 		// It should be updated on release branch
 		"rht.prod_ver":  "master",
 		"rht.comp":      "3scale",
-		"rht.comp_ver":  product.ThreescaleRelease,
+		"rht.comp_ver":  version.ThreescaleVersionMajorMinor(),
 		"rht.subcomp":   componentName,
 		"rht.subcomp_t": string(componentType),
 	}

--- a/test/manifests-version/deployment_version_test.go
+++ b/test/manifests-version/deployment_version_test.go
@@ -2,11 +2,12 @@ package test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
+	"os"
 	"path"
 	"testing"
 
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/product"
+	"github.com/3scale/3scale-operator/version"
 
 	appsv1 "k8s.io/api/apps/v1"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -15,12 +16,12 @@ import (
 func TestDeploymentVersions(t *testing.T) {
 	root := "../../config/manager/"
 	path := path.Join(root, "manager.yaml")
-	yamlBytes, err := ioutil.ReadFile(path)
+	yamlBytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	bytesReader := ioutil.NopCloser(bytes.NewReader(yamlBytes))
+	bytesReader := io.NopCloser(bytes.NewReader(yamlBytes))
 	yamlDocumentDecoder := utilyaml.NewDocumentDecoder(bytesReader)
 
 	// Read and discard Namespace object from the yaml file
@@ -53,7 +54,7 @@ func TestDeploymentVersions(t *testing.T) {
 		t.Errorf("Parsed object is not a Deployment object")
 	}
 
-	if deployment.Spec.Template.Labels["rht.comp_ver"] != product.ThreescaleRelease {
-		t.Errorf("rht.comp_ver differ: expected: %s; found: %s", product.ThreescaleRelease, deployment.Spec.Template.Labels["rht.comp_ver"])
+	if deployment.Spec.Template.Labels["rht.comp_ver"] != version.ThreescaleVersionMajorMinor() {
+		t.Errorf("rht.comp_ver differ: expected: %s; found: %s", version.ThreescaleVersionMajorMinor(), deployment.Spec.Template.Labels["rht.comp_ver"])
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,22 @@
 package version
 
-var (
-	Version = "0.11.0"
+import (
+	"strings"
 )
+
+var (
+	Version           = "0.11.0"
+	threescaleRelease = "2.14.0"
+)
+
+func ThreescaleVersionMajorMinor() string {
+	parts := strings.Split(threescaleRelease, ".")
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return ""
+}
+
+func ThreescaleVersionMajorMinorPatch() string {
+	return threescaleRelease
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-9711

Verification:
Install 3scale locally and confirm that the APIManager annotation: "apps.3scale.net/apimanager-threescale-version" includes the patch version of 3scale release. 
Pick a few random deployments and confirm that rht.comp_ver remains at Major.Minor version