### PR TITLE
THREESCALE-11208 add logging to version checks

### DIFF
--- a/controllers/apps/apimanager_controller.go
+++ b/controllers/apps/apimanager_controller.go
@@ -230,19 +230,19 @@ func (r *APIManagerReconciler) PreflightChecks(apimInstance *appsv1alpha1.APIMan
 	if !systemRedisVerified {
 		systemRedisVerified, err = helper.VerifySystemRedis(r.Client(), reqConfigMap, systemRedisRequirement, apimInstance, logger)
 		if err != nil {
-			return ctrl.Result{}, err, nil
+			return ctrl.Result{RequeueAfter: time.Minute * 10}, nil, fmt.Errorf("Failed to verify system redis version. Ensure that the system-redis secret is correctly configured. Error: %s", err)
 		}
 	}
 	if !backendRedisVerified {
 		backendRedisVerified, err = helper.VerifyBackendRedis(r.Client(), reqConfigMap, backendRedisRequirement, apimInstance, logger)
 		if err != nil {
-			return ctrl.Result{}, err, nil
+			return ctrl.Result{RequeueAfter: time.Minute * 10}, nil, fmt.Errorf("Failed to verify backend redis version. Ensure that the backend-redis secret is correctly configured. Error: %s", err)
 		}
 	}
 	if !systemDatabaseVerified {
 		systemDatabaseVerified, err = helper.VerifySystemDatabase(r.Client(), reqConfigMap, apimInstance, logger)
 		if err != nil {
-			return ctrl.Result{}, err, nil
+			return ctrl.Result{RequeueAfter: time.Minute * 10}, nil, fmt.Errorf("Failed to verify system database version. Ensure that the system-database secret is correctly configured. Error: %s", err)
 		}
 	}
 

--- a/controllers/apps/apimanager_status_reconciler.go
+++ b/controllers/apps/apimanager_status_reconciler.go
@@ -347,8 +347,8 @@ func (s *APIManagerStatusReconciler) reconcilePreflightsStatus(conditions *commo
 
 	upgradeSuccessfulPreflight := "All requirement for incoming version are met. If using automatic upgrades the upgrade will start shortly, if manual, you can proceed with approval"
 	requirementConfigMapNotFoundPreflight := "Requirement config map is not found yet, it should be generated shortly"
-	freshInstallPreflightsErrorMessage := fmt.Sprintf("Preflights failed - %s- re-running preflights in 10 minutes", s.preflightsErr)
-	upgradePreflightsErrorMessage := fmt.Sprintf("Preflights failed - %s- re-running preflights in 10 minutes", s.preflightsErr)
+	freshInstallPreflightsErrorMessage := fmt.Sprintf("Preflights failed - %s - re-running preflights in 10 minutes", s.preflightsErr)
+	upgradePreflightsErrorMessage := fmt.Sprintf("Preflights failed - %s - re-running preflights in 10 minutes", s.preflightsErr)
 	multiMinorHopPreflightsMessage := fmt.Sprintf("Preflights failed - %s. Multi minor version hop detected. Reconciliation of this 3scale instance is stopped. Remove the operator and refer to official upgrade path for 3scale Operator", s.preflightsErr)
 
 	reqConfigMap, err := subController.RetrieveRequirementsConfigMap(s.Client())

--- a/pkg/helper/redis_database_version.go
+++ b/pkg/helper/redis_database_version.go
@@ -78,6 +78,7 @@ func verifySystemRedisVersion(k8sclient client.Client, connSecret v1.Secret, nam
 
 	redisPod, err := CreateRedisThrowAwayPod(k8sclient, namespace)
 	if err != nil {
+		logger.Info("Failed to create throwaway pod")
 		return false, err
 	}
 
@@ -86,6 +87,7 @@ func verifySystemRedisVersion(k8sclient client.Client, connSecret v1.Secret, nam
 		redisCliCommand = retrieveRedisSentinelCommand(redis.sentinelHost, redis.sentinelPort, redis.sentinelPassword, redis.sentinelGroup)
 		stdout, err := executeRedisCliCommand(*redisPod, redisCliCommand, logger)
 		if err != nil {
+			logger.Info("Failed to execute command to retrieve the system redis version")
 			return false, err
 		}
 		redis.redisHost, redis.redisPort = parseRedisSentinelResponse(stdout)
@@ -95,11 +97,13 @@ func verifySystemRedisVersion(k8sclient client.Client, connSecret v1.Secret, nam
 
 	stdout, err := executeRedisCliCommand(*redisPod, redisCliCommand, logger)
 	if err != nil {
+		logger.Info("Failed to execute command to retrieve the system redis version")
 		return false, err
 	}
 
 	currentRedisVersion, err := retrieveCurrentVersionOfRedis(stdout)
 	if err != nil {
+		logger.Info("Failed to retrieve current version of system redis from the cli command")
 		return false, err
 	}
 
@@ -113,6 +117,7 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 
 	redisPod, err := CreateRedisThrowAwayPod(k8sclient, namespace)
 	if err != nil {
+		logger.Info("Failed to create throwaway pod")
 		return false, err
 	}
 
@@ -121,6 +126,7 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 		redisCliCommand = retrieveRedisSentinelCommand(redis.sentinelHost, redis.sentinelPort, redis.sentinelPassword, redis.sentinelGroup)
 		stdout, err := executeRedisCliCommand(*redisPod, redisCliCommand, logger)
 		if err != nil {
+			logger.Info("Failed to execute command to retrieve the backend redis version")
 			return false, err
 		}
 		redis.redisHost, redis.redisPort = parseRedisSentinelResponse(stdout)
@@ -130,11 +136,13 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 
 	stdout, err := executeRedisCliCommand(*redisPod, redisCliCommand, logger)
 	if err != nil {
+		logger.Info("Failed to execute command to retrieve the system redis version")
 		return false, err
 	}
 
 	currentRedisVersion, err := retrieveCurrentVersionOfRedis(stdout)
 	if err != nil {
+		logger.Info("Failed to retrieve current version of Redis from the cli command")
 		return false, err
 	}
 
@@ -145,6 +153,7 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 		redisCliCommand = retrieveRedisSentinelCommand(redis.sentinelHost, redis.sentinelPort, redis.sentinelPassword, redis.sentinelGroup)
 		stdout, err := executeRedisCliCommand(*redisPod, redisCliCommand, logger)
 		if err != nil {
+			logger.Info("Failed to execute command to retrieve the version")
 			return false, err
 		}
 		redis.redisHost, redis.redisPort = parseRedisSentinelResponse(stdout)
@@ -154,11 +163,13 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 
 	stdout, err = executeRedisCliCommand(*redisPod, redisCliCommand, logger)
 	if err != nil {
+		logger.Info("Failed to execute command to retrieve the version")
 		return false, err
 	}
 
 	currentRedisVersion, err = retrieveCurrentVersionOfRedis(stdout)
 	if err != nil {
+		logger.Info("Failed to retrieve current version of Redis from the cli command")
 		return false, err
 	}
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-11208

# What
Added more logs + error reporting to APIM in case of failed preflights due to incorrectly configured/missing db secrets.

# Verification
- Create namespace

```
oc new-project threescale
```

- Install CRDs

```
make install
```

- Run the operator

```
make run
```

- Create new secret to be consumed by APIM

```
oc apply -f - <<EOF   
---
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: s3-credentials
stringData:
  AWS_ACCESS_KEY_ID: something
  AWS_SECRET_ACCESS_KEY: something
  AWS_BUCKET: something
  AWS_REGION: us-east-1
type: Opaque
EOF
```

- Fetch cluster domain

```
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
```

- Create APIM

```
kubectl apply -f - <<EOF                                                        
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
  namespace: threescale
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```

- Confirm 3scale is fully installed

```
oc wait --for=condition=available apimanager/apimanager-sample --timeout=-1s
```
- Stop the operator
- Navigate to API Manager and remove the apps.3scale.net/apimanager-confirmed-requirements-version annotation
- Navigate to backend-redis secret and edit the REDIS_QUEUES_URL to something like `redis://backend-redi:6379/1`
- Start the operator
- After a minute or so, confirm that the preflight error is logged in API Manager CR
- Without stopping the operator, edit the secret back to correct value
- Confirm that after about 10 mins, the operator re-checks and updates the APIM with preflight pass message.
- Repeat the steps for system redis and system database secrets.
