### PR TITLE
THREESCALE-11541 add managed-by operator flag

### DIFF
--- a/controllers/capabilities/backend_threescale_reconciler.go
+++ b/controllers/capabilities/backend_threescale_reconciler.go
@@ -76,6 +76,11 @@ func (t *BackendThreescaleReconciler) syncBackend(_ interface{}) error {
 			"name":             t.backendResource.Spec.Name,
 			"private_endpoint": t.backendResource.Spec.PrivateBaseURL,
 		}
+
+		for k, v := range helper.ManagedByOperatorAnnotation() {
+			params[k] = v
+		}
+
 		backendAPIEntity, err = t.backendRemoteIndex.CreateBackendAPI(params)
 		if err != nil {
 			return fmt.Errorf("Error sync backend [%s]: %w", t.backendResource.Spec.SystemName, err)
@@ -97,6 +102,12 @@ func (t *BackendThreescaleReconciler) syncBackend(_ interface{}) error {
 
 	if t.backendAPIEntity.PrivateEndpoint() != t.backendResource.Spec.PrivateBaseURL {
 		updatedParams["private_endpoint"] = t.backendResource.Spec.PrivateBaseURL
+	}
+
+	if !helper.ManagedByOperatorAnnotationExists(backendAPIEntity.Annotations()) {
+		for k, v := range helper.ManagedByOperatorAnnotation() {
+			updatedParams[k] = v
+		}
 	}
 
 	if len(updatedParams) > 0 {

--- a/controllers/capabilities/developeraccount_threescale_reconciler.go
+++ b/controllers/capabilities/developeraccount_threescale_reconciler.go
@@ -173,6 +173,10 @@ func (s *DeveloperAccountThreescaleReconciler) createDevAccount() (*threescaleap
 		"password": password,
 	}
 
+	for k, v := range helper.ManagedByOperatorAnnotation() {
+		params[k] = v
+	}
+
 	if s.resource.Spec.MonthlyBillingEnabled != nil {
 		params["monthly_billing_enabled"] = strconv.FormatBool(*s.resource.Spec.MonthlyBillingEnabled)
 	}
@@ -264,6 +268,15 @@ func (s *DeveloperAccountThreescaleReconciler) syncDeveloperAccount(devAccount *
 	if devAccount.Element.MonthlyChargingEnabled != nil && *devAccount.Element.MonthlyChargingEnabled != desiredMonthlyChargingEnabled {
 		update = true
 		deltaAccount.Element.MonthlyChargingEnabled = &desiredMonthlyChargingEnabled
+	}
+
+	if !helper.ManagedByOperatorAnnotationExists(devAccount.Element.Annotations) {
+		for k, v := range helper.ManagedByOperatorAnnotation() {
+			update = true
+			deltaAccount.Element.Annotations = map[string]string{
+				k: v,
+			}
+		}
 	}
 
 	updatedDevAccount := devAccount

--- a/controllers/capabilities/developeraccount_threescale_reconciler.go
+++ b/controllers/capabilities/developeraccount_threescale_reconciler.go
@@ -271,11 +271,12 @@ func (s *DeveloperAccountThreescaleReconciler) syncDeveloperAccount(devAccount *
 	}
 
 	if !helper.ManagedByOperatorAnnotationExists(devAccount.Element.Annotations) {
-		for k, v := range helper.ManagedByOperatorAnnotation() {
+		for k, v := range helper.ManagedByOperatorDeveloperAccountAnnotation() {
 			update = true
-			deltaAccount.Element.Annotations = map[string]string{
-				k: v,
+			if deltaAccount.Element.Annotations == nil {
+				deltaAccount.Element.Annotations = make(map[string]string)
 			}
+			deltaAccount.Element.Annotations[k] = v
 		}
 	}
 

--- a/controllers/capabilities/product.go
+++ b/controllers/capabilities/product.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"fmt"
 
+	"github.com/3scale/3scale-operator/pkg/helper"
 	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
 )
 
@@ -30,6 +31,12 @@ func (t *ProductThreescaleReconciler) syncProduct(_ interface{}) error {
 			params["backend_version"] = *specAuthMode
 		}
 	} // only update backend_version when set in the CR
+
+	if !helper.ManagedByOperatorAnnotationExists(t.productEntity.Annotations()) {
+		for k, v := range helper.ManagedByOperatorAnnotation() {
+			params[k] = v
+		}
+	}
 
 	if len(params) > 0 {
 		err := t.productEntity.Update(params)

--- a/controllers/capabilities/product_threescale_reconciler.go
+++ b/controllers/capabilities/product_threescale_reconciler.go
@@ -86,6 +86,11 @@ func (t *ProductThreescaleReconciler) reconcile3scaleProduct() (*controllerhelpe
 		params := threescaleapi.Params{
 			"system_name": t.resource.Spec.SystemName,
 		}
+
+		for k, v := range helper.ManagedByOperatorAnnotation() {
+			params[k] = v
+		}
+
 		product, err := t.threescaleAPIClient.CreateProduct(t.resource.Spec.Name, params)
 		if err != nil {
 			return nil, fmt.Errorf("reconcile3scaleProduct product [%s]: %w", t.resource.Spec.SystemName, err)

--- a/go.mod
+++ b/go.mod
@@ -129,3 +129,5 @@ require (
 )
 
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20210831091943-07e756545ac1
+
+replace github.com/3scale/3scale-porta-go-client v0.11.0 => github.com/MStokluska/3scale-porta-go-client v0.0.0-20250124150520-23225e662421

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/3scale/3scale-porta-go-client v0.11.0 h1:cHJPJ1xzcc+TXitjAv90dAPZJyLs3u6aQ68mQ4DcHXI=
-github.com/3scale/3scale-porta-go-client v0.11.0/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
@@ -48,6 +46,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MStokluska/3scale-porta-go-client v0.0.0-20250124150520-23225e662421 h1:P/vWCWycdFARt5APkZ6yJs/1DWvkeESSRZZHMl1wkFo=
+github.com/MStokluska/3scale-porta-go-client v0.0.0-20250124150520-23225e662421/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.8.25 h1:fRMwXiwk3qDwc0P05eHnh+y2v07JdtsfQ1fuAc69m9g=

--- a/pkg/controller/helper/backendapi_entity.go
+++ b/pkg/controller/helper/backendapi_entity.go
@@ -48,6 +48,10 @@ func (b *BackendAPIEntity) PrivateEndpoint() string {
 	return b.backendAPIObj.Element.PrivateEndpoint
 }
 
+func (b *BackendAPIEntity) Annotations() map[string]string {
+	return b.backendAPIObj.Element.Annotations
+}
+
 func (b *BackendAPIEntity) Update(params threescaleapi.Params) error {
 	b.logger.V(1).Info("Update", "params", params)
 	updatedBackendAPI, err := b.client.UpdateBackendApi(b.backendAPIObj.Element.ID, params)

--- a/pkg/controller/helper/product_entity.go
+++ b/pkg/controller/helper/product_entity.go
@@ -57,6 +57,10 @@ func (b *ProductEntity) BackendVersion() string {
 	return b.productObj.Element.BackendVersion
 }
 
+func (b *ProductEntity) Annotations() map[string]string {
+	return b.productObj.Element.Annotations
+}
+
 func (b *ProductEntity) Update(params threescaleapi.Params) error {
 	b.logger.V(1).Info("Update", "params", params)
 	updated, err := b.client.UpdateProduct(b.productObj.Element.ID, params)

--- a/pkg/helper/annotations.go
+++ b/pkg/helper/annotations.go
@@ -1,0 +1,14 @@
+package helper
+
+func ManagedByOperatorAnnotation() map[string]string {
+	return map[string]string{
+		"annotations[managed_by]": "operator",
+	}
+}
+
+func ManagedByOperatorAnnotationExists(annotations map[string]string) bool {
+	if val, exists := annotations["managed_by"]; exists && val == "operator" {
+		return true
+	}
+	return false
+}

--- a/pkg/helper/annotations.go
+++ b/pkg/helper/annotations.go
@@ -12,3 +12,9 @@ func ManagedByOperatorAnnotationExists(annotations map[string]string) bool {
 	}
 	return false
 }
+
+func ManagedByOperatorDeveloperAccountAnnotation() map[string]string {
+	return map[string]string{
+		"managed_by": "operator",
+	}
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-11541

Verification:
- This PR temporary has go mod updated to use porta client build from: https://github.com/3scale/3scale-porta-go-client/pull/65

Scenario 1 - 2.16 creation of capabilities
Install 3scale:
Local installation of 3scale is fine,
- Run:
```
make install
make download

export NAMESPACE=3scale-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```
- run `make run`
- wait for installation to fully complete

Backend and product

- run:
```
cat << EOF | oc create -f -
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend-1
spec:
  name: "My Backend Name"
  privateBaseURL: "https://api.example.com"
  systemName: backend1
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1
spec:
  name: "OperatedProduct 1"
  backendUsages:
    backend1:
      path: /
EOF
```
- once created, navigate to 3scale UI > backend and then product and confirm that the Managed-by Operator is visible under product/backend names.

Developer Account

- run 
```
cat << EOF | oc create -f -
---
apiVersion: v1
kind: Secret
metadata:
  name: developeruserpassword4
stringData:
  password: developeruserpassword4
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperAccount
metadata:
  name: developeraccount04
spec:
  orgName: Ecorp
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: developeruser04
spec:
  username: myusername04
  email: myusername04@example.com
  role: admin
  passwordCredentialsRef:
    name: developeruserpassword4
  developerAccountRef:
    name: developeraccount04
EOF
```
- go into accounts, find ECorp account and confirm Managed-by operator is visible.

Tenant:
- run:
```
oc create secret generic test-admin-secret --from-literal=admin_password=password

MASTER_HOSTNAME=$(oc get route -n 3scale-test -l zync.3scale.net/route-to=system-master -o jsonpath='{range .items[*]}{.spec.host}{"\n"}{end}')

cat << EOF | oc create -f -
---
apiVersion: capabilities.3scale.net/v1alpha1
kind: Tenant
metadata:
  name: test-tenant
spec:
  username: admin
  systemMasterUrl: https://$MASTER_HOSTNAME
  email: admin@test.com
  organizationName: test
  masterCredentialsRef:
    name: system-seed
  passwordCredentialsRef:
    name: test-admin-secret
  tenantSecretRef:
    name: tenant-secret
EOF
```
- navigate to master portal and confirm that the new tenant is marked as managed by the operator:

![image](https://github.com/user-attachments/assets/07003868-f6d3-463c-adde-2a4b0c5cae90)

Scenario 2 - creation of capqbilities on 2.15 and uograde to 2.16

- checkout 2.15 stablw branch
- Install 3scake and create resources exactly as it is in scenario 1
- once 3scake is installed and resources created confirm that managed by opwrotr is not present
- Checkout this branch and run the operator
- after few seconds of the operator running run confirmation steps from scenario 1.

