### PR TITLE
THREESCALE-11344 create an generic pod monitor mutator to apply changes to the update

### DIFF
--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -288,7 +288,7 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	err = r.ReconcilePodMonitor(system.SystemAppPodMonitor(), reconcilers.CreateOnlyMutator)
+	err = r.ReconcilePodMonitor(system.SystemAppPodMonitor(), reconcilers.GenericPodMonitorMutator)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/reconcilers/pod_monitors.go
+++ b/pkg/reconcilers/pod_monitors.go
@@ -1,0 +1,27 @@
+package reconcilers
+
+import (
+	"fmt"
+	"github.com/3scale/3scale-operator/pkg/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"reflect"
+)
+
+func GenericPodMonitorMutator(existingObj, desiredObj common.KubernetesObject) (bool, error) {
+	existing, ok := existingObj.(*monitoringv1.PodMonitor)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *monitoringv1.PodMonitor", existingObj)
+	}
+	desired, ok := desiredObj.(*monitoringv1.PodMonitor)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *monitoringv1.PodMonitor", desiredObj)
+	}
+
+	updated := false
+	if !reflect.DeepEqual(desired.Spec, existing.Spec) {
+		existing.Spec = desired.Spec
+		updated = true
+	}
+
+	return updated, nil
+}

--- a/pkg/reconcilers/pod_monitors_test.go
+++ b/pkg/reconcilers/pod_monitors_test.go
@@ -1,0 +1,43 @@
+package reconcilers
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func podMonitoringTestFactory(port string) *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-app",
+		},
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+				{
+					Port:   port,
+					Path:   "/metrics",
+					Scheme: "http",
+				},
+			},
+		},
+	}
+}
+func TestGenericPodMonitorMutator(t *testing.T) {
+	var existingPort string = "8080"
+	var desiredPort string = "9090"
+
+	existing := podMonitoringTestFactory(existingPort)
+	desired := podMonitoringTestFactory(desiredPort)
+
+	update, err := GenericPodMonitorMutator(existing, desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !update {
+		t.Fatal("when defaults can be applied, reconciler reported no update needed")
+	}
+
+	if existing.Spec.PodMetricsEndpoints[0].Port != desiredPort {
+		t.Fatalf("PodMonitor not reconciled. Expected: %s, got: %s", desiredPort, existing.Spec.PodMetricsEndpoints[0].Port)
+	}
+}


### PR DESCRIPTION
## Issue

[THREESCALE-11344](https://issues.redhat.com//browse/THREESCALE-11344)

## What
create an generic pod monitor mutator to apply changes to the update


## Verification
- install 2.14 
- checkout the 3scale-2.14-stable branch
- install locally 
```bash
oc new-project 3scale-test
make install
make run
###
kubectl apply -f - <<EOF
---
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
data:
  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
  AWS_BUCKET: UkVQTEFDRV9NRQ==
  AWS_REGION: UkVQTEFDRV9NRQ==
  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
type: Opaque
EOF
###
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
###
kubectl apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager-sample
spec:
  monitoring:
    enabled: true
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  wildcardDomain: $DOMAIN
EOF
```
- Wait for the install to complete
- checkout the this branch
- install the monitoring stack as outline in https://github.com/3scale/3scale-operator/blob/master/doc/monitoring-stack-deployment/README.md
- Only really need prometheus installed, go to the prometheus route /targets endpoint e.g. http://prometheus.3scale-test.apps.aucunnin.4s6w.s1.devshift.org/targets 
- You should see the yabeda metrics endpoints on the system app
![Screenshot from 2024-09-13 10-23-43](https://github.com/user-attachments/assets/e65fcf34-14e3-432b-8f45-46d7f275c06f)
- Now run this branch locally 
```bash
make install
make run
```
- confirm that the pod monitoring yabeda metric endpoints are removed in the prometheus /targets endpoint
![image](https://github.com/user-attachments/assets/a01b0963-075c-408e-8e88-4cf7577762e3)

