### PR TITLE
THREESCALE-11209 Refactor preflight to use golib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ manager: generate fmt vet
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: export WATCH_NAMESPACE=$(LOCAL_RUN_NAMESPACE)
 run: export THREESCALE_DEBUG=1
+run: export PREFLIGHT_CHECKS_BYPASS=true
 run: generate fmt vet manifests
 	@-oc process THREESCALE_VERSION=$(THREESCALE_VERSION) -f config/requirements/operator-requirements.yaml | oc apply -f - -n $(WATCH_NAMESPACE)
 	$(GO) run ./main.go --zap-devel 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1
 	github.com/prometheus/client_golang v1.19.1
+	github.com/redis/go-redis/v9 v9.7.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.9.0
@@ -44,6 +45,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.10
 require (
 	github.com/3scale/3scale-porta-go-client v0.11.1-0.20250124150520-23225e662421
 	github.com/RHsyseng/operator-utils v1.4.9
+	github.com/blang/semver/v4 v4.0.0
 	github.com/getkin/kin-openapi v0.94.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.2
@@ -41,7 +42,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,12 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-playground/validator/v10 v10.2.0
+	github.com/go-sql-driver/mysql v1.9.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana-operator/grafana-operator/v4 v4.5.0
 	github.com/grafana-operator/grafana-operator/v5 v5.5.2
+	github.com/jackc/pgx/v5 v5.7.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.34.1
@@ -39,6 +41,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -77,6 +80,9 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
@@ -103,9 +109,11 @@ require (
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
+	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/MStokluska/3scale-porta-go-client v0.0.0-20250124150520-23225e662421 h1:P/vWCWycdFARt5APkZ6yJs/1DWvkeESSRZZHMl1wkFo=
-github.com/MStokluska/3scale-porta-go-client v0.0.0-20250124150520-23225e662421/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.8.25 h1:fRMwXiwk3qDwc0P05eHnh+y2v07JdtsfQ1fuAc69m9g=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/3scale/3scale-porta-go-client v0.11.1-0.20250124150520-23225e662421 h1:gOcBj+3tn3IJ1MLsNlpz8jo/FAPl0RgiGxLhd3UjPy0=
 github.com/3scale/3scale-porta-go-client v0.11.1-0.20250124150520-23225e662421/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -340,6 +342,8 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-sql-driver/mysql v1.9.0 h1:Y0zIbQXhQKmQgTp44Y1dp3wTXcn804QoTptLZT1vtvo=
+github.com/go-sql-driver/mysql v1.9.0/go.mod h1:pDetrLJeA3oMujJuvXc8RJoasr589B6A9fwzD3QMrqw=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
@@ -516,6 +520,14 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
+github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -890,6 +902,8 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,10 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1 h1:pgAtgj+A31JBVtEHu2uHuEx0n+2ukqUJnS2vVe5pQNA=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bugsnag/bugsnag-go v1.5.3 h1:yeRUT3mUE13jL1tGwvoQsKdVbAsQx9AJ+fqahKveP04=
 github.com/bugsnag/bugsnag-go v1.5.3/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABFQA=
@@ -161,6 +165,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/cli v20.10.12+incompatible h1:lZlz0uzG+GH+c0plStMUdF/qk3ppmgnswpR5EbqzVGA=
 github.com/docker/cli v20.10.12+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -703,6 +709,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/redis/go-redis/v9 v9.7.1 h1:4LhKRCIduqXqtvCUlaq9c8bdHOkICjDMrr1+Zb3osAc=
+github.com/redis/go-redis/v9 v9.7.1/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/helper/redis_database_version.go
+++ b/pkg/helper/redis_database_version.go
@@ -107,7 +107,10 @@ func verifySystemRedisVersion(k8sclient client.Client, connSecret v1.Secret, nam
 		return false, err
 	}
 
-	redisSystemVersionConfirmed := CompareVersions(requiredVersion, currentRedisVersion)
+	redisSystemVersionConfirmed, err := CompareVersions(requiredVersion, currentRedisVersion)
+	if err != nil {
+		return false, err
+	}
 
 	return redisSystemVersionConfirmed, nil
 }
@@ -146,7 +149,10 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 		return false, err
 	}
 
-	redisQueuesVersionConfirmed := CompareVersions(requiredVersion, currentRedisVersion)
+	redisQueuesVersionConfirmed, err := CompareVersions(requiredVersion, currentRedisVersion)
+	if err != nil {
+		return false, err
+	}
 
 	redis = reconcileStorageRedisSecret(connSecret)
 	if redis.sentinelHost != "" {
@@ -173,7 +179,10 @@ func verifyBackendRedisVersion(k8sclient client.Client, connSecret v1.Secret, na
 		return false, err
 	}
 
-	redisStorageVersionConfirmed := CompareVersions(requiredVersion, currentRedisVersion)
+	redisStorageVersionConfirmed, err := CompareVersions(requiredVersion, currentRedisVersion)
+	if err != nil {
+		return false, err
+	}
 
 	if redisQueuesVersionConfirmed && redisStorageVersionConfirmed {
 		err := DeletePod(k8sclient, redisPod)

--- a/pkg/helper/redis_database_version_test.go
+++ b/pkg/helper/redis_database_version_test.go
@@ -1,883 +1,305 @@
 package helper
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
+const (
+	caCert   = "./testdata/rootCA.pem"
+	certFile = "./testdata/client.crt"
+	keyFile  = "./testdata/client.key"
+)
+
+type mockRedisServer struct {
+	clientConnected bool
+}
+
+func (m *mockRedisServer) Listen(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+
+	require.NoError(t, err)
+
+	go func() {
+		defer ln.Close()
+		conn, err := ln.Accept()
+		assert.NoError(t, err)
+		m.clientConnected = true
+		conn.Write([]byte("OK\n"))
+	}()
+
+	return ln.Addr().String()
+}
+
+func (m *mockRedisServer) Connected() bool {
+	return m.clientConnected
+}
+
+// Secret reconcile test
 func TestReconcileRedisSecrets(t *testing.T) {
-	cases := []struct {
+
+	testCases := []struct {
 		testName            string
-		redisSecretFunction func(v1.Secret) Redis
+		redisSecretFunction func(v1.Secret) *RedisConfig
 		secret              v1.Secret
-		redis               Redis
+		redisConfig         *RedisConfig
 	}{
 		{
-			"SystemRedisSecretNoPasswordNoSentinels1",
+			"system-redis",
 			reconcileSystemRedisSecret,
 			v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "system-redis",
 				},
 				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte("redis://my-redis:5000/1"),
+					"SENTINEL_HOSTS": []byte("redis://username:password@sentinel-1:5000, redis://username:password@sentinel-2:5000, redis://username:password@sentinel-3:5000"),
+					"URL":            []byte("redis://username:password@my-redis:5000/1"),
 				},
 			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
+			&RedisConfig{
+				URL:         "redis://username:password@my-redis:5000/1",
+				SentinelURL: "redis://username:password@sentinel-1:5000, redis://username:password@sentinel-2:5000, redis://username:password@sentinel-3:5000",
 			},
 		},
 		{
-			"SystemRedisSecretNoPasswordNoSentinels2",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte("my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretNoPasswordNoSentinels3",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte("my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordNoSentinels1",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte("redis://:password@my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordNoSentinels2",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte(":password@my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordNoSentinels3",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte(":password@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordNoSentinels3",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(""),
-					"URL":            []byte(":password@my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"SystemRedisSecretNoPasswordSentinels1",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte("redis://sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"URL":            []byte("redis://my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordSentinels1",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"URL":            []byte("redis://my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordSentinels2",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"URL":            []byte("redis://:password1@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "password1",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordSentinels3",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"URL":            []byte("redis://:password1@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "password1",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordSentinels3",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte(":password@sentinel.cloud-resource-operator.svc.cluster.local"),
-					"URL":            []byte(":asdsada121252112sdag21123@redisgrp"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "6379",
-				sentinelGroup:    "redisgrp",
-				redisHost:        "redisgrp",
-				redisPassword:    "asdsada121252112sdag21123",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"SystemRedisSecretPasswordSentinels3",
-			reconcileSystemRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-redis",
-				},
-				Data: map[string][]byte{
-					"SENTINEL_HOSTS": []byte("redis//:password@sentinel.cloud-resource-operator.svc.cluster.local, redis//:password@sentinel.cloud-resource-operator.svc.cluster.local,redis//:password@sentinel.cloud-resource-operator.svc.cluster.local"),
-					"URL":            []byte(":asdsada121252112sdag21123@redisgrp"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "6379",
-				sentinelGroup:    "redisgrp",
-				redisHost:        "redisgrp",
-				redisPassword:    "asdsada121252112sdag21123",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"QueuesRedisSecretNoPasswordNoSentinels1",
+			"backend-redis (queues)",
 			reconcileQueuesRedisSecret,
 			v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "backend-redis",
 				},
 				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte("redis://my-redis:5000/1"),
+					"REDIS_QUEUES_SENTINEL_HOSTS": []byte("redis://username:password@sentinel-1:5000, redis://username:password@sentinel-2:5000, redis://username:password@sentinel-3:5000"),
+					"REDIS_QUEUES_URL":            []byte("redis://username:password@my-redis:5000/1"),
 				},
 			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
+			&RedisConfig{
+				URL:         "redis://username:password@my-redis:5000/1",
+				SentinelURL: "redis://username:password@sentinel-1:5000, redis://username:password@sentinel-2:5000, redis://username:password@sentinel-3:5000",
 			},
 		},
 		{
-			"QueuesRedisSecretNoPasswordNoSentinels2",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte("my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretNoPasswordNoSentinels3",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte("my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordNoSentinels1",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte("redis://:password@my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordNoSentinels2",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte(":password@my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordNoSentinels3",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte(":password@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordNoSentinels3",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(""),
-					"REDIS_QUEUES_URL":            []byte(":password@my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"QueuesRedisSecretNoPasswordSentinels1",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte("redis://sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_QUEUES_URL":            []byte("redis://my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordSentinels1",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_QUEUES_URL":            []byte("redis://my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordSentinels2",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_QUEUES_URL":            []byte("redis://:password1@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "password1",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordSentinels3",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_QUEUES_URL":            []byte("redis://:password1@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "password1",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordSentinels3",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte(":password@sentinel.cloud-resource-operator.svc.cluster.local"),
-					"REDIS_QUEUES_URL":            []byte(":asdsada121252112sdag21123@redisgrp"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "6379",
-				sentinelGroup:    "redisgrp",
-				redisHost:        "redisgrp",
-				redisPassword:    "asdsada121252112sdag21123",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"QueuesRedisSecretPasswordSentinels3",
-			reconcileQueuesRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_QUEUES_SENTINEL_HOSTS": []byte("redis//:password@sentinel.cloud-resource-operator.svc.cluster.local, redis//:password@sentinel.cloud-resource-operator.svc.cluster.local,redis//:password@sentinel.cloud-resource-operator.svc.cluster.local"),
-					"REDIS_QUEUES_URL":            []byte(":asdsada121252112sdag21123@redisgrp"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "6379",
-				sentinelGroup:    "redisgrp",
-				redisHost:        "redisgrp",
-				redisPassword:    "asdsada121252112sdag21123",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"StorageRedisSecretNoPasswordNoSentinels1",
+			"backend-redis (storage)",
 			reconcileStorageRedisSecret,
 			v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "backend-redis",
 				},
 				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte("redis://my-redis:5000/1"),
+					"REDIS_STORAGE_SENTINEL_HOSTS": []byte("redis://username:password@sentinel-1:5000, redis://username:password@sentinel-2:5000, redis://username:password@sentinel-3:5000"),
+					"REDIS_STORAGE_URL":            []byte("redis://username:password@my-redis:5000/1"),
 				},
 			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretNoPasswordNoSentinels2",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte("my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretNoPasswordNoSentinels3",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte("my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordNoSentinels1",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte("redis://:password@my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordNoSentinels2",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte(":password@my-redis:5000/1"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordNoSentinels3",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte(":password@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordNoSentinels3",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(""),
-					"REDIS_STORAGE_URL":            []byte(":password@my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "",
-				sentinelPassword: "",
-				sentinelPort:     "",
-				redisHost:        "my-redis",
-				redisPassword:    "password",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"StorageRedisSecretNoPasswordSentinels1",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte("redis://sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_STORAGE_URL":            []byte("redis://my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordSentinels1",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_STORAGE_URL":            []byte("redis://my-redis"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordSentinels2",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_STORAGE_URL":            []byte("redis://:password1@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "password1",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordSentinels3",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte("redis://:password@sentinel.cloud-resource-operator.svc.cluster.local:5000"),
-					"REDIS_STORAGE_URL":            []byte("redis://:password1@my-redis:5000"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "5000",
-				sentinelGroup:    "my-redis",
-				redisHost:        "my-redis",
-				redisPassword:    "password1",
-				redisPort:        "5000",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordSentinels3",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte(":password@sentinel.cloud-resource-operator.svc.cluster.local"),
-					"REDIS_STORAGE_URL":            []byte(":asdsada121252112sdag21123@redisgrp"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "6379",
-				sentinelGroup:    "redisgrp",
-				redisHost:        "redisgrp",
-				redisPassword:    "asdsada121252112sdag21123",
-				redisPort:        "6379",
-			},
-		},
-		{
-			"StorageRedisSecretPasswordSentinels3",
-			reconcileStorageRedisSecret,
-			v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "backend-redis",
-				},
-				Data: map[string][]byte{
-					"REDIS_STORAGE_SENTINEL_HOSTS": []byte("redis//:password@sentinel.cloud-resource-operator.svc.cluster.local, redis//:password@sentinel.cloud-resource-operator.svc.cluster.local,redis//:password@sentinel.cloud-resource-operator.svc.cluster.local"),
-					"REDIS_STORAGE_URL":            []byte(":asdsada121252112sdag21123@redisgrp"),
-				},
-			},
-			Redis{
-				sentinelHost:     "sentinel.cloud-resource-operator.svc.cluster.local",
-				sentinelPassword: "password",
-				sentinelPort:     "6379",
-				sentinelGroup:    "redisgrp",
-				redisHost:        "redisgrp",
-				redisPassword:    "asdsada121252112sdag21123",
-				redisPort:        "6379",
+			&RedisConfig{
+				URL:         "redis://username:password@my-redis:5000/1",
+				SentinelURL: "redis://username:password@sentinel-1:5000, redis://username:password@sentinel-2:5000, redis://username:password@sentinel-3:5000",
 			},
 		},
 	}
 
-	for _, tc := range cases {
+	for _, tc := range testCases {
 		t.Run(tc.testName, func(subT *testing.T) {
 			function := tc.redisSecretFunction
 			redisRetrieved := function(tc.secret)
 
-			if redisRetrieved.redisHost != tc.redis.redisHost {
-				subT.Fatalf("test failed for test case %s, expected redis host %v but got %v", tc.testName, tc.redis.redisHost, redisRetrieved.redisHost)
+			require.Equal(t, tc.redisConfig.URL, redisRetrieved.URL)
+			require.Equal(t, tc.redisConfig.SentinelURL, redisRetrieved.SentinelURL)
+			require.Equal(t, tc.redisConfig.SentinelMaster, redisRetrieved.SentinelMaster)
+		})
+	}
+}
+
+func TestConfigureNoConfig(t *testing.T) {
+	rdb, err := Configure(nil)
+	require.NoError(t, err)
+	require.Nil(t, rdb, "rdb client should be nil")
+}
+
+func TestConfigureWithEmptyConfig(t *testing.T) {
+	rdb, err := Configure(&RedisConfig{})
+	require.EqualError(t, err, "redis: invalid URL scheme: ")
+	require.Nil(t, rdb, "rdb client should be nil")
+}
+
+func TestConfigureWithInvalidConfig(t *testing.T) {
+
+	testCases := []struct {
+		testName    string
+		redisConfig *RedisConfig
+		err         string
+	}{
+		{
+			"invalid url scheme",
+			&RedisConfig{
+				URL: "invalid://redis:5000",
+			},
+			"redis: invalid URL scheme: invalid",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			rdb, err := Configure(tc.redisConfig)
+			require.EqualError(t, err, tc.err)
+			require.Nil(t, rdb, "rdb client should be nil")
+		})
+	}
+}
+
+func TestConnectToRedis(t *testing.T) {
+	testCases := []struct {
+		testName         string
+		scheme           string
+		username         string
+		password         string
+		overridepassword string
+		expected         *redis.Options
+	}{
+		{
+			"With redis scheme",
+			"redis",
+			"",
+			"",
+			"",
+			&redis.Options{
+				Username: "",
+				Password: "",
+			},
+		},
+		{
+			"With rediss scheme",
+			"rediss",
+			"",
+			"",
+			"",
+			&redis.Options{
+				Username: "",
+				Password: "",
+			},
+		},
+		{
+			"With username and password from url",
+			"redis",
+			"foo",
+			"bar",
+			"",
+			&redis.Options{
+				Username: "foo",
+				Password: "bar",
+			},
+		},
+		{
+			"With password from url only",
+			"redis",
+			"",
+			"bar",
+			"",
+			&redis.Options{
+				Username: "",
+				Password: "bar",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			mockServer := &mockRedisServer{}
+			a := mockServer.Listen(t)
+
+			var u string
+			if tc.username != "" || tc.password != "" {
+				u = fmt.Sprintf("%s://%s:%s@%s", tc.scheme, tc.username, tc.password, a)
+			} else {
+				u = fmt.Sprintf("%s://%s", tc.scheme, a)
 			}
-			if redisRetrieved.redisPort != tc.redis.redisPort {
-				subT.Fatalf("test failed for test case %s, expected redis port %v but got %v", tc.testName, tc.redis.redisPort, redisRetrieved.redisPort)
+
+			config := &RedisConfig{
+				URL: u,
 			}
-			if redisRetrieved.redisPassword != tc.redis.redisPassword {
-				subT.Fatalf("test failed for test case %s, expected redis password %v but got %v", tc.testName, tc.redis.redisPassword, redisRetrieved.redisPassword)
-			}
-			if redisRetrieved.sentinelHost != tc.redis.sentinelHost {
-				subT.Fatalf("test failed for test case %s, expected redis sentinel host %v but got %v", tc.testName, tc.redis.sentinelHost, redisRetrieved.sentinelHost)
-			}
-			if redisRetrieved.sentinelPort != tc.redis.sentinelPort {
-				subT.Fatalf("test failed for test case %s, expected redis sentinel port %v but got %v", tc.testName, tc.redis.sentinelPort, redisRetrieved.sentinelPort)
-			}
-			if redisRetrieved.sentinelPassword != tc.redis.sentinelPassword {
-				subT.Fatalf("test failed for test case %s, expected redis sentinel password %v but got %v", tc.testName, tc.redis.sentinelPassword, redisRetrieved.sentinelPassword)
-			}
-			if redisRetrieved.sentinelGroup != tc.redis.sentinelGroup {
-				subT.Fatalf("test failed for test case %s, expected redis group %v but got %v", tc.testName, tc.redis.sentinelGroup, redisRetrieved.sentinelGroup)
-			}
+			rdb, err := Configure(config)
+			require.NoError(t, err)
+			defer rdb.Close()
+
+			require.NotNil(t, rdb.Conn(), "Pool should not be nil")
+
+			opt := rdb.Options()
+			require.Equal(t, tc.expected.Username, opt.Username)
+			require.Equal(t, tc.expected.Password, opt.Password)
+
+			rdb.Ping(context.Background())
+			require.True(t, mockServer.Connected())
+		})
+	}
+}
+
+func TestSentinelOptions(t *testing.T) {
+	testCases := []struct {
+		testName    string
+		redisConfig *RedisConfig
+		expected    *redis.FailoverOptions
+	}{
+		{
+			"no sentiel master",
+			&RedisConfig{
+				SentinelURL: "redis://sentinel1:5000",
+			},
+			&redis.FailoverOptions{
+				SentinelAddrs: []string{"sentinel1:5000"},
+			},
+		},
+		{
+			"with sentiel master",
+			&RedisConfig{
+				URL:         "redis://master:3000/1",
+				SentinelURL: "redis://sentinel1:5000",
+			},
+			&redis.FailoverOptions{
+				MasterName:    "master",
+				SentinelAddrs: []string{"sentinel1:5000"},
+			},
+		},
+		{
+			"with username/password in master url",
+			&RedisConfig{
+				URL:         "redis://username:password@master:3000/1",
+				SentinelURL: "redis://sentinel:sentinelpass@sentinel1:5000",
+			},
+			&redis.FailoverOptions{
+				MasterName:    "master",
+				SentinelAddrs: []string{"sentinel1:5000"},
+				Username:      "username",
+				Password:      "password",
+			},
+		},
+		{
+			"with multiple sentiels",
+			&RedisConfig{
+				URL:         "redis://master:3000/1",
+				SentinelURL: "redis://sentinel:sentinelpass@sentinel1:5000, redis://sentinel2:5000, redis://sentinel3:5000",
+			},
+			&redis.FailoverOptions{
+				MasterName:    "master",
+				SentinelAddrs: []string{"sentinel1:5000", "sentinel2:5000", "sentinel3:5000"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(subT *testing.T) {
+			opt, err := sentinelOptions(tc.redisConfig)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected.SentinelAddrs, opt.SentinelAddrs)
+			require.Equal(t, tc.expected.MasterName, opt.MasterName)
+			require.Equal(t, tc.expected.Username, opt.Username)
+			require.Equal(t, tc.expected.Password, opt.Password)
 		})
 	}
 }

--- a/pkg/helper/requirements_common_helper_test.go
+++ b/pkg/helper/requirements_common_helper_test.go
@@ -7,8 +7,8 @@ import (
 func TestVersionCompare(t *testing.T) {
 	cases := []struct {
 		testName        string
+		requiredVersion string
 		currentVersion  string
-		incomingVersion string
 		expectedResult  bool
 	}{
 		{"IncomingMajorRequiredIsHigher", "7.0.0", "6.2", false},
@@ -22,7 +22,10 @@ func TestVersionCompare(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(subT *testing.T) {
-			value := CompareVersions(tc.currentVersion, tc.incomingVersion)
+			value, err := CompareVersions(tc.requiredVersion, tc.currentVersion)
+			if err != nil {
+				subT.Fatal(err)
+			}
 			if value != tc.expectedResult {
 				subT.Fatalf("test failed for test case %s, expected %v but got %v", tc.testName, tc.expectedResult, value)
 			}

--- a/pkg/helper/system_database_helper.go
+++ b/pkg/helper/system_database_helper.go
@@ -1,47 +1,100 @@
 package helper
 
 import (
+	"database/sql"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5"
+	pgxstd "github.com/jackc/pgx/v5/stdlib"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
-	urlKey     = "URL"
-	secretName = "system-database"
+	systemDatabaseURL = "URL"
+	secretName        = "system-database"
 )
 
-func systemDatabaseURLIsValid(rawURL string) (*url.URL, bool, error) {
-	resultURL, err := url.Parse(rawURL)
+type DatabaseConfig struct {
+	URL string
+}
+
+func reconcileSystemDBSecret(secret v1.Secret) *DatabaseConfig {
+	return &DatabaseConfig{
+		URL: string(secret.Data[systemDatabaseURL]),
+	}
+}
+
+func verifyMySQLVersion(cfg *DatabaseConfig, requiredVersion string) (bool, error) {
+	url, err := url.Parse(cfg.URL)
 	if err != nil {
-		return nil, false, fmt.Errorf("'%s' field of '%s' secret must have 'scheme://user:password@host/path' format", urlKey, secretName)
+		return false, err
 	}
-	if resultURL.Scheme != "mysql2" && resultURL.Scheme != "postgresql" {
-		if resultURL.Scheme == "oracle-enhanced" {
-			return nil, true, nil
-		}
-		return nil, false, fmt.Errorf("'%s' field of '%s' secret must contain 'mysql2' or 'postgresql' as the scheme part", urlKey, secretName)
-	}
-
-	if resultURL.User == nil {
-		return nil, false, fmt.Errorf("authentication information in '%s' field of '%s' secret must be provided", urlKey, secretName)
-	}
-	if resultURL.User.Username() == "" {
-		return nil, false, fmt.Errorf("authentication information in '%s' field of '%s' secret must contain a username", urlKey, secretName)
+	password, _ := url.User.Password()
+	port := url.Port()
+	if port == "" {
+		port = "3306"
 	}
 
-	if _, set := resultURL.User.Password(); !set {
-		return nil, false, fmt.Errorf("authentication information in '%s' field of '%s' secret must contain a password", urlKey, secretName)
+	dbConfig := mysql.NewConfig()
+
+	dbConfig.Net = "tcp"
+	dbConfig.Addr = net.JoinHostPort(url.Hostname(), port)
+	dbConfig.User = url.User.Username()
+	dbConfig.Passwd = password
+
+	// Append params
+	params := make(map[string]string)
+	q := url.Query()
+	for k := range q {
+		params[k] = q.Get(k)
+	}
+	dbConfig.Params = params
+
+	connector, err := mysql.NewConnector(dbConfig)
+	if err != nil {
+		return false, err
 	}
 
-	if resultURL.Host == "" {
-		return nil, false, fmt.Errorf("host information in '%s' field of '%s' secret must be provided", urlKey, secretName)
-	}
-	if resultURL.Path == "" {
-		return nil, false, fmt.Errorf("database name in '%s' field of '%s' secret must be provided", urlKey, secretName)
+	db := sql.OpenDB(connector)
+
+	var version string
+	err = db.QueryRow("SELECT version()").Scan(&version)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve database version. Error %s", err)
 	}
 
-	return resultURL, false, nil
+	databaseCurrentVersion, err := retrieveMysqlVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	return CompareVersions(requiredVersion, databaseCurrentVersion)
+}
+
+func verifyPostgresVersion(cfg *DatabaseConfig, requiredVersion string) (bool, error) {
+	dbConfig, err := pgx.ParseConfig(cfg.URL)
+	if err != nil {
+		return false, err
+	}
+
+	db := pgxstd.OpenDB(*dbConfig)
+	var version string
+
+	err = db.QueryRow("SELECT version()").Scan(&version)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve database version. Error %s", err)
+	}
+
+	databaseCurrentVersion, err := retrievePostgresVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	return CompareVersions(requiredVersion, databaseCurrentVersion)
 }
 
 func retrievePostgresVersion(stdout string) (string, error) {

--- a/pkg/helper/system_database_versions.go
+++ b/pkg/helper/system_database_versions.go
@@ -123,7 +123,10 @@ func verifySystemPostgresDatabaseVersion(k8sclient client.Client, namespace, req
 		return false, err
 	}
 
-	requirementsMet := CompareVersions(requiredVersion, currentPostgresVersion)
+	requirementsMet, err := CompareVersions(requiredVersion, currentPostgresVersion)
+	if err != nil {
+		return false, err
+	}
 	if requirementsMet {
 		err := DeletePod(k8sclient, databasePod)
 		if err != nil {
@@ -157,7 +160,10 @@ func verifySystemMysqlDatabaseVersion(k8sclient client.Client, namespace, requir
 		return false, err
 	}
 
-	requirementsMet := CompareVersions(requiredVersion, currentMysqlVersion)
+	requirementsMet, err := CompareVersions(requiredVersion, currentMysqlVersion)
+	if err != nil {
+		return false, err
+	}
 
 	if requirementsMet {
 		err := DeletePod(k8sclient, databasePod)

--- a/pkg/helper/system_database_versions.go
+++ b/pkg/helper/system_database_versions.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -11,15 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-type SystemDatabase struct {
-	scheme   string
-	host     string
-	port     string
-	password string
-	user     string
-	path     string
-}
 
 const (
 	systemDatabaseName = "system-database"
@@ -36,42 +26,37 @@ func VerifySystemDatabase(k8sclient client.Client, reqConfigMap *v1.ConfigMap, a
 		return databaseVersionVerified, err
 	}
 
-	// validate secret URL
-	databaseUrl, bypass, err := systemDatabaseURLIsValid(string(connSecret.Data["URL"]))
-	if err != nil {
-		logger.Info("System database secret is invalid")
-		return false, err
-	}
-	if bypass {
+	dbConfig := reconcileSystemDBSecret(*connSecret)
+	var databaseRequirement string
+
+	if strings.HasPrefix(dbConfig.URL, "postgres://") || strings.HasPrefix(dbConfig.URL, "postgresql://") {
+		databaseRequirement = reqConfigMap.Data[RHTThreescalePostgresRequirements]
+		if databaseRequirement == "" {
+			return true, nil
+		}
+
+		databaseVersionVerified, err = verifyPostgresVersion(dbConfig, databaseRequirement)
+		if err != nil {
+			logger.Info("Failed to verify Postgres database version", "err", err)
+			return false, err
+		}
+	} else if strings.HasPrefix(dbConfig.URL, "mysql://") || strings.HasPrefix(dbConfig.URL, "mysql2://") {
+		databaseRequirement = reqConfigMap.Data[RHTThreescaleMysqlRequirements]
+		if databaseRequirement == "" {
+			return true, nil
+		}
+
+		databaseVersionVerified, err = verifyMySQLVersion(dbConfig, databaseRequirement)
+
+		if err != nil {
+			logger.Info("Failed to verify MySQL database version", "err", err)
+			return false, err
+		}
+	} else if strings.HasPrefix(dbConfig.URL, "oracle-enhanced://") {
 		logger.Info("Oracle system database discovered, bypassing version check")
 		return true, nil
-	}
-	systemDatabase := databaseObject(databaseUrl)
-
-	if systemDatabase.scheme == postgresScheme {
-		postgresDatabaseRequirement := reqConfigMap.Data[RHTThreescalePostgresRequirements]
-		if postgresDatabaseRequirement == "" {
-			databaseVersionVerified = true
-		} else {
-			databaseVersionVerified, err = verifySystemPostgresDatabaseVersion(k8sclient, apimInstance.Namespace, postgresDatabaseRequirement, systemDatabase, logger)
-			if err != nil {
-				logger.Info("Encountered error during version verification of system Postgres")
-				return false, err
-			}
-		}
-	}
-
-	if systemDatabase.scheme == mysqlScheme {
-		mysqlDatabaseRequirement := reqConfigMap.Data[RHTThreescaleMysqlRequirements]
-		if mysqlDatabaseRequirement == "" {
-			databaseVersionVerified = true
-		} else {
-			databaseVersionVerified, err = verifySystemMysqlDatabaseVersion(k8sclient, apimInstance.Namespace, mysqlDatabaseRequirement, systemDatabase, logger)
-			if err != nil {
-				logger.Info("Encountered error during version verification of system MySQL")
-				return false, err
-			}
-		}
+	} else {
+		return false, fmt.Errorf("unsupported database")
 	}
 
 	if databaseVersionVerified {
@@ -81,96 +66,4 @@ func VerifySystemDatabase(k8sclient client.Client, reqConfigMap *v1.ConfigMap, a
 	}
 
 	return databaseVersionVerified, nil
-}
-
-func databaseObject(url *url.URL) SystemDatabase {
-	password, _ := url.User.Password()
-	return SystemDatabase{
-		scheme:   url.Scheme,
-		host:     url.Hostname(),
-		port:     url.Port(),
-		password: password,
-		user:     url.User.Username(),
-		path:     url.Path,
-	}
-}
-
-func verifySystemPostgresDatabaseVersion(k8sclient client.Client, namespace, requiredVersion string, databaseObject SystemDatabase, logger logr.Logger) (bool, error) {
-	databasePod, err := CreateDatabaseThrowAwayPod(k8sclient, namespace, "postgres")
-	if err != nil {
-		logger.Info("Failed to create system database throwaway pod")
-		return false, err
-	}
-
-	if databaseObject.port == "" {
-		databaseObject.port = "5432"
-	}
-
-	postgresqlCommand := fmt.Sprintf("PGPASSWORD=\"%s\" psql -h \"%s\" -U \"%s\" -d \"%s\" -p\"%s\" -t -A -c \"SELECT version();\"", databaseObject.password, databaseObject.host, databaseObject.user, strings.TrimLeft(databaseObject.path, "/"), databaseObject.port)
-	command := []string{"/bin/bash", "-c", postgresqlCommand}
-	podExecutor := NewPodExecutor(logger)
-	stdout, stderr, err := podExecutor.ExecuteRemoteCommand(databasePod.Namespace, databasePod.Name, command)
-	if err != nil {
-		return false, fmt.Errorf("Failed to execute command to retrieve database version. Error %s", err)
-	}
-	if stderr != "" {
-		return false, fmt.Errorf("Failed to execute command to retrieve database version. Error %s", err)
-	}
-
-	currentPostgresVersion, err := retrievePostgresVersion(stdout)
-	if err != nil {
-		logger.Info("Failed to retrieve postgres version from the cli command")
-		return false, err
-	}
-
-	requirementsMet, err := CompareVersions(requiredVersion, currentPostgresVersion)
-	if err != nil {
-		return false, err
-	}
-	if requirementsMet {
-		err := DeletePod(k8sclient, databasePod)
-		if err != nil {
-			return false, nil
-		}
-	}
-
-	return requirementsMet, nil
-}
-
-func verifySystemMysqlDatabaseVersion(k8sclient client.Client, namespace, requiredVersion string, databaseObject SystemDatabase, logger logr.Logger) (bool, error) {
-	databasePod, err := CreateDatabaseThrowAwayPod(k8sclient, namespace, "mysql")
-	if err != nil {
-		return false, err
-	}
-
-	mysqlCommand := fmt.Sprintf("mysql -sN -h \"%s\" -u \"%s\" -p\"%s\" -e \"SELECT VERSION();\"", databaseObject.host, databaseObject.user, databaseObject.password)
-	command := []string{"/bin/bash", "-c", mysqlCommand}
-	podExecutor := NewPodExecutor(logger)
-	stdout, stderr, err := podExecutor.ExecuteRemoteCommand(databasePod.Namespace, databasePod.Name, command)
-	if err != nil {
-		return false, fmt.Errorf("Failed to execute command to retrieve database version. Error %s", err)
-	}
-	if stderr != "" {
-		return false, fmt.Errorf("Failed to execute command to retrieve database version. Error %s", err)
-	}
-
-	currentMysqlVersion, err := retrieveMysqlVersion(stdout)
-	if err != nil {
-		logger.Info("Failed to retrieve postgres version from the cli command")
-		return false, err
-	}
-
-	requirementsMet, err := CompareVersions(requiredVersion, currentMysqlVersion)
-	if err != nil {
-		return false, err
-	}
-
-	if requirementsMet {
-		err := DeletePod(k8sclient, databasePod)
-		if err != nil {
-			return false, nil
-		}
-	}
-
-	return requirementsMet, nil
 }


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-11209

## Verification steps
Previously we created new pod in the same namespace as 3scale instance, but now we moved to golib and requests come from operator itself so requests to DB(s) will not be resolved. Hence, required to verify with OLM


* Checkout this branch
* Run `make cluster/prepare/local`
* Create new catalog
```
cat << EOF | oc create -f -                   
apiVersion: operators.coreos.com/v1alpha1     
kind: CatalogSource                           
metadata:                                     
  name: threescale-dev                        
  namespace: openshift-marketplace            
spec:                                         
  sourceType: grpc                            
  image: quay.io/an_tran/3scale-index:v0.14.0
EOF                                           
```
* Change  the image of both backend-redis to `quay.io/fedora/redis-6`
* Navigate to 3scale-test ns and install 3scale 0.13.0 from `threescale-dev` catalog
* Create apim
```
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```
* Check the operator log. You should see preflight fails for Redis
```
Backend redis version not matching the required version
```
* Change  the image of backend-redis to: `quay.io/fedora/redis-7`
* Wait for the preflight to kick in again, and check the operator log, all preflight should pass
* At this point, you should have full 3scale instance
* Remove the namespace and repeat the process but for PostgreSQL database as default

NOTE: change Postgres version to 12 if you want to test the preflight for system-db

```diff
diff --git a/config/dev-databases/system-postgresql/kustomization.yaml b/config/dev-databases/system-postgresql/kustomization.yaml
index 1a2c814d..fb96a94e 100644                                                                                                   
--- a/config/dev-databases/system-postgresql/kustomization.yaml                                                                   
+++ b/config/dev-databases/system-postgresql/kustomization.yaml                                                                   
@@ -6,4 +6,4 @@ resources:                                                                                                        
                                                                                                                                  
 images:                                                                                                                          
   - name: postgres                                                                                                               
-    newName: mirror.gcr.io/library/postgres:13                                                                                   
\ No newline at end of file                                                                                                       
+    newName: mirror.gcr.io/library/postgres:12                                                                                   
\ No newline at end of file                                                                                                       
```
* After 3scale finishes installing, upgrade the version to 0.14.0
* Check the operator and ensure that the version is 0.14.0 and no preflight error in the log



