### PR TITLE
THREESCALE-11119 OAS extension support for products

### DIFF
--- a/controllers/capabilities/openapi_controller_test.go
+++ b/controllers/capabilities/openapi_controller_test.go
@@ -1,0 +1,327 @@
+package controllers
+
+import (
+	"context"
+	"github.com/3scale/3scale-operator/pkg/helper"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"reflect"
+	"testing"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestOpenAPIReconciler_validateOASExtensions(t *testing.T) {
+	productExtensionPath := field.NewPath("x-3scale-product")
+	metricsExtensionPath := productExtensionPath.Child("metrics")
+	policiesExtensionPath := productExtensionPath.Child("policies")
+
+	type fields struct {
+		BaseReconciler *reconcilers.BaseReconciler
+	}
+	type args struct {
+		openapiObj *openapi3.T
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   error
+	}{
+		{
+			name: "valid OAS",
+			fields: fields{
+				BaseReconciler: getBaseReconciler(getOpenAPICR(), getValidOpenAPISecret()),
+			},
+			args: args{
+				openapiObj: getOpenAPIObj(getValidOpenAPISecret()),
+			},
+			want: nil,
+		},
+		{
+			name: "unextended OAS",
+			fields: fields{
+				BaseReconciler: getBaseReconciler(getOpenAPICR(), getUnextendedOpenAPISecret()),
+			},
+			args: args{
+				openapiObj: getOpenAPIObj(getUnextendedOpenAPISecret()),
+			},
+			want: nil,
+		},
+		{
+			name: "bad OAS",
+			fields: fields{
+				BaseReconciler: getBaseReconciler(getOpenAPICR(), getBadExtendedOpenAPISecret()),
+			},
+			args: args{
+				openapiObj: getOpenAPIObj(getBadExtendedOpenAPISecret()),
+			},
+			want: &helper.SpecFieldError{
+				ErrorType: helper.InvalidError,
+				FieldErrorList: field.ErrorList{
+					{
+						Type:     field.ErrorTypeRequired,
+						Field:    metricsExtensionPath.String(),
+						BadValue: "",
+						Detail:   "metric metric01 is missing a friendlyName",
+					},
+					{
+						Type:     field.ErrorTypeRequired,
+						Field:    metricsExtensionPath.String(),
+						BadValue: "",
+						Detail:   "metric metric01 is missing a unit",
+					},
+					{
+						Type:     field.ErrorTypeRequired,
+						Field:    policiesExtensionPath.String(),
+						BadValue: "",
+						Detail:   "one or more policies are missing a name",
+					},
+					{
+						Type:     field.ErrorTypeRequired,
+						Field:    policiesExtensionPath.String(),
+						BadValue: "",
+						Detail:   "policy  is missing a version",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &OpenAPIReconciler{
+				BaseReconciler: tt.fields.BaseReconciler,
+			}
+			got := r.validateOASExtensions(tt.args.openapiObj)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("validateOASExtensions() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func getTestBaseReconciler(objects ...runtime.Object) (baseReconciler *reconcilers.BaseReconciler) {
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	err := capabilitiesv1beta1.AddToScheme(s)
+	if err != nil {
+		panic(err)
+	}
+	err = appsv1alpha1.AddToScheme(s)
+	if err != nil {
+		panic(err)
+	}
+	err = corev1.AddToScheme(s)
+	if err != nil {
+		panic(err)
+	}
+
+	var clientObjects []client.Object
+	if objects != nil {
+		for _, o := range objects {
+			co, ok := o.(client.Object)
+			if ok {
+				clientObjects = append(clientObjects, co)
+			}
+		}
+	}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).WithStatusSubresource(clientObjects...).Build()
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+	baseReconciler = reconcilers.NewBaseReconciler(context.TODO(), cl, s, cl, getOpenAPITestLogger(), clientset.Discovery(), recorder)
+	return baseReconciler
+}
+
+func getOpenAPITestLogger() logr.Logger {
+	return logf.Log.WithName("openapi_product_reconciler_test")
+}
+
+func getOpenAPICR() *capabilitiesv1beta1.OpenAPI {
+	return &capabilitiesv1beta1.OpenAPI{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testCR",
+			Namespace: "testNamespace",
+		},
+		Spec: capabilitiesv1beta1.OpenAPISpec{
+			OpenAPIRef: capabilitiesv1beta1.OpenAPIRefSpec{
+				SecretRef: &corev1.ObjectReference{
+					Name:      "testOpenAPISecret",
+					Namespace: "testNamespace",
+				},
+			},
+		},
+	}
+}
+
+func getOpenAPIObj(openAPISecret *corev1.Secret) *openapi3.T {
+	openAPIReconciler := OpenAPIReconciler{
+		BaseReconciler: getTestBaseReconciler(openAPISecret),
+	}
+
+	openapiObj, err := openAPIReconciler.readOpenAPI(getOpenAPICR())
+	if err != nil {
+		panic(err)
+	}
+	return openapiObj
+}
+
+func getValidOpenAPISecret() *corev1.Secret {
+	secretData := `
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      x-3scale-operation:
+        mappingRule:
+          metricMethodRef: "metric01"
+          increment: 2
+          last: true
+      responses:
+        '200':
+          description: A paged array of pets
+x-3scale-product:
+  metrics:
+    metric01:
+      friendlyName: "My Metric 01"
+      unit: "hits"
+      description: "This is a custom metric"
+  policies:
+    - name: "myPolicy1"
+      version: "0.1"
+      enabled: true
+      configuration:
+        http_proxy: http://example.com
+    - name: "myPolicy2"
+      version: "2.0"
+      enabled: true
+      configurationRef:
+        name: "my-config-policy-secret"
+        namespace: "testNamespace"
+  applicationPlans:
+    plan01:
+      name: "My Plan 01"
+      appsRequireApproval: false
+      trialPeriod: 1
+      setupFee: "1.00"
+      costMonth: "1.00"
+      pricingRules:
+        - from: 1
+          to: 100
+          pricePerUnit: "1.00"
+          metricMethodRef:
+            systemName: "metric01"
+      limits:
+        - period: "week"
+          value: 100
+          metricMethodRef:
+            systemName: "hits"
+            backend: "Swagger_Petstore"
+`
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testOpenAPISecret",
+			Namespace: "testNamespace",
+		},
+		Data: map[string][]byte{
+			"oas": []byte(secretData),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+func getUnextendedOpenAPISecret() *corev1.Secret {
+	secretData := `
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        '200':
+          description: A paged array of pets
+`
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testOpenAPISecret",
+			Namespace: "testNamespace",
+		},
+		Data: map[string][]byte{
+			"oas": []byte(secretData),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+func getBadExtendedOpenAPISecret() *corev1.Secret {
+	secretData := `
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        '200':
+          description: A paged array of pets
+x-3scale-product:
+  metrics:
+    metric01:
+      description: "This is a custom metric"
+  policies:
+    - enabled: true
+      configuration:
+        http_proxy: http://example.com
+`
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testOpenAPISecret",
+			Namespace: "testNamespace",
+		},
+		Data: map[string][]byte{
+			"oas": []byte(secretData),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}

--- a/controllers/capabilities/openapi_product_reconciler_test.go
+++ b/controllers/capabilities/openapi_product_reconciler_test.go
@@ -1,0 +1,323 @@
+package controllers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	"testing"
+
+	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+	controllerhelper "github.com/3scale/3scale-operator/pkg/controller/helper"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-logr/logr"
+)
+
+func TestOpenAPIProductReconciler_desiredMappingRules(t *testing.T) {
+	trueVal := true
+
+	type fields struct {
+		BaseReconciler  *reconcilers.BaseReconciler
+		openapiCR       *capabilitiesv1beta1.OpenAPI
+		openapiObj      *openapi3.T
+		providerAccount *controllerhelper.ProviderAccount
+		logger          logr.Logger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []capabilitiesv1beta1.MappingRuleSpec
+		wantErr bool
+	}{
+		{
+			name: "valid OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getValidOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getValidOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want: []capabilitiesv1beta1.MappingRuleSpec{
+				{
+					HTTPMethod:      "GET",
+					Pattern:         "/v1/pets$",
+					MetricMethodRef: "metric01",
+					Increment:       2,
+					Last:            &trueVal,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unextended OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getUnextendedOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getUnextendedOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want: []capabilitiesv1beta1.MappingRuleSpec{
+				{
+					HTTPMethod:      "GET",
+					Pattern:         "/v1/pets$",
+					MetricMethodRef: "listpets", // Defaults to OAS.paths[/pets].get.operationId when not extended
+					Increment:       1,          // Defaults to 1 when not extended
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OpenAPIProductReconciler{
+				BaseReconciler:  tt.fields.BaseReconciler,
+				openapiCR:       tt.fields.openapiCR,
+				openapiObj:      tt.fields.openapiObj,
+				providerAccount: tt.fields.providerAccount,
+				logger:          tt.fields.logger,
+			}
+			got, err := p.desiredMappingRules()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("desiredMappingRules() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("desiredMappingRules() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAPIProductReconciler_desiredMetrics(t *testing.T) {
+	type fields struct {
+		BaseReconciler  *reconcilers.BaseReconciler
+		openapiCR       *capabilitiesv1beta1.OpenAPI
+		openapiObj      *openapi3.T
+		providerAccount *controllerhelper.ProviderAccount
+		logger          logr.Logger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    map[string]capabilitiesv1beta1.MetricSpec
+		wantErr bool
+	}{
+		{
+			name: "valid OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getValidOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getValidOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want: map[string]capabilitiesv1beta1.MetricSpec{
+				"metric01": {
+					Name:        "My Metric 01",
+					Unit:        "hits",
+					Description: "This is a custom metric",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unextended OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getUnextendedOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getUnextendedOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want:    make(map[string]capabilitiesv1beta1.MetricSpec), // Expect empty map
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OpenAPIProductReconciler{
+				BaseReconciler:  tt.fields.BaseReconciler,
+				openapiCR:       tt.fields.openapiCR,
+				openapiObj:      tt.fields.openapiObj,
+				providerAccount: tt.fields.providerAccount,
+				logger:          tt.fields.logger,
+			}
+			got, err := p.desiredMetrics()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("desiredMetrics() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("desiredMetrics() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAPIProductReconciler_desiredPolicies(t *testing.T) {
+	type fields struct {
+		BaseReconciler  *reconcilers.BaseReconciler
+		openapiCR       *capabilitiesv1beta1.OpenAPI
+		openapiObj      *openapi3.T
+		providerAccount *controllerhelper.ProviderAccount
+		logger          logr.Logger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []capabilitiesv1beta1.PolicyConfig
+		wantErr bool
+	}{
+		{
+			name: "valid OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getValidOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getValidOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want: []capabilitiesv1beta1.PolicyConfig{
+				{
+					Name:    "myPolicy1",
+					Version: "0.1",
+					Enabled: true,
+					Configuration: runtime.RawExtension{
+						Raw: []byte("{\"http_proxy\":\"http://example.com\"}"),
+					},
+				},
+				{
+					Name:    "myPolicy2",
+					Version: "2.0",
+					Enabled: true,
+					ConfigurationRef: corev1.SecretReference{
+						Name:      "my-config-policy-secret",
+						Namespace: "testNamespace",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unextended OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getUnextendedOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getUnextendedOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want:    nil, // Expect empty list
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OpenAPIProductReconciler{
+				BaseReconciler:  tt.fields.BaseReconciler,
+				openapiCR:       tt.fields.openapiCR,
+				openapiObj:      tt.fields.openapiObj,
+				providerAccount: tt.fields.providerAccount,
+				logger:          tt.fields.logger,
+			}
+			got, err := p.desiredPolicies()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("desiredPolicies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("desiredPolicies() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAPIProductReconciler_desiredApplicationPlans(t *testing.T) {
+	planName := "My Plan 01"
+	planAppsRequireApproval := false
+	planTrialPeriod := 1
+	planSetupPrice := "1.00"
+	planBackendSystemName := "Swagger_Petstore"
+
+	type fields struct {
+		BaseReconciler  *reconcilers.BaseReconciler
+		openapiCR       *capabilitiesv1beta1.OpenAPI
+		openapiObj      *openapi3.T
+		providerAccount *controllerhelper.ProviderAccount
+		logger          logr.Logger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    map[string]capabilitiesv1beta1.ApplicationPlanSpec
+		wantErr bool
+	}{
+		{
+			name: "valid OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getValidOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getValidOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want: map[string]capabilitiesv1beta1.ApplicationPlanSpec{
+				"plan01": {
+					Name:                &planName,
+					AppsRequireApproval: &planAppsRequireApproval,
+					TrialPeriod:         &planTrialPeriod,
+					SetupFee:            &planSetupPrice,
+					CostMonth:           &planSetupPrice,
+					PricingRules: []capabilitiesv1beta1.PricingRuleSpec{
+						{
+							From: 1,
+							To:   100,
+							MetricMethodRef: capabilitiesv1beta1.MetricMethodRefSpec{
+								SystemName: "metric01",
+							},
+							PricePerUnit: planSetupPrice,
+						},
+					},
+					Limits: []capabilitiesv1beta1.LimitSpec{
+						{
+							Period: "week",
+							Value:  100,
+							MetricMethodRef: capabilitiesv1beta1.MetricMethodRefSpec{
+								SystemName:        "hits",
+								BackendSystemName: &planBackendSystemName,
+							},
+						},
+					},
+					Published: nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unextended OAS",
+			fields: fields{
+				BaseReconciler: getTestBaseReconciler(getOpenAPICR(), getUnextendedOpenAPISecret()),
+				openapiCR:      getOpenAPICR(),
+				openapiObj:     getOpenAPIObj(getUnextendedOpenAPISecret()),
+				logger:         getOpenAPITestLogger(),
+			},
+			want:    make(map[string]capabilitiesv1beta1.ApplicationPlanSpec), // Expect empty map
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OpenAPIProductReconciler{
+				BaseReconciler:  tt.fields.BaseReconciler,
+				openapiCR:       tt.fields.openapiCR,
+				openapiObj:      tt.fields.openapiObj,
+				providerAccount: tt.fields.providerAccount,
+				logger:          tt.fields.logger,
+			}
+			got, err := p.desiredApplicationPlans()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("desiredApplicationPlans() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("desiredApplicationPlans() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/doc/openapi-3scale-extensions.md
+++ b/doc/openapi-3scale-extensions.md
@@ -1,0 +1,71 @@
+# OpenAPI 3.0.x 3scale Extensions
+
+This reference information shows examples of how to add 3scale extensions at the root, path, or operation level in an OpenAPI 3.0.x definition.
+
+## Root-level 3scale extension
+
+You can optionally add a 3scale extension at the root level of an OpenAPI definition to add custom metrics, policies, and application plans to a product. 
+
+The `metrics` block adheres to the [MetricSpec](https://github.com/3scale/3scale-operator/blob/master/doc/product-reference.md#metricspec), the `policies` block adheres to the [PolicyConfigSpec](https://github.com/3scale/3scale-operator/blob/master/doc/product-reference.md#policyconfigspec), the `applicationPlans` block adheres to the [ApplicationPlanSpec](https://github.com/3scale/3scale-operator/blob/master/doc/product-reference.md#applicationplanspec), the `pricingRules` block adheres to the [PricingRuleSpec](https://github.com/3scale/3scale-operator/blob/master/doc/product-reference.md#PricingRuleSpec), and the `limits` block adheres to the [LimitSpec](https://github.com/3scale/3scale-operator/blob/master/doc/product-reference.md#LimitSpec).
+
+The following example shows an extension to configure custom policies and application plans:
+
+```yaml
+x-3scale-product:
+  metrics:  ## map[string]github.com/3scale/3scale-operator/apis/capabilities/v1beta1.MetricSpec
+    metric01:  ## This system name needs to be unique across all methods AND metrics
+      friendlyName: "My Metric 01"
+      unit: "hits"
+      description: "This is a custom metric"
+  policies:  ## []github.com/3scale/3scale-operator/apis/capabilities/v1beta1.PolicyConfig
+    - name: "myPolicy1"
+      version: "0.1"
+      enabled: true
+      configuration:
+        http_proxy: http://example.com
+        https_proxy: https://example.com
+    - name: "myPolicy2"
+      version: "2.0"
+      enabled: true
+      configurationRef:
+        name: "my-config-policy-secret"
+        namespace: "my-3scale-namespace"
+  applicationPlans:  ## map[string]github.com/3scale/3scale-operator/apis/capabilities/v1beta1.ApplicationPlanSpec
+    plan01:
+      name: "My Plan 01"
+      appsRequireApproval: false
+      trialPeriod: 3
+      setupFee: "3.00"
+      costMonth: "2.00"
+      pricingRules:  ## []github.com/3scale/3scale-operator/apis/capabilities/v1beta1.PricingRuleSpec
+        - from: 1
+          to: 100
+          pricePerUnit: "0.05"
+          metricMethodRef:
+            systemName: "metric01"
+      limits:  ## []github.com/3scale/3scale-operator/apis/capabilities/v1beta1.LimitSpec
+        - period: "week"
+          value: 100
+          metricMethodRef:
+            systemName: "hits"
+            backend: "backendA"
+```
+
+## Operation-level 3scale extension
+
+You can optionally add a 3scale extension at the operation level of an OpenAPI definition to specify additional fields for a mapping rule.
+The `mappingRule` fields listed in the example below (`metricMethodRef`, `increment`, and `last`) adhere to the [MappingRuleSpec](https://github.com/3scale/3scale-operator/blob/master/doc/product-reference.md#mappingrulespec).
+
+The following example shows an extension added for a `get` operation for a `petstore` app:
+
+```yaml
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      x-3scale-operation:  ## Operation-level 3scale extension
+        mappingRule:
+          metricMethodRef: "metric01"  ## Optional. If let unset, metricMethodRef will be set to the operationId by default.
+          increment: 2
+          last: true
+```

--- a/doc/openapi-user-guide.md
+++ b/doc/openapi-user-guide.md
@@ -1,6 +1,6 @@
 # OpenAPI Custom Resource
 
-The [OpenAPI CRD](openapi-reference.md) is used as the source of truth to reconciliate
+The [OpenAPI CRD](openapi-reference.md) is used as the source of truth to reconcile
 one [3scale Product custom resource](product-reference.md) and
 one [3scale Backend custom resource](backend-reference.md).
 
@@ -22,6 +22,7 @@ one [3scale Backend custom resource](backend-reference.md).
       * [3scale Mapping Rules](#3scale-mapping-rules)
       * [Authentication](#authentication)
       * [ActiveDocs](#activedocs)
+      * [3scale Application Plans](#3scale-application-plans)
       * [3scale Product Policy Chain](#3scale-product-policy-chain)
       * [3scale Deployment Mode](#3scale-deployment-mode)
    * [Minimum required OAS doc](#minimum-required-oas-doc)
@@ -272,14 +273,19 @@ of the [OpenAPI CRD](openapi-reference.md).
 Each OpenAPI defined operation will translate in one 3scale method at product level.
 The method name is read from the [operationId](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#operationObject) field of the operation object.
 
+### 3scale Metrics
+
+The default `Hits` metric will be assigned to the OAS-generated Product CR by default however custom metrics can be created and assigned using [OAS 3scale extensions](openapi-3scale-extensions.md#root-level-3scale-extension).
+
 ### 3scale Mapping Rules
 
 Each OpenAPI defined operation will translate in one 3scale mapping rule at product level.
 Previously existing mapping rules will be replaced by those imported from the OpenAPI.
 
-OpenAPI [paths](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#pathsObject) object provides mapping rules *Verb* and *Pattern* properties. 3scale methods will be associated accordingly to the [operationId](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#operationObject)
+OpenAPI [paths](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#pathsObject) object provides mapping rules *Verb* and *Pattern* properties. 3scale methods will be associated accordingly to the [operationId](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#operationObject).
+The mapping rule can be associated with custom methods/metrics using [OAS 3scale extensions](openapi-3scale-extensions.md#operation-level-3scale-extension).
 
-*Delta* value is hard-coded to `1`.
+*Delta* value is hard-coded to `1`. This can be set to an arbitrary value using [OAS 3scale extensions](openapi-3scale-extensions.md#operation-level-3scale-extension)
 
 By default, *Strict matching* policy is being configured.
 Matching policy can be switched to **Prefix matching** using the `spec.PrefixMatching` field
@@ -322,9 +328,14 @@ When OpenAPI does not specify any security requirements:
 
 No 3scale ActiveDoc is created.
 
+### 3scale Application Plans
+
+Custom application plans can be added to the product using [OAS 3scale extensions](openapi-3scale-extensions.md#root-level-3scale-extension).
+
 ### 3scale Product Policy Chain
 
 3scale policy chain will be the default one created by 3scale.
+This can be overridden with a custom policy chain using [OAS 3scale extensions](openapi-3scale-extensions.md#root-level-3scale-extension).
 
 ### 3scale Deployment Mode
 


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-11119](https://issues.redhat.com/browse/THREESCALE-11119)

# What
This PR adds support for [OAS extensions](https://swagger.io/docs/specification/openapi-extensions/) as defined in the proposed [OpenAPI 3scale Extensions](https://github.com/carlkyrillos/3scale-operator/blob/THREESCALE-11119/doc/openapi-3scale-extensions.md) doc. The extensions allow users to define `ApplicationPlans`, `Policies`, `Metrics`, and more `MappingRule` fields in a Product CR created using OpenAPI.

# Verification Steps
1. Checkout this PR

2. Run the operator locally or via OLM using prebuilt image
```bash
BUNDLE_IMG=quay.io/ckyrillo/3scale-operator-bundles:threescale-11119 make bundle-run
```

3. Create a Namespace, dummy s3 Secret, and APIManager CR:
```bash
export NAMESPACE=3scale-test
oc new-project $NAMESPACE
cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```

4. Wait for the install to complete:
```bash
oc get apimanager 3scale -n 3scale-test -oyaml -w
```

5. Create the _unextended_ OAS Secret:
<details>

```bash
touch unextended-oas-secret-data.yaml

cat << EOF > unextended-oas-secret-data.yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Unextended Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      responses:
        '200':
          description: A paged array of pets
EOF

oc create secret generic unextended-oas-secret --from-file unextended-oas-secret-data.yaml
```
</details>

6. Create the _extended_ OAS Secret:
<details>

```bash
touch extended-oas-secret-data.yaml

cat << EOF > extended-oas-secret-data.yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Extended Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      x-3scale-operation:
        mappingRule:
          metricMethodRef: "metric01"
          increment: 2
          last: true
      responses:
        '200':
          description: A paged array of pets
x-3scale-product:
  metrics:
    metric01:
      friendlyName: "My Metric 01"
      unit: "hits"
      description: "This is a custom metric"
  policies:
    - name: "myPolicy1"
      version: "0.1"
      enabled: true
      configuration:
        http_proxy: http://example.com
        https_proxy: https://example.com
    - name: "myPolicy2"
      version: "2.0"
      enabled: true
      configurationRef:
        name: "dummy-policy-config-secret"
        namespace: "3scale-test"
  applicationPlans:
    plan01:
      name: "My Plan 01"
      appsRequireApproval: false
      trialPeriod: 3
      setupFee: "3.00"
      costMonth: "2.00"
      pricingRules:
        - from: 1
          to: 100
          pricePerUnit: "0.05"
          metricMethodRef:
            systemName: "metric01"
      limits:
        - period: "week"
          value: 100
          metricMethodRef:
            systemName: "hits"
            backend: "Extended_Petstore"
EOF

oc create secret generic extended-oas-secret --from-file extended-oas-secret-data.yaml
```
</details>

7. Create a dummy Proxy config Secret:
```bash
cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: dummy-policy-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  configuration: '{}'
EOF
```

8. Create the _unextended_ OpenAPI CR:
```bash
cat << EOF | oc create -f -
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: unextended-oas
spec:
  openapiRef:
    secretRef:
      name: unextended-oas-secret
EOF
```

9. Verify that the _unextended_ OpenAPI CR is ready:
```bash
oc get openapi unextended-oas -oyaml |  yq e '.status.conditions[] | select(.type == "Ready")'
```

10. Verify that the _unextended_ Product CR's `.spec` matches the expected value:

<details>

```
$ oc get product $(oc get products | grep unextended | awk '{print $1}') -oyaml | yq '.spec'

backendUsages:
  Unextended_Petstore:
    path: /
deployment:
  apicastHosted:
    authentication:
      userkey: {}
mappingRules:
  - httpMethod: GET
    increment: 1
    metricMethodRef: listpets
    pattern: /v1/pets$
methods:
  listpets:
    friendlyName: listPets
metrics:
  hits:
    description: Number of API hits
    friendlyName: Hits
    unit: hit
name: Unextended Petstore
policies:
  - configuration: {}
    configurationRef: {}
    enabled: true
    name: apicast
    version: builtin
systemName: Unextended_Petstore
```
</details>

11. Create the _extended_ OpenAPI CR:
```bash
cat << EOF | oc create -f -
apiVersion: capabilities.3scale.net/v1beta1
kind: OpenAPI
metadata:
  name: extended-oas
spec:
  openapiRef:
    secretRef:
      name: extended-oas-secret
EOF
```

12. Verify that the _extended_ OpenAPI CR is ready:
```bash
oc get openapi extended-oas -oyaml |  yq e '.status.conditions[] | select(.type == "Ready")'
```

13. Verify that the _extended_ Product CR's `.spec` matches the expected value:

<details>

```
$ oc get product $(oc get products | grep -w extendedpetstore | awk '{print $1}') -oyaml | yq '.spec'

applicationPlans:
  plan01:
    appsRequireApproval: false
    costMonth: "2.00"
    limits:
      - metricMethodRef:
          backend: Extended_Petstore
          systemName: hits
        period: week
        value: 100
    name: My Plan 01
    pricingRules:
      - from: 1
        metricMethodRef:
          systemName: metric01
        pricePerUnit: "0.05"
        to: 100
    setupFee: "3.00"
    trialPeriod: 3
backendUsages:
  Extended_Petstore:
    path: /
deployment:
  apicastHosted:
    authentication:
      userkey: {}
mappingRules:
  - httpMethod: GET
    increment: 2
    last: true
    metricMethodRef: metric01
    pattern: /v1/pets$
methods:
  listpets:
    friendlyName: listPets
metrics:
  hits:
    description: Number of API hits
    friendlyName: Hits
    unit: hit
  metric01:
    description: This is a custom metric
    friendlyName: My Metric 01
    unit: hits
name: Extended Petstore
policies:
  - configuration:
      http_proxy: http://example.com
      https_proxy: https://example.com
    configurationRef: {}
    enabled: true
    name: myPolicy1
    version: "0.1"
  - configuration: {}
    configurationRef:
      name: dummy-policy-config-secret
      namespace: 3scale-test
    enabled: true
    name: myPolicy2
    version: "2.0"
  - configuration: {}
    configurationRef: {}
    enabled: true
    name: apicast
    version: builtin
systemName: Extended_Petstore
```
</details>