### PR TITLE
[WIP]THREESCALE-11319 investigate - replace Redis with Valkey

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -557,9 +557,9 @@ spec:
                 - name: RELATED_IMAGE_SYSTEM_MEMCACHED
                   value: memcached:1.5
                 - name: RELATED_IMAGE_BACKEND_REDIS
-                  value: quay.io/fedora/redis-6:latest
+                  value: docker.io/valkey/valkey:8.0
                 - name: RELATED_IMAGE_SYSTEM_REDIS
-                  value: quay.io/fedora/redis-6:latest
+                  value: docker.io/valkey/valkey:8.0
                 - name: RELATED_IMAGE_SYSTEM_MYSQL
                   value: quay.io/sclorg/mysql-80-c8s
                 - name: RELATED_IMAGE_SYSTEM_POSTGRESQL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,9 +60,9 @@ spec:
         - name: RELATED_IMAGE_SYSTEM_MEMCACHED
           value: "memcached:1.5"
         - name: RELATED_IMAGE_BACKEND_REDIS
-          value: "quay.io/fedora/redis-6:latest"
+          value: "docker.io/valkey/valkey:8.0"
         - name: RELATED_IMAGE_SYSTEM_REDIS
-          value: "quay.io/fedora/redis-6:latest"
+          value: "docker.io/valkey/valkey:8.0"
         - name: RELATED_IMAGE_SYSTEM_MYSQL
           value: "quay.io/sclorg/mysql-80-c8s"
         - name: RELATED_IMAGE_SYSTEM_POSTGRESQL

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -21,11 +21,11 @@ func ZyncImageURL() string {
 }
 
 func BackendRedisImageURL() string {
-	return "quay.io/fedora/redis-6"
+	return "docker.io/valkey/valkey:8.0"
 }
 
 func SystemRedisImageURL() string {
-	return "quay.io/fedora/redis-6"
+	return "docker.io/valkey/valkey:8.0"
 }
 
 func SystemMySQLImageURL() string {

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -587,7 +587,7 @@ func (system *System) AppDeployment(containerImage string) *k8sappsv1.Deployment
 						{
 							Name:         SystemAppMasterContainerName,
 							Image:        containerImage,
-							Args:         []string{"env", "TENANT_MODE=master", "PORT=3002", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
+							Args:         []string{"env", "TENANT_MODE=master", "PORT=3002", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
 							Ports:        system.appMasterPorts(),
 							Env:          system.buildAppMasterContainerEnv(),
 							Resources:    *system.Options.AppMasterContainerResourceRequirements,
@@ -638,7 +638,7 @@ func (system *System) AppDeployment(containerImage string) *k8sappsv1.Deployment
 						{
 							Name:         SystemAppProviderContainerName,
 							Image:        containerImage,
-							Args:         []string{"env", "TENANT_MODE=provider", "PORT=3000", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
+							Args:         []string{"env", "TENANT_MODE=provider", "PORT=3000", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
 							Ports:        system.appProviderPorts(),
 							Env:          system.buildAppProviderContainerEnv(),
 							Resources:    *system.Options.AppProviderContainerResourceRequirements,
@@ -689,7 +689,7 @@ func (system *System) AppDeployment(containerImage string) *k8sappsv1.Deployment
 						{
 							Name:         SystemAppDeveloperContainerName,
 							Image:        containerImage,
-							Args:         []string{"env", "PORT=3001", "container-entrypoint", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
+							Args:         []string{"env", "PORT=3001", "bundle", "exec", "unicorn", "-c", "config/unicorn.rb"},
 							Ports:        system.appDeveloperPorts(),
 							Env:          system.buildAppDeveloperContainerEnv(),
 							Resources:    *system.Options.AppDeveloperContainerResourceRequirements,

--- a/pkg/3scale/amp/operator/redis_reconciler.go
+++ b/pkg/3scale/amp/operator/redis_reconciler.go
@@ -189,7 +189,7 @@ func (r *RedisReconciler) redisConfigMapMutator(existingObj, desiredObj common.K
 	}
 
 	update := false
-	fieldUpdated := reconcilers.RedisConfigMapReconcileField(desired, existing, "redis.conf")
+	fieldUpdated := reconcilers.RedisConfigMapReconcileField(desired, existing, "valkey.conf")
 	update = update || fieldUpdated
 
 	return update, nil

--- a/pkg/helper/podHelper.go
+++ b/pkg/helper/podHelper.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	redisDefaultImage      = "quay.io/fedora/redis-6"
+	redisDefaultImage      = "docker.io/valkey/valkey:8.0"
 	mySqlDefaultImage      = "quay.io/sclorg/mysql-80-c8s"
 	postgreSqlDefaultImage = "quay.io/sclorg/postgresql-10-c8s"
 )


### PR DESCRIPTION
## this PR is not for Merge, but investigation only

Jira: https://issues.redhat.com/browse/THREESCALE-11319

## Verification done:
- 3scale local installation
- Image:         docker.io/valkey/valkey:8.0

```
$ oc get pod
NAME                                     READY   STATUS      RESTARTS      AGE
apicast-production-77d48df4dc-26477      1/1     Running     0             44m
apicast-staging-79c4bbdd67-xs7qm         1/1     Running     0             44m
backend-cron-7dd8b957bf-9lggp            1/1     Running     0             45m
backend-listener-6d8fd688db-xcq8z        1/1     Running     0             45m
backend-redis-5cddf84b7c-l6gsd           1/1     Running     0             45m
backend-worker-6b98f7458c-8zxv4          1/1     Running     0             45m
system-app-7d699485fb-xhbqm              3/3     Running     0             43m
system-app-post-qnb27                    0/1     Completed   0             42m
system-app-pre-8lvdm                     0/1     Completed   0             44m
system-memcache-768996bbd5-8kvnp         1/1     Running     0             45m
system-mysql-774c477998-96z9f            1/1     Running     0             45m
system-redis-5888b4975c-xtdph            1/1     Running     0             3m1s
system-searchd-67664b89d4-r476j          1/1     Running     0             45m
system-searchd-manticore-reindex-wd2gw   0/1     Completed   0             44m
system-sidekiq-5d75c96cf8-n6lp7          1/1     Running     0             44m
zync-5745bbf864-cgclx                    1/1     Running     0             44m
zync-database-59f7d5f4f5-67f4c           1/1     Running     0             44m
zync-que-648ff494cc-jpkpx                1/1     Running     2 (44m ago)   44m

$ date
Thu Sep  5 13:36:02 EEST 2024

$ oc describe pod backend-redis-5cddf84b7c-l6gsd |grep Image:
    Image:         docker.io/valkey/valkey:8.0
$ oc describe pod system-redis-5888b4975c-xtdph |grep Image:
    Image:         docker.io/valkey/valkey:8.0

```

-  Login to 3scale, create product, hit it's endpoint and go analytics, you can see data in there
![Screenshot 2024-09-05 at 14 23 59](https://github.com/user-attachments/assets/51c3d059-504a-478e-b323-83cb39171443)
