### PR TITLE
THREESCALE-11226 extend hpa logic

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -41,6 +41,7 @@ const (
 	OperatorVersionAnnotation       = "apps.3scale.net/threescale-operator-version"
 	Default3scaleAppLabel           = "3scale-api-management"
 	ThreescaleRequirementsConfirmed = "apps.3scale.net/apimanager-confirmed-requirements-version"
+	DisableAsyncAnnotation          = "apps.3scale.net/disable-async"
 )
 
 const (
@@ -1319,6 +1320,30 @@ func (apimanager *APIManager) IsS3STSEnabled() bool {
 
 func (apimanager *APIManager) IsS3IAMEnabled() bool {
 	return apimanager.IsS3Enabled() && !apimanager.IsS3STSEnabled()
+}
+
+func (apimanager *APIManager) IsApicastHpaEnabled() bool {
+	return apimanager.Spec.Apicast != nil &&
+		apimanager.Spec.Apicast.ProductionSpec != nil &&
+		apimanager.Spec.Apicast.ProductionSpec.Hpa
+}
+
+func (apimanager *APIManager) IsBackendHpaEnabled() bool {
+	return apimanager.Spec.Backend != nil &&
+		apimanager.Spec.Backend.WorkerSpec != nil &&
+		apimanager.Spec.Backend.WorkerSpec.Hpa ||
+		apimanager.Spec.Backend != nil &&
+			apimanager.Spec.Backend.ListenerSpec != nil &&
+			apimanager.Spec.Backend.ListenerSpec.Hpa
+}
+
+func (apimanager *APIManager) IsAsyncDisableAnnotationPresent() bool {
+	asyncDisabledFound := false
+	if val, ok := apimanager.Annotations[DisableAsyncAnnotation]; ok && val == "true" {
+		asyncDisabledFound = true
+	}
+
+	return asyncDisabledFound
 }
 
 func (apimanager *APIManager) Validate() field.ErrorList {

--- a/pkg/3scale/amp/operator/apicast_reconciler.go
+++ b/pkg/3scale/amp/operator/apicast_reconciler.go
@@ -230,16 +230,9 @@ func (r *ApicastReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// create or delete HPA
-	sentinelHost := GetSystemRedisSecret(r.apiManager.Namespace, r.Context(), r.Client(), r.logger)
-	if !sentinelHost {
-		err = r.ReconcileHpa(component.DefaultHpa(component.ApicastProductionName, r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	} else {
-		message := "SentinelHost with authentication found in the system, which is blocking redis async mode, horizontal pod autoscaling for backend cannot be enabled without async mode"
-		r.logger.Info(message)
+	err = r.ReconcileHpa(component.DefaultHpa(component.ApicastProductionName, r.apiManager.Namespace), reconcilers.CreateOnlyMutator)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	res, err := r.reconcileAPImanagerCR(context.TODO())


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-11226

What
- removed the check of apicast hpa when sentinels are discovered
- added hpa removal once the async disabled flag is on

Verification
- install 3scale from this branch:
```
make install
# get the domain name
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
# add the apimanger cr
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
spec:
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
# set the s3 secret
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
```
- Add the hpa to backends by editing the apimanager spec.backend.workerSpec.hpa: true and spec.backend.listenerSpec.hpa: true.
- HPA should turn on, verify by checking HPA CRs under same namespaces
- Once APIManager reports completed, set apicast prod hpa on as well spec.apicast.productionSpec.hpa: true
- HPA for apicast production should be created.
- Add the disable async annotation to the apim: `apps.3scale.net/disable-async: "true"` - expectation is that backends asnyc will switch off and hpa CRs for backends will be removed. Can be checked via ASYNC envs on backends (more info in here: https://github.com/3scale/3scale-operator/pull/990)
- Confirm that APIManager contains a new message re hpa + async annotation being set
- Confirm that hpa for apicast prod is still on but backends hpa is removed.