### PR TITLE
THREESCALE-10670 Update system-sphinx reference in docs to system-searchd

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -834,7 +834,7 @@ APIManager components are the following ones:
 | system-app's system-provider | 50m | 1000m | 600Mi | 800Mi |
 | system-app's system-developer | 50m | 1000m | 600Mi | 800Mi |
 | system-sidekiq | 100m | 1000m  | 500Mi  | 2Gi |
-| system-sphinx | 80m | 1000m | 250Mi | 512Mi |
+| system-searchd | 80m | 1000m | 250Mi | 512Mi |
 | system-redis | 150m | 500m | 256Mi | 32Gi |
 | system-mysql | 250m | No limit | 512Mi | 2Gi |
 | system-postgresql | 250m | No limit | 512Mi | 2Gi |


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10670](https://issues.redhat.com/browse/THREESCALE-10670)

# What
This PR cherry picks the commit that updates the `system-sphinx` entry to instead be `system-searchd` for the Default APIManager components compute resources table. The actual [default resource values](https://github.com/3scale/3scale-operator/blob/ec722ac321dfdc0d9df883edcbd14719680c2dc0/pkg/3scale/amp/component/system_searchd_options.go#L40-L51) are unchanged so this just updates the name in the table.

This change was already merged into master, this PR just cherry picks it to the `3scale-2.14-stable` branch.

# Verification Steps
Passing prow checks and eye review