### PR TITLE
THREESCALE-11256 Fixed ReplicaSets RBAC

### DIFF
--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -122,7 +122,6 @@ func (zync *Zync) QueRole() *rbacv1.Role {
 				Resources: []string{
 					"pods",
 					"replicationcontrollers",
-					"replicasets",
 				},
 				Verbs: []string{
 					"get",


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-11256](https://issues.redhat.com/browse/THREESCALE-11256)

# What
This PR removes unnecessary RBAC from the `zync-que-role` Role. In #1007, we added get/list permissions for ReplicaSets in the `''` APIGroup **_and_** in the `apps` APIGroup. However the operator doesn't have the RBAC to grant get/list permissions to ReplicaSets in the `''` APIGroup. 

After further investigation, it was discovered that we actually don't need to grant RBAC for the `''` APIGroup because ReplicaSets will always be in the `apps` APIGroup since they're a standard type. Therefore we can safely remove that rule from the `zync-que-role` Role.

This wasn't caught when verifying #1007 because that verification was done through a local installation where the operator technically has kubeadmin permissions. However when you install 3scale using OLM, this becomes a problem. 

# Verification Steps
## Upgrade Scenario
1. Install 3scale using an image built from the `3scale-2.14-stable` branch
2. Upgrade to an image built from this PR
3. Verify that the upgrade completes successfully
4. Create a new tenant in 3scale and confirm that the created Routes' ownerRef is the `zync-que` Deployment.

## Fresh Install
1. Install 3scale using an image built from this PR
2. Verify that the installation completes successfully
3. Create a new tenant in 3scale and confirm that the created Routes' ownerRef is the `zync-que` Deployment.

