### PR TITLE
THREESCALE-11117 add a password check on redis uri in the backend, improve url trim to handle all values

### DIFF
--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -743,13 +743,12 @@ spec:
 #### Setting Horizontal Pod Autoscaling 
 Horizontal Pod Autoscaling(HPA) is available for Apicast-production, Backend-listener and Backend-worker. The backend
 components require Redis running [async mode](https://github.com/3scale/apisonator/blob/master/docs/openshift_horizontal_scaling.md#async). 
-Async is enabled by default by the operator provided you aren't using [logical Redis databases](https://github.com/3scale/apisonator/blob/master/docs/openshift_horizontal_scaling.md#redis-databases).
-If you are not running in Async mode you won't be able to enable HPA for the backend.
+Async is enabled by default by the operator.
 
 > **NOTE:** If ResourceRequirementsEnabled is set to false HPA can't function as there are no resources set for it to 
 > compare to.
 
-Provided you are running in Async mode, you can enable hpa for the components and accept the default configuration which
+You can enable hpa for the components and accept the default configuration which
 will give you a HPA with 85% resources set and max and min pods set to 5 and 1. The following is an example of the 
 output HPA for backend-worker using the defaults. 
 

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -21,7 +21,7 @@ func NewBackendReconciler(baseAPIManagerLogicReconciler *BaseAPIManagerLogicReco
 }
 
 func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
-	DisableAsync := "disable-async"
+	disableAsyncAnnotation := "apps.3scale.net/disable-async"
 	ampImages, err := AmpImages(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -55,7 +55,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 	listenerDeploymentMutator := reconcilers.GenericBackendDeploymentMutators()
 	// Check for DisableAsync: true in annotations
 	currentAnnotations := r.apiManager.GetAnnotations()
-	if containsAsyncDisable(currentAnnotations, DisableAsync, "true") {
+	if containsAsyncDisable(currentAnnotations, disableAsyncAnnotation, "true") {
 		listenerDeploymentMutator = append(listenerDeploymentMutator, reconcilers.DeploymentListenerAsyncDisableArgsMutator)
 		listenerDeploymentMutator = append(listenerDeploymentMutator, reconcilers.DeploymentListenerAsyncDisableEnvMutator)
 	} else {
@@ -99,7 +99,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Worker Deployment
 	workerDeploymentMutator := reconcilers.GenericBackendDeploymentMutators()
-	if containsAsyncDisable(currentAnnotations, DisableAsync, "true") {
+	if containsAsyncDisable(currentAnnotations, disableAsyncAnnotation, "true") {
 		workerDeploymentMutator = append(workerDeploymentMutator, reconcilers.DeploymentWorkerDisableAsyncEnvMutator)
 	} else {
 		workerDeploymentMutator = append(workerDeploymentMutator, reconcilers.DeploymentWorkerEnvMutator)
@@ -188,7 +188,7 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	if !containsAsyncDisable(currentAnnotations, DisableAsync, "true") {
+	if !containsAsyncDisable(currentAnnotations, disableAsyncAnnotation, "true") {
 		err = r.ReconcileHpa(component.DefaultHpa(component.BackendListenerName, r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/pkg/3scale/amp/operator/backend_reconciler.go
+++ b/pkg/3scale/amp/operator/backend_reconciler.go
@@ -1,17 +1,11 @@
 package operator
 
 import (
-	"context"
-	"github.com/go-logr/logr"
-	"strings"
-
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	"github.com/3scale/3scale-operator/pkg/upgrade"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -27,6 +21,7 @@ func NewBackendReconciler(baseAPIManagerLogicReconciler *BaseAPIManagerLogicReco
 }
 
 func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
+	DisableAsync := "DisableAsync"
 	ampImages, err := AmpImages(r.apiManager)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -57,14 +52,10 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Listener Deployment
-	RedisQueuesUrl, RedisStorageUrl, RedisQueuesSentinelHost, RedisStorageSentinelHost := GetBackendRedisSecret(r.apiManager.Namespace, r.Context(), r.Client(), r.logger)
-
 	listenerDeploymentMutator := reconcilers.GenericBackendDeploymentMutators()
-	// this checks for logical redis exists
-	// this checks if SentinelHost are configured with passwords
-	if RedisStorageUrl != RedisQueuesUrl && !RedisQueuesSentinelHost && !RedisStorageSentinelHost {
-		// this checks if SentinelHost are configured with passwords
+	// Check for DisableAsync: true in annotations
+	currentAnnotations := r.apiManager.GetAnnotations()
+	if !containsAsyncDisable(currentAnnotations, DisableAsync, "true") {
 		listenerDeploymentMutator = append(listenerDeploymentMutator, reconcilers.DeploymentListenerEnvMutator)
 		listenerDeploymentMutator = append(listenerDeploymentMutator, reconcilers.DeploymentListenerArgsMutator)
 	}
@@ -105,10 +96,9 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 
 	// Worker Deployment
 	workerDeploymentMutator := reconcilers.GenericBackendDeploymentMutators()
-	if RedisStorageUrl != RedisQueuesUrl && !RedisQueuesSentinelHost && !RedisStorageSentinelHost {
+	if !containsAsyncDisable(currentAnnotations, DisableAsync, "true") {
 		workerDeploymentMutator = append(workerDeploymentMutator, reconcilers.DeploymentWorkerEnvMutator)
 	}
-
 	if r.apiManager.Spec.Backend.WorkerSpec.Replicas != nil {
 		workerDeploymentMutator = append(workerDeploymentMutator, reconcilers.DeploymentReplicasMutator)
 	}
@@ -192,20 +182,16 @@ func (r *BackendReconciler) Reconcile() (reconcile.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if RedisStorageUrl != RedisQueuesUrl && !RedisQueuesSentinelHost && !RedisStorageSentinelHost {
+
+	if !containsAsyncDisable(currentAnnotations, DisableAsync, "true") {
 		err = r.ReconcileHpa(component.DefaultHpa(component.BackendListenerName, r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+
 		err = r.ReconcileHpa(component.DefaultHpa(component.BackendWorkerName, r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
 		if err != nil {
 			return reconcile.Result{}, err
-		}
-	} else {
-		// set log message if logical redis db are detected in the backend
-		if r.apiManager.Spec.Backend.ListenerSpec.Hpa || r.apiManager.Spec.Backend.WorkerSpec.Hpa {
-			message := "logical redis instances or SentinelHost with authentication found in the backend, which is blocking redis async mode, horizontal pod autoscaling for backend cannot be enabled without async mode"
-			r.logger.Info(message)
 		}
 	}
 
@@ -221,20 +207,9 @@ func Backend(apimanager *appsv1alpha1.APIManager, client client.Client) (*compon
 	return component.NewBackend(opts), nil
 }
 
-func GetBackendRedisSecret(apimanagerNs string, ctx context.Context, client client.Client, logger logr.Logger) (string, string, bool, bool) {
-	backendRedisSecret := &v1.Secret{}
-	err := client.Get(ctx, types.NamespacedName{
-		Name:      "backend-redis",
-		Namespace: apimanagerNs,
-	}, backendRedisSecret)
-	if err != nil {
-		logger.Error(err, "Failed to get system-redis secret, can't check logical databases or authenticated redis sentinels, check the backend-redis secret exists")
-		return "", "", false, false
+func containsAsyncDisable(m map[string]string, key, value string) bool {
+	if v, ok := m[key]; ok {
+		return v == value
 	}
-	RedisQueuesUrl := strings.TrimSuffix(string(backendRedisSecret.Data["REDIS_QUEUES_URL"]), "1")
-	RedisStorageUrl := strings.TrimSuffix(string(backendRedisSecret.Data["REDIS_STORAGE_URL"]), "0")
-	RedisQueuesSentinelHost := strings.Contains(string(backendRedisSecret.Data["REDIS_QUEUES_SENTINEL_HOSTS"]), "@")
-	RedisStorageSentinelHost := strings.Contains(string(backendRedisSecret.Data["REDIS_STORAGE_SENTINEL_HOSTS"]), "@")
-
-	return RedisQueuesUrl, RedisStorageUrl, RedisQueuesSentinelHost, RedisStorageSentinelHost
+	return false
 }

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"reflect"
 
 	"github.com/google/go-cmp/cmp"
@@ -346,6 +347,59 @@ func DeploymentListenerArgsMutator(_, existing *k8sappsv1.Deployment) (bool, err
 	update = false
 	return update, nil
 }
+func DeploymentListenerAsyncDisableArgsMutator(_, existing *k8sappsv1.Deployment) (bool, error) {
+	update := true
+	falconArgs := []string{"bin/3scale_backend", "start", "-e", "production", "-p", "3000", "-x", "/dev/stdout"}
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Args, falconArgs) {
+		existing.Spec.Template.Spec.Containers[0].Args = falconArgs
+		return update, nil
+	}
+	update = false
+	return update, nil
+}
+
+func DeploymentListenerAsyncDisableEnvMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	update := false
+	updateListenerWorkers := true
+	updateConfigRedisAsync := true
+	// This may be redundant as operator crashes if LISTENER_WORKERS=0
+	// Update LISTENER_WORKERS and CONFIG_REDIS_ASYNC to 1 if found
+	for envId, envVar := range existing.Spec.Template.Spec.Containers[0].Env {
+		if envVar.Name == "LISTENER_WORKERS" {
+			updateListenerWorkers = false
+			if envVar.Value == "1" {
+				existing.Spec.Template.Spec.Containers[0].Env = removeEnvVar(existing.Spec.Template.Spec.Containers[0].Env, "LISTENER_WORKERS")
+				update = true
+			}
+		}
+		if envVar.Name == "CONFIG_REDIS_ASYNC" {
+			updateConfigRedisAsync = false
+			if envVar.Value == "1" {
+				existing.Spec.Template.Spec.Containers[0].Env[envId].Value = "0"
+				update = true
+			}
+		}
+		if update {
+			return update, nil
+		}
+	}
+	// if either updateListenerWorkers or updateConfigRedisAsync is true then proceed to the append logic
+	// to add the env var LISTENER_WORKERS and CONFIG_REDIS_ASYNC
+	if updateListenerWorkers || updateConfigRedisAsync {
+		update = true
+	} else {
+		update = false
+	}
+	if updateConfigRedisAsync {
+		existing.Spec.Template.Spec.Containers[0].Env = append(existing.Spec.Template.Spec.Containers[0].Env,
+			helper.EnvVarFromValue("CONFIG_REDIS_ASYNC", "0"))
+	}
+	if updateListenerWorkers {
+		existing.Spec.Template.Spec.Containers[0].Env = removeEnvVar(existing.Spec.Template.Spec.Containers[0].Env, "LISTENER_WORKERS")
+	}
+
+	return update, nil
+}
 
 func DeploymentListenerEnvMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
 	update := false
@@ -412,4 +466,36 @@ func DeploymentWorkerEnvMutator(desired, existing *k8sappsv1.Deployment) (bool, 
 			helper.EnvVarFromValue("CONFIG_REDIS_ASYNC", "1"))
 	}
 	return update, nil
+}
+
+func DeploymentWorkerDisableAsyncEnvMutator(desired, existing *k8sappsv1.Deployment) (bool, error) {
+	update := true
+	// Always set env var CONFIG_REDIS_ASYNC to 1 this logic is only hit when you don't have logical redis db
+	for envId, envVar := range existing.Spec.Template.Spec.Containers[0].Env {
+		if envVar.Name == "CONFIG_REDIS_ASYNC" {
+			if envVar.Value == "1" {
+				existing.Spec.Template.Spec.Containers[0].Env[envId].Value = "0"
+				update = true
+				return update, nil
+			}
+			update = false
+
+		}
+	}
+	// Adds the env CONFIG_REDIS_ASYNC if not present
+	if update {
+		existing.Spec.Template.Spec.Containers[0].Env = append(existing.Spec.Template.Spec.Containers[0].Env,
+			helper.EnvVarFromValue("CONFIG_REDIS_ASYNC", "0"))
+	}
+	return update, nil
+}
+
+func removeEnvVar(envVars []corev1.EnvVar, name string) []corev1.EnvVar {
+	var newEnvVars []corev1.EnvVar
+	for _, envVar := range envVars {
+		if envVar.Name != name {
+			newEnvVars = append(newEnvVars, envVar)
+		}
+	}
+	return newEnvVars
 }


### PR DESCRIPTION
## Issue
[THREESCALE-11117](https://issues.redhat.com//browse/THREESCALE-11117)

## What 
add a password check on redis uri in the backend to disable async if detected, 
improve url trim to handle all values

## Verification
- install the operator locally
```bash
make install
# get the domain name
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
# add the apimanger cr
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
# set the s3 secret
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Once installed check the env vars on the backend-worker `CONFIG_REDIS_ASYNC=1`
```bash
oc get deployment backend-worker -o json | jq -r '.spec.template.spec.containers[].env[] | "\(.name)=\(.value)"' | grep ASYNC
CONFIG_REDIS_ASYNC=1
```
- check the env vars on the backend listener `CONFIG_REDIS_ASYNC=1`&`LISTENER_WORKERS=1`
```bash
oc get deployment backend-listener -o json | jq -r '.spec.template.spec.containers[].env[] | "\(.name)=\(.value)"' | grep ASYNC
CONFIG_REDIS_ASYNC=1
oc get deployment backend-listener -o json | jq -r '.spec.template.spec.containers[].env[] | "\(.name)=\(.value)"' | grep LISTENER_WORKERS
LISTENER_WORKERS=1
```
- check the args equal 
```bash
oc get deployment backend-listener -o json | jq -r '.spec.template.spec.containers[].args[]'
bin/3scale_backend
-s
falcon
start
-e
production
-p
3000
-x
/dev/stdout
```
### apps.3scale.net/disable-async annotation
- set the `apps.3scale.net/disable-async: "true"` in the apimanager CR

- Once update has completed check the env vars on the backend-worker `CONFIG_REDIS_ASYNC=0`
```bash
oc get deployment backend-worker -o json | jq -r '.spec.template.spec.containers[].env[] | "\(.name)=\(.value)"' | grep ASYNC
CONFIG_REDIS_ASYNC=0
```
- check the env vars on the backend listener `CONFIG_REDIS_ASYNC=0`& the `LISTENER_WORKERS=1` has been removed
```bash
oc get deployment backend-listener -o json | jq -r '.spec.template.spec.containers[].env[] | "\(.name)=\(.value)"' | grep ASYNC
CONFIG_REDIS_ASYNC=0
oc get deployment backend-listener -o json | jq -r '.spec.template.spec.containers[].env[] | "\(.name)=\(.value)"' | grep LISTENER_WORKERS
```
- check the args equal 
```bash
oc get deployment backend-listener -o json | jq -r '.spec.template.spec.containers[].args[]'
bin/3scale_backend
start
-e
production
-p
3000
-x
/dev/stdout

```


