### PR TITLE
THREESCALE-10589 Fix env var for APIManagerBackup OC CLI image

### DIFF
--- a/pkg/backup/apimanager_backup_options_provider.go
+++ b/pkg/backup/apimanager_backup_options_provider.go
@@ -96,5 +96,5 @@ func (a *APIManagerBackupOptionsProvider) autodiscoveredAPIManager() (*appsv1alp
 }
 
 func (a *APIManagerBackupOptionsProvider) ocCLIImageURL() string {
-	return helper.GetEnvVar("OSE_CLI_IMAGE", component.OCCLIImageURL())
+	return helper.GetEnvVar("RELATED_IMAGE_OC_CLI", component.OCCLIImageURL())
 }


### PR DESCRIPTION
# Issue Link
JIRA: [THREESCALE-10589](https://issues.redhat.com/browse/THREESCALE-10589)

# What
This PR fixes the env var that is checked when specifying the `oc` CLI image for the APIManagerBackup procedure. It was incorrectly set to `OSE_CLI_IMAGE` when it should be set to `RELATED_IMAGE_OC_CLI`.

# Verification Steps
Eye review and passing the PROW checks should be sufficient verification.