### PR TITLE
THREESCALE-11021 add redis ACL credentials to system and backend

### DIFF
--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -735,14 +735,22 @@ The available configurable secrets are:
 | **Field** | **Description** | **Default value**                                                                                                 |
 | --- | --- |-------------------------------------------------------------------------------------------------------------------|
 | REDIS_STORAGE_URL | Backend's redis storage database URL. | Mandatory when the instance is managed externally. Otherwise the default value is: `redis://backend-redis:6379/0` |
-| REDIS_STORAGE_SENTINEL_ROLE | Backend's redis storage sentinel role name. Used only when Redis sentinel is configured in the Redis database being used | `""`                                                                                                              |
-| REDIS_STORAGE_SENTINEL_HOSTS | Backend's redis storage sentinel hosts name. Used only when Redis sentinel is configured in the Redis database being used | `""`                                                                                                              |
-| REDIS_QUEUES_URL | Backend's redis queues database URL | Mandatory when the instance is managed externally. Otherwise the default value is: `redis://backend-redis:6379/1` |
-| REDIS_QUEUES_SENTINEL_ROLE | Backend's redis queues sentinel role name. Used only when Redis sentinel is configured in the Redis database being used | `""`                                                                                                              |
-| REDIS_QUEUES_SENTINEL_HOSTS | Backend's redis queues sentinel hosts name. Used only when Redis sentinel is configured in the Redis database being used | `""`                                                                                                              |
+| REDIS_STORAGE_USERNAME | Backend's redis ACL creds - username. | `""` |
+| REDIS_STORAGE_PASSWORD | Backend's redis ACL creds - password. | `""` |
+| REDIS_STORAGE_SENTINEL_ROLE | Backend's redis storage sentinel role name. Used only when Redis sentinel is configured in the Redis database being used | `""` |
+| REDIS_STORAGE_SENTINEL_HOSTS | Backend's redis storage sentinel hosts name. Used only when Redis sentinel is configured in the Redis database being used | `""` |
+| REDIS_STORAGE_SENTINEL_USERNAME | Backend's redis sentinel ACL creds - username. | `""` |
+| REDIS_STORAGE_SENTINEL_PASSWORD | Backend's redis sentinel ACL creds - password. | `""` |
 | REDIS_SSL_CA | Redis Certificate Authority (CA) certificate | Required to set TLS Redis connection. Only for TLS  |
 | REDIS_SSL_CERT | Redis client certificate | Required to set TLS Redis connection. Only for TLS |
 | REDIS_SSL_KEY | The private key for the Redis client certificate | Required to set TLS Redis connection. Only for TLS |
+| REDIS_QUEUES_URL | Backend's redis queues database URL | Mandatory when the instance is managed externally. Otherwise the default value is: `redis://backend-redis:6379/1` |
+| REDIS_QUEUES_USERNAME | Backend's redis queues ACL creds - username. | `""` |
+| REDIS_QUEUES_PASSWORD | Backend's redis queues ACL creds - password. | `""` |
+| REDIS_QUEUES_SENTINEL_ROLE | Backend's redis queues sentinel role name. Used only when Redis sentinel is configured in the Redis database being used | `""`                                                                                                              |
+| REDIS_QUEUES_SENTINEL_HOSTS | Backend's redis queues sentinel hosts name. Used only when Redis sentinel is configured in the Redis database being used | `""`                                                                                                              |
+| REDIS_QUEUES_SENTINEL_USERNAME | Backend's redis queues sentinel ACL creds - username. | `""` |
+| REDIS_QUEUES_SENTINEL_PASSWORD | Backend's redis queues sentinel ACL creds - password. | `""` |
 | REDIS_SSL_QUEUES_CA | Redis Queues Certificate Authority (CA) certificate | Required to set TLS Redis connection. Only for TLS |
 | REDIS_SSL_QUEUES_CERT | Redis Queues client certificate | Required to set TLS Redis connection. Only for TLS |
 | REDIS_SSL_QUEUES_KEY | The private key for the Redis Queues client certificate | Required to set TLS Redis connection. Only for TLS |
@@ -826,9 +834,13 @@ For Oracle:
 | **Field** | **Description** | **Default value** |
 | --- | --- | --- |
 | URL | System's Redis database URL | Mandatory when instance is managed externally. Otherwise the default value is: `redis://system-redis:6379/1` |
+| REDIS_USERNAME | System's redis ACL creds - username. | `""` |
+| REDIS_PASSWORD | System's redis ACL creds - password. | `""` |
 | NAMESPACE | Define the namespace to be used by System's Redis Database. The empty value means not namespaced | `""` |
 | SENTINEL_HOSTS | System's Redis sentinel hosts. Used only when Redis sentinel is configured | `""` |
 | SENTINEL_ROLE | System's Redis sentinel role name. Used only when Redis sentinel is configured | `""` |
+| REDIS_SENTINEL_USERNAME | System's redis sentinel ACL creds - username. | `""` |
+| REDIS_SENTINEL_PASSWORD | System's redis sentinel ACL creds - password. | `""` |
 | REDIS_SSL_CA | Redis Certificate Authority (CA) certificate | Required to set TLS Redis connection. Only for TLS |
 | REDIS_SSL_CERT | Redis client certificate | Required to set TLS Redis connection. Only for TLS |
 | REDIS_SSL_KEY | The private key for the Redis client certificate | Required to set TLS Redis connection. Only for TLS |

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -1208,7 +1208,6 @@ kind: APIManager
 metadata:
   name: example-apimanager
 spec:
-  sentinelIsUsed: true
   system:
     fileStorage:
       simpleStorageService:

--- a/pkg/3scale/amp/component/backend.go
+++ b/pkg/3scale/amp/component/backend.go
@@ -24,13 +24,22 @@ const (
 )
 
 const (
-	BackendSecretBackendRedisSecretName                    = "backend-redis"
-	BackendSecretBackendRedisStorageURLFieldName           = "REDIS_STORAGE_URL"
-	BackendSecretBackendRedisQueuesURLFieldName            = "REDIS_QUEUES_URL"
-	BackendSecretBackendRedisStorageSentinelHostsFieldName = "REDIS_STORAGE_SENTINEL_HOSTS"
-	BackendSecretBackendRedisStorageSentinelRoleFieldName  = "REDIS_STORAGE_SENTINEL_ROLE"
-	BackendSecretBackendRedisQueuesSentinelHostsFieldName  = "REDIS_QUEUES_SENTINEL_HOSTS"
-	BackendSecretBackendRedisQueuesSentinelRoleFieldName   = "REDIS_QUEUES_SENTINEL_ROLE"
+	BackendSecretBackendRedisSecretName                      = "backend-redis"
+	BackendSecretBackendRedisQueuesURLFieldName              = "REDIS_QUEUES_URL"
+	BackendSecretBackendRedisQueuesUsernameFieldName         = "REDIS_QUEUES_USERNAME"
+	BackendSecretBackendRedisQueuesPasswordFieldName         = "REDIS_QUEUES_PASSWORD"
+	BackendSecretBackendRedisQueuesSentinelHostsFieldName    = "REDIS_QUEUES_SENTINEL_HOSTS"
+	BackendSecretBackendRedisQueuesSentinelRoleFieldName     = "REDIS_QUEUES_SENTINEL_ROLE"
+	BackendSecretBackendRedisQueuesSentinelUsernameFieldName = "REDIS_QUEUES_SENTINEL_USERNAME"
+	BackendSecretBackendRedisQueuesSentinelPasswordFieldName = "REDIS_QUEUES_SENTINEL_PASSWORD"
+
+	BackendSecretBackendRedisStorageURLFieldName              = "REDIS_STORAGE_URL"
+	BackendSecretBackendRedisStorageUsernameFieldName         = "REDIS_STORAGE_USERNAME"
+	BackendSecretBackendRedisStoragePasswordFieldName         = "REDIS_STORAGE_PASSWORD"
+	BackendSecretBackendRedisStorageSentinelHostsFieldName    = "REDIS_STORAGE_SENTINEL_HOSTS"
+	BackendSecretBackendRedisStorageSentinelRoleFieldName     = "REDIS_STORAGE_SENTINEL_ROLE"
+	BackendSecretBackendRedisStorageSentinelUsernameFieldName = "REDIS_STORAGE_SENTINEL_USERNAME"
+	BackendSecretBackendRedisStorageSentinelPasswordFieldName = "REDIS_STORAGE_SENTINEL_PASSWORD"
 )
 
 const (
@@ -419,6 +428,15 @@ func (backend *Backend) buildBackendCommonEnv() []v1.EnvVar {
 		helper.EnvVarFromSecret("CONFIG_QUEUES_MASTER_NAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesURLFieldName),
 		helper.EnvVarFromSecret("CONFIG_QUEUES_SENTINEL_HOSTS", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesSentinelHostsFieldName),
 		helper.EnvVarFromSecret("CONFIG_QUEUES_SENTINEL_ROLE", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesSentinelRoleFieldName),
+		// ACL
+		helper.EnvVarFromSecretOptional("CONFIG_REDIS_USERNAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageUsernameFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_REDIS_PASSWORD", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStoragePasswordFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_REDIS_SENTINEL_USERNAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageSentinelUsernameFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_REDIS_SENTINEL_PASSWORD", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageSentinelPasswordFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_QUEUES_USERNAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesUsernameFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_QUEUES_PASSWORD", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesPasswordFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_QUEUES_SENTINEL_USERNAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesSentinelUsernameFieldName),
+		helper.EnvVarFromSecretOptional("CONFIG_QUEUES_SENTINEL_PASSWORD", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisQueuesSentinelPasswordFieldName),
 		helper.EnvVarFromConfigMap("RACK_ENV", "backend-environment", "RACK_ENV"),
 	)
 	if backend.Options.BackendRedisTLSEnabled {

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -2,9 +2,10 @@ package component
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sort"
 	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	k8sappsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -56,6 +57,12 @@ const (
 	SystemSecretSystemRedisURLFieldName  = "URL"
 	SystemSecretSystemRedisSentinelHosts = "SENTINEL_HOSTS"
 	SystemSecretSystemRedisSentinelRole  = "SENTINEL_ROLE"
+
+	// ACL
+	SystemSecretSystemRedisUsernameFieldName         = "REDIS_USERNAME"
+	SystemSecretSystemRedisPasswordFieldName         = "REDIS_PASSWORD"
+	SystemSecretSystemRedisSentinelUsernameFieldName = "REDIS_SENTINEL_USERNAME"
+	SystemSecretSystemRedisSentinelPasswordFieldName = "REDIS_SENTINEL_PASSWORD"
 )
 
 const (
@@ -194,6 +201,11 @@ func (system *System) SystemRedisEnvVars() []v1.EnvVar {
 		helper.EnvVarFromSecret("REDIS_URL", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisURLFieldName),
 		helper.EnvVarFromSecret("REDIS_SENTINEL_HOSTS", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisSentinelHosts),
 		helper.EnvVarFromSecret("REDIS_SENTINEL_ROLE", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisSentinelRole),
+		// ACL
+		helper.EnvVarFromSecretOptional("REDIS_USERNAME", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisUsernameFieldName),
+		helper.EnvVarFromSecretOptional("REDIS_PASSWORD", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisPasswordFieldName),
+		helper.EnvVarFromSecretOptional("REDIS_SENTINEL_USERNAME", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisSentinelUsernameFieldName),
+		helper.EnvVarFromSecretOptional("REDIS_SENTINEL_PASSWORD", SystemSecretSystemRedisSecretName, SystemSecretSystemRedisSentinelPasswordFieldName),
 	)
 	if system.Options.RedisTLSEnabled {
 		result = append(result, system.SystemRedisTLSEnvVars()...)
@@ -369,6 +381,10 @@ func (system *System) BackendRedisEnvVars() []v1.EnvVar {
 		helper.EnvVarFromSecret("BACKEND_REDIS_URL", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageURLFieldName),
 		helper.EnvVarFromSecret("BACKEND_REDIS_SENTINEL_HOSTS", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageSentinelHostsFieldName),
 		helper.EnvVarFromSecret("BACKEND_REDIS_SENTINEL_ROLE", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageSentinelRoleFieldName),
+		helper.EnvVarFromSecretOptional("BACKEND_REDIS_USERNAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageUsernameFieldName),
+		helper.EnvVarFromSecretOptional("BACKEND_REDIS_PASSWORD", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStoragePasswordFieldName),
+		helper.EnvVarFromSecretOptional("BACKEND_REDIS_SENTINEL_USERNAME", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageSentinelUsernameFieldName),
+		helper.EnvVarFromSecretOptional("BACKEND_REDIS_SENTINEL_PASSWORD", BackendSecretBackendRedisSecretName, BackendSecretBackendRedisStorageSentinelPasswordFieldName),
 	)
 	if system.Options.RedisTLSEnabled {
 		result = append(result, system.BackendRedisTLSEnvVars()...)


### PR DESCRIPTION
## What

Fix https://issues.redhat.com/browse/THREESCALE-11021

Mostly copied from Valery's commit #1048 but removing unnecessary parts

## Verification steps
1. Checkout this branch
2. Prepare local env
```
make cluster/prepare/local
```
3. Create apim
```
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```
4. Run the operator locally
```
PREFLIGHT_CHECKS_BYPASS=true make run
```
5. Wait for the install to complete:
```
oc get apimanager 3scale -n 3scale-test -oyaml -w
```
6. Stop and remove apim
```
CTRL-C

make uninstall
```
8. Remove namespace
```
oc delete ns 3scale-test
```
9. Prepare local env again
```
make cluster/prepare/local
```
10. Update backend-redis and system-redis with password
```
oc set env deployment/backend-redis REDIS_PASSWORD=password
oc set env deployment/system-redis REDIS_PASSWORD=password
```
11. Update backend-redis secret
```
oc  patch secret backend-redis  --patch='{"stringData": { "REDIS_STORAGE_PASSWORD": "password" }}'
oc  patch secret backend-redis  --patch='{"stringData": { "REDIS_QUEUES_PASSWORD": "password" }}'

oc  patch secret system-redis  --patch='{"stringData": { "REDIS_PASSWORD": "password" }}'
```
12. Follow step 3-5 again
13. exec into the backend-listener and backend-worker pods to to confirm the env vars have been set e.g.
```
 ▲ ~ oc exec -it backend-listener-5d994d6d56-5gz7f -- printenv | grep _PASSWORD      
CONFIG_INTERNAL_API_PASSWORD=bJ6IgCTv                                                
CONFIG_QUEUES_PASSWORD=password                                                      
CONFIG_REDIS_PASSWORD=password                                                       
 ▲ ~ oc exec -it backend-worker-57d7ffcc89-w8dfv -- printenv | grep _PASSWORD        
Defaulted container "backend-worker" out of: backend-worker, backend-redis-svc (init)
CONFIG_QUEUES_PASSWORD=password                                                      
CONFIG_REDIS_PASSWORD=password                                                                                                             
``` 
14. Update backend-redis password
```
oc set env deployment/backend-redis REDIS_PASSWORD=password22
```
15. Backend-pod should enter crashloopback state

### Test with Redis ACL

16. Login into backend-redis and create a new user
```
$ redis-cli ACL SETUSER guest on >password

OK
```
17. Confirm the new user is created
```
$redis-cli ACL LIST

127.0.0.1:6379> ACL LIST
1) "user default on nopass sanitize-payload ~* &* +@all"
2) "user guest on sanitize-payload #5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8 resetchannels -@all"
127.0.0.1:6379> 
```
18. Check whether we can login with new user, 
```
$redis-cli AUTH guest password
OK
```
you should receive `OK` , if wrong password is provided you will see the following
```
(error) WRONGPASS invalid username-password pair or user is disabled.
```
19. Update backend-redis secret
```
oc  patch secret backend-redis  --patch='{"stringData": { "REDIS_STORAGE_USERNAME": "guest" }}'
oc  patch secret backend-redis  --patch='{"stringData": { "REDIS_QUEUES_USERNAME": "guest" }}'
oc  patch secret system-redis  --patch='{"stringData": { "REDIS_USERNAME": "guest" }}'
```
20.  Backend-pod should come online
21. exec into the backend-listener and backend-worker pods to to confirm the env vars have been set e.g.
```
 ▲ ~ oc exec -it backend-listener-5d994d6d56-5gz7f -- printenv | grep _USERNAME
CONFIG_QUEUES_USERNAME=guest                                                      
CONFIG_REDIS_USERNAME=guest                                                       
 ▲ ~ oc exec -it backend-worker-57d7ffcc89-w8dfv -- printenv | grep _USERNAME        
Defaulted container "backend-worker" out of: backend-worker, backend-redis-svc (init)
CONFIG_QUEUES_USERNAME=guest                                                      
CONFIG_REDIS_USERNAME=guest                                                                                                             
``` 