### PR TITLE
THREESCALE-11254 fix zync routes ownerRef

### DIFF
--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -110,6 +110,7 @@ func (zync *Zync) QueRole() *rbacv1.Role {
 				APIGroups: []string{"apps"},
 				Resources: []string{
 					"deployments",
+					"replicasets",
 				},
 				Verbs: []string{
 					"get",
@@ -121,6 +122,7 @@ func (zync *Zync) QueRole() *rbacv1.Role {
 				Resources: []string{
 					"pods",
 					"replicationcontrollers",
+					"replicasets",
 				},
 				Verbs: []string{
 					"get",


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-11254

Verification:
Run upgrade from 2.14 to master and create a new tenant in 3scale. Confirm that the routes ownerRef is the deployment.
Run fresh install from this branch and create a new tenant in 3scale. Confirm that the routes ownerRef is the deployment.