### PR TITLE
THREESCALE-10875 Fix DeveloperAccount/DeveloperUser Backup and Restore

### DIFF
--- a/controllers/capabilities/developeruser_threescale_reconciler.go
+++ b/controllers/capabilities/developeruser_threescale_reconciler.go
@@ -60,13 +60,13 @@ func (s *DeveloperUserThreescaleReconciler) Reconcile() (*threescaleapi.Develope
 
 	if devUser == nil {
 		s.logger.V(1).Info("DeveloperUser does not exist", "username", s.userCR.Spec.Username)
-		// The DeveloperAccount doesn't exist yet and must be created in 3scale
+		// The DeveloperUser doesn't exist yet and must be created in 3scale
 		devUser, err = s.createDevUser()
 		if err != nil {
 			return nil, err
 		}
 
-		// Update the CR status with the account's ID and return the account
+		// Update the CR status with the user's ID and return the user
 		s.userCR.Status.ID = devUser.Element.ID
 		return devUser, nil
 	} else {


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10875](https://issues.redhat.com/browse/THREESCALE-10875)

# What
This PR hardens the DeveloperAccount and DeveloperUser capabilities by implementing the following:

1. Fixes a flaky issue where the porta call to create accounts was getting a 409 response even though the account was correctly created in 3scale.
2. Adds an annotation, `accountId`, to the DeveloperAccount CR to fix broken backup and restore behavior.
3. Adds an annotation, `userId`, to the DeveloperUser CR to fix broken backup and restore behavior.

# Verification Steps
1. Checkout this branch

2. Prepare for a local install:
```bash
make install
make download

export NAMESPACE=3scale-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF 
```

3. Run the operator locally:
```bash
make run 
```

4. Wait for the install to complete:
```bash
oc get apimanager 3scale -n 3scale-test -oyaml -w
```

5. Create the password Secret, DeveloperAccount, and DeveloperUser:
```bash
cat << EOF | oc create -f -
---
apiVersion: v1
kind: Secret
metadata:
  name: developeruserpassword4
stringData:
  password: developeruserpassword4
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperAccount
metadata:
  name: developeraccount04
spec:
  orgName: Ecorp
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: developeruser04
spec:
  username: myusername04
  email: myusername04@example.com
  role: admin
  passwordCredentialsRef:
    name: developeruserpassword4
  developerAccountRef:
    name: developeraccount04
EOF
```

6. Wait until the DeveloperAccount and DeveloperUser are reconciled and verify they have the `accountId` or `userId` annotations:
```bash
oc get developeraccount developeraccount04 -oyaml
oc get developeruser developeruser04 -oyaml
```

7. Pull the DeveloperAccount and DeveloperUser CRs to your local machine (either by using `oc get` or downloading the yaml in the OpenShift UI)

8. Stop running the operator

9. Delete the DeveloperAccount and DeveloperUser CRs (you will need to remove their finalizers to ensure they actually delete)

10. Restart the operator locally:
```bash
make run
```

11. Recreate the DeveloperAccount and DeveloperUser using the saved yaml files from step 7 (remember to first remove the managedFields, .status, ownerReferences, etc.)

12. Wait until the DeveloperAccount and DeveloperUser CRs are reconciled and verify that they have the `accountId` or `userId` annotations:
```bash
oc get developeraccount developeraccount04 -oyaml
oc get developeruser developeruser04 -oyaml
```

13. Verify that the account wasn't duplicated in the 3scale-admin portal (Accounts -> Listing)