### PR TITLE
THREESCALE-10971 fix application creation nil pointer issue

### DIFF
--- a/controllers/capabilities/application_status_reconciler.go
+++ b/controllers/capabilities/application_status_reconciler.go
@@ -70,7 +70,10 @@ func (s *ApplicationStatusReconciler) Reconcile() (reconcile.Result, error) {
 
 func (s *ApplicationStatusReconciler) calculateStatus() *capabilitiesv1beta1.ApplicationStatus {
 	newStatus := &capabilitiesv1beta1.ApplicationStatus{}
-	if s.entity != nil {
+	// if status ID is populated leave unchanged by status update
+	if s.applicationResource.Status.ID != nil {
+		newStatus.ID = s.applicationResource.Status.ID
+	} else if s.entity != nil {
 		tmpID := s.entity.ID()
 		newStatus.ID = &tmpID
 	}

--- a/controllers/capabilities/application_threescale_reconciler.go
+++ b/controllers/capabilities/application_threescale_reconciler.go
@@ -78,10 +78,6 @@ func (t *ApplicationThreescaleReconciler) reconcile3scaleApplication() (*control
 		return -1, false
 	}(applicationList.Applications)
 	var applicationObj *threescaleapi.Application
-	// check if application CR is ready state if not return nil, applications can exist without a validID
-	if t.applicationResource.Status.Conditions.IsFalseFor(capabilitiesv1beta1.ApplicationReadyConditionType) {
-		return nil, nil
-	}
 	if exists {
 		applicationObj = &applicationList.Applications[idx].Application
 	} else {


### PR DESCRIPTION
## Issue
[THREESCALE-10971](https://issues.redhat.com//browse/THREESCALE-10971)

## What
Fix an intermittent nil pointer on application creation

## Verification
Need to repeat a couple of times to verify
- Install this branch to the 3scale-test ns
- Install a product and application via cr you can use [./setup_product](https://github.com/3scale-labs/3scale-perf-setup/blob/main/setup_product.sh)
- confirm the operator doesn't crash
- you can use the script below to clean up the cluster before running a second time
```bash
#!/bin/bash
oc project 3scale-test
oc delete application application-cr --wait=false
oc delete product product1-cr --wait=false
oc delete backend backend1-cr --wait=false
oc delete developeruser developeruser01 --wait=false
oc delete developeraccount developeraccount01 --wait=false
sleep 60
oc delete apimanager apimanager-sample --wait=false
oc delete project 3scale-test --wait=false
```