### PR TITLE
THREESCALE-11633 fix application controller nil pointer

### DIFF
--- a/controllers/capabilities/application_controller.go
+++ b/controllers/capabilities/application_controller.go
@@ -268,6 +268,11 @@ func (r *ApplicationReconciler) removeApplicationFrom3scale(application *capabil
 		return nil
 	}
 
+	if account.Status.ID == nil {
+		logger.Info("could not remove application because ID is missing in the status of developer account")
+		return fmt.Errorf("could not remove application because ID is missing in the satus of developer account %s", account.Name)
+	}
+
 	err = threescaleAPIClient.DeleteApplication(*account.Status.ID, *application.Status.ID)
 	if err != nil && !threescaleapi.IsNotFound(err) {
 		return err

--- a/controllers/capabilities/application_controller.go
+++ b/controllers/capabilities/application_controller.go
@@ -89,6 +89,16 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	err = r.Client().Get(r.Context(), projectMeta, accountResource)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// If the application CR is marked for deletion and the dev account associated doesn't exist, remove the application CR since there is nothing else to do with application.
+			if application.GetDeletionTimestamp() != nil && controllerutil.ContainsFinalizer(application, applicationFinalizer) {
+				controllerutil.RemoveFinalizer(application, applicationFinalizer)
+				err = r.UpdateResource(application)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+
+				return ctrl.Result{}, nil
+			}
 			reqLogger.Error(err, "error developer account not found ")
 			statusReconciler := NewApplicationStatusReconciler(r.BaseReconciler, application, nil, "", err)
 			statusResult, statusUpdateErr := statusReconciler.Reconcile()
@@ -97,13 +107,14 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					return ctrl.Result{}, fmt.Errorf("Failed to reconcile application: %v. Failed to update application status: %w", err, statusUpdateErr)
 				}
 
-				return ctrl.Result{}, fmt.Errorf("Failed to update applicatino status: %w", statusUpdateErr)
+				return ctrl.Result{}, fmt.Errorf("Failed to update application status: %w", statusUpdateErr)
 			}
 			if statusResult.Requeue {
 				return statusResult, nil
 			}
 		}
 	}
+
 	// get providerAccountRef from account
 	providerAccount, err := controllerhelper.LookupProviderAccount(r.Client(), accountResource.Namespace, accountResource.Spec.ProviderAccountRef, r.Logger())
 	if err != nil {
@@ -138,7 +149,11 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	metadataUpdated := r.reconcileMetadata(application)
+	metadataUpdated, err := r.reconcileMetadata(application, accountResource)
+	if err != nil {
+		r.EventRecorder().Eventf(application, corev1.EventTypeWarning, "Failed to update ownerReferences in application", "%v", err)
+		return ctrl.Result{}, err
+	}
 	if metadataUpdated {
 		err = r.UpdateResource(application)
 		if err != nil {
@@ -187,7 +202,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-func (r *ApplicationReconciler) reconcileMetadata(application *capabilitiesv1beta1.Application) bool {
+func (r *ApplicationReconciler) reconcileMetadata(application *capabilitiesv1beta1.Application, developerAccount *capabilitiesv1beta1.DeveloperAccount) (bool, error) {
 	changed := false
 
 	// If the application.Status.ID is found and the annotation is not found - create
@@ -209,7 +224,16 @@ func (r *ApplicationReconciler) reconcileMetadata(application *capabilitiesv1bet
 		changed = true
 	}
 
-	return changed
+	// Add ownerRef of associated account CR, this is done because application CR can't exist without associated dev account. Therefore, if dev account is removed, the application CR should also be removed
+	if !r.HasOwnerReference(developerAccount, application) {
+		updated, err := r.EnsureOwnerReference(developerAccount, application)
+		if err != nil {
+			return false, err
+		}
+		changed = changed || updated
+	}
+
+	return changed, nil
 }
 
 func (r *ApplicationReconciler) applicationReconciler(applicationResource *capabilitiesv1beta1.Application, req ctrl.Request, threescaleAPIClient *threescaleapi.ThreeScaleClient, providerAccountAdminURLStr string, accountResource *capabilitiesv1beta1.DeveloperAccount) (*ApplicationStatusReconciler, error) {

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -275,3 +275,13 @@ func resourceExists(dc discovery.DiscoveryInterface, groupVersion, kind string) 
 
 	return false, nil
 }
+
+// HasOwnerReference checks if the given owner is already present in the object's OwnerReferences.
+func (b *BaseReconciler) HasOwnerReference(owner, obj common.KubernetesObject) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == owner.GetUID() {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-11633

Verification:

Install 3scale:

- run `make cluster/prepare/local`
- run:

```
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
EOF
```
- run `make run`
- let 3scale install
- run:
```
cat << EOF | oc create -f -
---
apiVersion: v1
kind: Secret
metadata:
  name: developeruserpassword4
stringData:
  password: developeruserpassword4
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperAccount
metadata:
  name: developeraccount04
spec:
  orgName: Ecorp
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: developeruser04
spec:
  username: myusername04
  email: myusername04@example.com
  role: admin
  passwordCredentialsRef:
    name: developeruserpassword4
  developerAccountRef:
    name: developeraccount04
EOF
```
- run:
```
cat << EOF | oc create -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: testproduct
spec:
  description: Custom resources test product
  applicationPlans:
    default:
      name: default
  metrics:
    hits:
      description: Number of API hits
      friendlyName: Hits
      unit: hit
  name: testapp
  systemName: testapp
EOF
```
- run:
```
cat << EOF | oc create -f -
---
kind: Application
apiVersion: capabilities.3scale.net/v1beta1
metadata:
  name: testapplication
spec:
  accountCR:
    name: developeraccount04
  applicationPlanName: default
  description: Custom resources test application
  name: testapplication
  productCR:
    name: testproduct
---
kind: Application
apiVersion: capabilities.3scale.net/v1beta1
metadata:
  name: testapplication2
spec:
  accountCR:
    name: developeraccount04
  applicationPlanName: default
  description: Custom resources test application
  name: testapplication2
  productCR:
    name: testproduct
EOF
 ```
  Test 1:
 - let all create successfully
 - confirm that application CRs now reference the account CR as ownerRef
 - delete testapplication2
- confirm testapplication2 removed from 3scale and from cluster
- delete the dev account CR and confirm dev account is gone from 3scale along with application
- confirm the application, dev user and dev account are deleted from cluster.

Test 2:
- re-create the resources again
- wait for all to create successfully
- delete application testapplication2
 - scale down the operator
 - take copy of dev user and dev account (spec + metadata)
 - delete dev user + dev ACC CRs (remember to clear the finalizers)
 - confirm application CR has been marked for deletion
 - re-create dev user and dev ACC (just spec and metadata that you have copied over)
 - run the operator
 - expectation is that 1) operator won't crash 2) dev acc and user CRs will be synced 3) application CR will be removed from cluster.
 
Test 3:
- re-create all resources and let them provision successfully
- take a backup of application CRs including metadata
- scale down operator
- remove application CRs from cluster
- add application CRs back to cluster without the status but with all the metadata
- scale up operator
- application should be synced with existing application in 3scale with the same ID instead of being re-created