### PR TITLE
THREESCALE 9308 HeadCrab Vulnerability (Redis)

### DIFF
--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -346,6 +346,16 @@ func (r *APIManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	resourceVersionChangePredicate := predicate.ResourceVersionChangedPredicate{}
 
+	redisConfigLabelSelector := &apimachinerymetav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"threescale_component_element": "redis",
+		},
+	}
+	redisConfigLabelPredicate, err := predicate.LabelSelectorPredicate(*redisConfigLabelSelector)
+	if err != nil {
+		return nil
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1alpha1.APIManager{}).
 		Watches(
@@ -365,6 +375,7 @@ func (r *APIManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(configMapToApimanagerEventMapper.Map),
 			builder.WithPredicates(resourceVersionChangePredicate),
 		).
+		Owns(&v1.ConfigMap{}, builder.WithPredicates(redisConfigLabelPredicate)).
 		Complete(r)
 }
 

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -583,6 +583,8 @@ also enabled the user has to pre-create the following secret too:
   with the values pointing to the desired external database settings.
   The database should be configured in high-availability mode
 
+Use of slaves for Internal Redis is not supported.
+
 ### ExternalComponentsSpec
 
 | **json/yaml field**| **Type** | **Required** | **Description** |

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -188,6 +188,8 @@ operator will deploy and configure system database and zync database components.
 The 3scale operator requires a secret with the connection string for every single external database
 component. If a externally managed database secret does not exist, the operator will not deploy 3scale.
 
+Use of slaves for Internal Redis is not supported.
+
 * **Backend redis secret**
 
 Two external redis instances must be deployed by the customer. Then fill connection settings.

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -318,6 +318,9 @@ activerehashing no
 
 aof-rewrite-incremental-fsync yes
 dir /var/lib/redis/data
+
+rename-command REPLICAOF ""
+rename-command SLAVEOF ""
 `
 }
 

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -516,13 +516,6 @@ func (r *RedisConfigMap) buildConfigMapObjectMeta() metav1.ObjectMeta {
 	}
 }
 
-func (redis *Redis) buildConfigMapTypeMeta() metav1.TypeMeta {
-	return metav1.TypeMeta{
-		Kind:       "ConfigMap",
-		APIVersion: "v1",
-	}
-}
-
 func (r *RedisConfigMap) buildConfigMapData() map[string]string {
 	return map[string]string{
 		"redis.conf": r.getRedisConfData(),

--- a/pkg/3scale/amp/component/redis.go
+++ b/pkg/3scale/amp/component/redis.go
@@ -18,6 +18,16 @@ const (
 	SystemRedisDeploymentName  = "system-redis"
 )
 
+const (
+	redisConfigVolumeName              = "redis-config"
+	backendRedisObjectMetaName         = "backend-redis"
+	backendRedisDeploymentSelectorName = backendRedisObjectMetaName
+	backendRedisStorageVolumeName      = "backend-redis-storage"
+	backendRedisConfigMapKey           = "redis.conf"
+	backendRedisContainerName          = "backend-redis"
+	backendRedisConfigPath             = "/etc/redis.d/"
+)
+
 type Redis struct {
 	Options *RedisOptions
 }
@@ -47,17 +57,6 @@ func (redis *Redis) buildDeploymentObjectMeta() metav1.ObjectMeta {
 		Labels: redis.Options.BackendRedisLabels,
 	}
 }
-
-const (
-	redisConfigVolumeName = "redis-config"
-
-	backendRedisObjectMetaName         = "backend-redis"
-	backendRedisDeploymentSelectorName = backendRedisObjectMetaName
-	backendRedisStorageVolumeName      = "backend-redis-storage"
-	backendRedisConfigMapKey           = "redis.conf"
-	backendRedisContainerName          = "backend-redis"
-	backendRedisConfigPath             = "/etc/redis.d/"
-)
 
 func (redis *Redis) buildDeploymentSpec() k8sappsv1.DeploymentSpec {
 	var redisReplicas int32 = 1
@@ -242,86 +241,6 @@ func (redis *Redis) buildServiceSelector() map[string]string {
 	return map[string]string{
 		reconcilers.DeploymentLabelSelector: backendRedisDeploymentSelectorName,
 	}
-}
-
-func (redis *Redis) ConfigMap() *v1.ConfigMap {
-	return &v1.ConfigMap{
-		ObjectMeta: redis.buildConfigMapObjectMeta(),
-		TypeMeta:   redis.buildConfigMapTypeMeta(),
-		Data:       redis.buildConfigMapData(),
-	}
-}
-
-func (redis *Redis) buildConfigMapObjectMeta() metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:   redisConfigVolumeName,
-		Labels: redis.Options.SystemRedisLabels,
-	}
-}
-
-func (redis *Redis) buildConfigMapTypeMeta() metav1.TypeMeta {
-	return metav1.TypeMeta{
-		Kind:       "ConfigMap",
-		APIVersion: "v1",
-	}
-}
-
-func (redis *Redis) buildConfigMapData() map[string]string {
-	return map[string]string{
-		"redis.conf": redis.getRedisConfData(),
-	}
-}
-
-func (redis *Redis) getRedisConfData() string { // TODO read this from a real file
-	return `protected-mode no
-
-port 6379
-
-timeout 0
-tcp-keepalive 300
-
-daemonize no
-supervised no
-
-loglevel notice
-
-databases 16
-
-save 900 1
-save 300 10
-save 60 10000
-
-stop-writes-on-bgsave-error yes
-
-rdbcompression yes
-rdbchecksum yes
-
-dbfilename dump.rdb
-
-slave-serve-stale-data yes
-slave-read-only yes
-
-repl-diskless-sync no
-repl-disable-tcp-nodelay no
-
-appendonly yes
-appendfilename "appendonly.aof"
-appendfsync everysec
-no-appendfsync-on-rewrite no
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
-aof-load-truncated yes
-
-lua-time-limit 5000
-
-activerehashing no
-
-aof-rewrite-incremental-fsync yes
-dir /var/lib/redis/data
-
-rename-command REPLICAOF ""
-rename-command SLAVEOF ""
-`
 }
 
 func (redis *Redis) BackendPVC() *v1.PersistentVolumeClaim {
@@ -571,3 +490,118 @@ func (redis *Redis) buildEnv() []v1.EnvVar {
 }
 
 ////// End System Redis
+
+// //// Redis Config Map Begin
+type RedisConfigMap struct {
+	Options *RedisConfigMapOptions
+}
+
+func NewRedisConfigMap(options *RedisConfigMapOptions) *RedisConfigMap {
+	return &RedisConfigMap{Options: options}
+}
+
+func (r *RedisConfigMap) ConfigMap() *v1.ConfigMap {
+	return &v1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: r.buildConfigMapObjectMeta(),
+		Data:       r.buildConfigMapData(),
+	}
+}
+
+func (r *RedisConfigMap) buildConfigMapObjectMeta() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      redisConfigVolumeName,
+		Labels:    r.Options.Labels,
+		Namespace: r.Options.Namespace,
+	}
+}
+
+func (redis *Redis) buildConfigMapTypeMeta() metav1.TypeMeta {
+	return metav1.TypeMeta{
+		Kind:       "ConfigMap",
+		APIVersion: "v1",
+	}
+}
+
+func (r *RedisConfigMap) buildConfigMapData() map[string]string {
+	return map[string]string{
+		"redis.conf": r.getRedisConfData(),
+	}
+}
+
+func (r *RedisConfigMap) getRedisConfData() string { // TODO read this from a real file
+	return `protected-mode no
+
+port 6379
+
+timeout 0
+tcp-keepalive 300
+
+daemonize no
+supervised no
+
+loglevel notice
+
+databases 16
+
+save 900 1
+save 300 10
+save 60 10000
+
+stop-writes-on-bgsave-error yes
+
+rdbcompression yes
+rdbchecksum yes
+
+dbfilename dump.rdb
+
+slave-serve-stale-data yes
+slave-read-only yes
+
+repl-diskless-sync no
+repl-disable-tcp-nodelay no
+
+appendonly yes
+appendfilename "appendonly.aof"
+appendfsync everysec
+no-appendfsync-on-rewrite no
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+aof-load-truncated yes
+
+lua-time-limit 5000
+
+activerehashing no
+
+aof-rewrite-incremental-fsync yes
+dir /var/lib/redis/data
+
+rename-command REPLICAOF ""
+rename-command SLAVEOF ""
+`
+}
+
+////// Redis Config Map End
+
+func BackendCommonLabels(appLabel string) map[string]string {
+	return map[string]string{
+		"app":                  appLabel,
+		"threescale_component": "backend",
+	}
+}
+func BackendRedisLabels(appLabel string) map[string]string {
+	labels := BackendCommonLabels(appLabel)
+	labels["threescale_component_element"] = "redis"
+	return labels
+}
+func SystemCommonLabels(appLabel string) map[string]string {
+	return map[string]string{
+		"app":                  appLabel,
+		"threescale_component": "system",
+	}
+}
+func SystemRedisLabels(appLabel string) map[string]string {
+	labels := SystemCommonLabels(appLabel)
+	labels["threescale_component_element"] = "redis"
+	return labels
+}

--- a/pkg/3scale/amp/component/redis_configmap_options.go
+++ b/pkg/3scale/amp/component/redis_configmap_options.go
@@ -1,0 +1,19 @@
+package component
+
+import (
+	"github.com/go-playground/validator/v10"
+)
+
+type RedisConfigMapOptions struct {
+	Labels    map[string]string `validate:"required"`
+	Namespace string
+}
+
+func NewRedisConfigMapOptions() *RedisConfigMapOptions {
+	return &RedisConfigMapOptions{}
+}
+
+func (r *RedisConfigMapOptions) Validate() error {
+	validate := validator.New()
+	return validate.Struct(r)
+}

--- a/pkg/3scale/amp/operator/redis_configmap_options_provider.go
+++ b/pkg/3scale/amp/operator/redis_configmap_options_provider.go
@@ -1,0 +1,39 @@
+package operator
+
+import (
+	"fmt"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
+)
+
+type RedisConfigMapOptionsProvider struct {
+	apimanager *appsv1alpha1.APIManager
+	options    *component.RedisConfigMapOptions
+}
+
+func NewRedisConfigMapOptionsProvider(apimanager *appsv1alpha1.APIManager) *RedisConfigMapOptionsProvider {
+	return &RedisConfigMapOptionsProvider{
+		apimanager: apimanager,
+		options:    component.NewRedisConfigMapOptions(),
+	}
+}
+
+func (r *RedisConfigMapOptionsProvider) GetOptions() (*component.RedisConfigMapOptions, error) {
+	r.options.Labels = r.systemRedisLabels()
+	r.options.Namespace = r.apimanager.Namespace
+
+	err := r.options.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("RedisConfigMapOptionsProvider validating: %w", err)
+	}
+	return r.options, nil
+}
+
+func (r *RedisConfigMapOptionsProvider) systemRedisLabels() map[string]string {
+	return component.SystemRedisLabels(*r.apimanager.Spec.AppLabel)
+}
+
+func (r *RedisConfigMapOptionsProvider) systemCommonLabels() map[string]string {
+	return component.SystemCommonLabels(*r.apimanager.Spec.AppLabel)
+}

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/3scale/3scale-operator/pkg/common"
 	k8sappsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -23,7 +24,7 @@ type RedisReconciler struct {
 
 	Deployment            func(redis *component.Redis) *k8sappsv1.Deployment
 	Service               func(redis *component.Redis) *corev1.Service
-	ConfigMap             func(redis *component.Redis) *corev1.ConfigMap
+	ConfigMap             func(redis *component.RedisConfigMap) *corev1.ConfigMap
 	PersistentVolumeClaim func(redis *component.Redis) *corev1.PersistentVolumeClaim
 	Secret                func(redis *component.Redis) *corev1.Secret
 }
@@ -36,7 +37,7 @@ func NewSystemRedisDependencyReconciler(baseAPIManagerLogicReconciler *BaseAPIMa
 
 		Deployment:            (*component.Redis).SystemDeployment,
 		Service:               (*component.Redis).SystemService,
-		ConfigMap:             (*component.Redis).ConfigMap,
+		ConfigMap:             (*component.RedisConfigMap).ConfigMap,
 		PersistentVolumeClaim: (*component.Redis).SystemPVC,
 		Secret:                (*component.Redis).SystemRedisSecret,
 	}
@@ -48,30 +49,44 @@ func NewBackendRedisDependencyReconciler(baseAPIManagerLogicReconciler *BaseAPIM
 
 		Deployment:            (*component.Redis).BackendDeployment,
 		Service:               (*component.Redis).BackendService,
-		ConfigMap:             (*component.Redis).ConfigMap,
+		ConfigMap:             (*component.RedisConfigMap).ConfigMap,
 		PersistentVolumeClaim: (*component.Redis).BackendPVC,
 		Secret:                (*component.Redis).BackendRedisSecret,
 	}
 }
 
 func (r *RedisReconciler) Reconcile() (reconcile.Result, error) {
-	redis, err := Redis(r.apiManager, r.Client())
+	redisConfigMapGenerator, err := RedisConfigMap(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// We want to reconcile redis-conf ConfigMap before Deployment
 	// to avoid restart redis pods twice in case of User change ConfigMap.
-	// Annotation GenerationID was added to Pod Template to support Upgrade scenario.
-	// this GenerationID is taken from ConfigMap resourceVersion.
-	// If User change Config Map, Operator will revert it to original one,
+	// Annotation "redisConfigMapResourceVersion" added to Pod Template to support Upgrade scenario.
+	// this "redisConfigMapResourceVersion" is taken from ConfigMap resourceVersion.
+	// If User changes Config Map, Operator will revert it to original one,
 	// but resourceVersion could be changed twice (after user change and after operator).
 	// To avoid this scenario by placing CM reconciliation before Deployment
-	if r.ConfigMap != nil {
-		err = r.ReconcileConfigMap(r.ConfigMap(redis), r.redisConfigMapMutator)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
+	err = r.ReconcileConfigMap(r.ConfigMap(redisConfigMapGenerator), r.redisConfigMapMutator)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// check config map exists, otherwise requeue.
+	cmKey := client.ObjectKeyFromObject(r.ConfigMap(redisConfigMapGenerator))
+	err = r.Client().Get(context.Background(), cmKey, &corev1.ConfigMap{})
+	if apierrors.IsNotFound(err) {
+		r.logger.Info("waiting for redis config map to be available")
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	redis, err := Redis(r.apiManager, r.Client())
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	deploymentMutator := reconcilers.DeploymentMutator(
@@ -179,4 +194,13 @@ func (r *RedisReconciler) redisConfigMapMutator(existingObj, desiredObj common.K
 	update = update || fieldUpdated
 
 	return update, nil
+}
+
+func RedisConfigMap(apimanager *appsv1alpha1.APIManager) (*component.RedisConfigMap, error) {
+	optsProvider := NewRedisConfigMapOptionsProvider(apimanager)
+	opts, err := optsProvider.GetOptions()
+	if err != nil {
+		return nil, err
+	}
+	return component.NewRedisConfigMap(opts), nil
 }

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -3,18 +3,17 @@ package operator
 import (
 	"context"
 	"fmt"
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/common"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/pkg/upgrade"
 	k8sappsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
-	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
-	"github.com/3scale/3scale-operator/pkg/reconcilers"
-	"github.com/3scale/3scale-operator/pkg/upgrade"
 )
 
 // RedisReconciler is a generic DependencyReconciler that reconciles
@@ -190,7 +189,7 @@ func (r *RedisReconciler) redisConfigMapMutator(existingObj, desiredObj common.K
 	}
 
 	update := false
-	fieldUpdated := reconcilers.ConfigMapReconcileField(desired, existing, "redis.conf")
+	fieldUpdated := reconcilers.RedisConfigMapReconcileField(desired, existing, "redis.conf")
 	update = update || fieldUpdated
 
 	return update, nil

--- a/pkg/reconcilers/configmap.go
+++ b/pkg/reconcilers/configmap.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"strings"
 )
 
 func ConfigMapReconcileField(desired, existing *v1.ConfigMap, fieldName string) bool {
@@ -13,6 +14,32 @@ func ConfigMapReconcileField(desired, existing *v1.ConfigMap, fieldName string) 
 	} else {
 		if desired.Data[fieldName] != existingVal {
 			existing.Data[fieldName] = desired.Data[fieldName]
+			updated = true
+		}
+	}
+	return updated
+}
+
+func RedisConfigMapReconcileField(desired, existing *v1.ConfigMap, fieldName string) bool {
+	updated := false
+
+	if existingVal, ok := existing.Data[fieldName]; !ok {
+		existing.Data[fieldName] = desired.Data[fieldName]
+		updated = true
+	} else {
+		existingString := existingVal
+
+		replicaOfString := "rename-command REPLICAOF \"\""
+		if !strings.Contains(existingString, replicaOfString) {
+			existingString = existingString + "\n" + replicaOfString
+			existing.Data[fieldName] = existingString
+			updated = true
+		}
+
+		slaveOfString := "rename-command SLAVEOF \"\""
+		if !strings.Contains(existingString, slaveOfString) {
+			existingString = existingString + "\n" + slaveOfString
+			existing.Data[fieldName] = existingString
 			updated = true
 		}
 	}


### PR DESCRIPTION
Jira:  https://issues.redhat.com/browse/THREESCALE-9308

**This PR is recreated from https://github.com/3scale/3scale-operator/pull/954, that was closed because of significant changes in master**  

- Current PR is intended to prevent redis replication and slaves creation to prevent HeadCrab Vulnerability.
- for Internal Redis Only.
- If Redis is Internal than following records are added to configuration to disable replicaoff and slaveoff redis cli commands: 
      rename-command REPLICAOF ""
      rename-command SLAVEOF ""
- If both or one of these `rename-command` records removed or not found in `redis-config` config map - controller will restore them.
- PR does not prevent changes to other settings in the reids configuration (not REPLICAOF or SLAVEOF)

## Tests Preparation - files
- s3-creds-secret.yaml

```
kind: Secret
apiVersion: v1
metadata: 
  name: s3-credentials
  namespace: 3scale-test
data: 
  AWS_ACCESS_KEY_ID: QUtJQVY2SVcccc
  AWS_SECRET_ACCESS_KEY: aU5VbWdZY3hjSDFccc
  AWS_BUCKET: dm1vY2NzZjZxOGxyZWRoYXRyaGccccc
  AWS_REGION: ZXUtd2Vcccc
type: Opaque
```

- apimanagerCR.yaml

```
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: example-apimanager
spec:
  system: 
    fileStorage: 
      simpleStorageService: 
        configurationSecretRef: 
          name: s3-credentials
  wildcardDomain: apps.xxxxxx.axxxx.xxx.xxxxx.org

```

## Validation

-  get this PR

cd .../3scale-operator and run 3scale installation:

```
make install
oc new-project 3scale-test
make download
make run
```

- in another xterm:

```
oc apply -f s3-creds-secret.yaml
oc apply -f apimanagerCR.yaml
```

- Check that `redis-config` ConfigMap has required changes:
```
$ oc describe cm redis-config |grep rename-command
rename-command REPLICAOF ""
rename-command SLAVEOF ""
```

- Check that replicaof and slaveof commands are disabled.
Expected behavior as in example below

```
kubectl exec -ti $(kubectl get pods -l deployment=backend-redis -o name) -- /bin/bash
bash-4.2$ redis-cli 
127.0.0.1:6379> replicaof 10.10.10.10 6379
(error) ERR unknown command `replicaof`, with args beginning with: `10.10.10.10`, `6379`,
127.0.0.1:6379> replicaof
(error) ERR unknown command `replicaof`, with args beginning with: 
127.0.0.1:6379> slaveof
(error) ERR unknown command `slaveof`, with args beginning with: 
127.0.0.1:6379> 
```

Notes: Internally, within redis system, the `slaveof` and `replicaof` commands will be disabled. 
So the only way to enable it would be changing the configuration 
See next item  - that operator is controllilng `redis-config` config map and  will restore records that prevening HeadCrab Vulnerability.

- Check that `redis-config` config map changes are reverted
    - Edit config map - delete `rename-command REPLICAOF ""` or/and `rename-command SLAVEOF ""`
    ```
    $ oc edit cm redis-config
    ......
    ......
    // delete these lines
      rename-command REPLICAOF ""
      rename-command SLAVEOF ""
    ```
    ```
    $ oc edit cm redis-config
    configmap/redis-config edited
    ```

    - Check configMap and see that these lines are exists (reconsiler reverted configmap) 
    ```
    rename-command REPLICAOF ""
    rename-command SLAVEOF ""
    .....
    Events:  <none>
    $ oc describe cm redis-config
    ```
### Check Upgrade
**Following validation was done**
- Create Images/Indexes for master and for branch of PR

-  Install master ; check that redis-config CM does Not contain rename-command for REPLICAOF and SLAVEOF 
```
$ oc describe cm redis-config |grep rename-com
```
- Do upgrade  and check that Redis configuration was updated, new records added: 
```
$ oc describe cm redis-config |grep rename-com
rename-command REPLICAOF ""
rename-command SLAVEOF ""
```

### Regression testing
**PR does not prevent changes to other settings in the reids configuration (not REPLICAOF or SLAVEOF)**
Make sure it works as expected:  
- edit the `redis-config` configuration map, edit one or more entries/definitions.
- describe the `redis-config` configuration map and make sure the changes are in place.

**Wrong formatting of redis configuration**
In Redis, if the configuration file (redis.conf) contains a setting with an incorrect name or syntax, Redis will typically treat it as an error. Redis expects the configuration file to be correctly formatted with valid configuration directives.    
If there's a typo or an unrecognized setting name in the configuration file, Redis will log an error when starting up. - -- try change one or `rename-command` or other settings name, or add something like`test` in `redis-config` config map.  Expected behavior:

```
$ oc edit cm redis-config
....
    dir /var/lib/redis/data
    xxxrename-command SLAVEOF ""
    xxxrename-command REPLICAOF ""
kind: ConfigMap
metadata:
.......
$ oc edit cm redis-config
configmap/redis-config edited

$ oc get pod |grep redis
backend-redis-6fcbd5964f-tnp7n           0/1     CrashLoopBackOff   1 (5s ago)    6s
system-redis-77bbb6f955-d9nxs            0/1     CrashLoopBackOff   1 (5s ago)    6s

$ oc logs backend-redis-6fcbd5964f-tnp7n
*** FATAL CONFIG FILE ERROR (Redis 6.2.7) ***
Reading the configuration file, at line 47
>>> 'xxxrename-command SLAVEOF ""'
Bad directive or wrong number of arguments
$ 
```
- restore changed settings:
```
    rename-command SLAVEOF ""
    rename-command REPLICAOF ""
kind: ConfigMap
metadata:
  creationTimestamp: "2024-04-08T16:07:40Z"
$ oc edit cm redis-config
configmap/redis-config edited

$ oc get pod |grep redis
backend-redis-59bd88f884-4tvrk           1/1     Running            0             39s
system-redis-549598d55b-nk9lr            1/1     Running            0             38s

```


