### PR TITLE
circleci: update ubuntu base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
   tag-operator-image-master:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - attach-workspace
@@ -150,7 +150,7 @@ jobs:
 
   tag-operator-image-release:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - attach-workspace


### PR DESCRIPTION
### What

circleci machine image `ubuntu-2004:202201-02` is being deprecated https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

### Verification steps

Create tag following `/^v.*/` regexp, and circleci should push image to quay.io. 

I added custom (temporary) tag `v0.12.1-this-is-a-test` and [circleci job](https://app.circleci.com/pipelines/github/3scale/3scale-operator/6577/workflows/7ef6a3d1-9a1c-4591-9439-af3175200c75/jobs/46515) succeeded. 
