### PR TITLE
THREESCALE-11719 openshift 4.18 support and version bump

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -242,7 +242,7 @@ metadata:
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
     description: 3scale Operator to provision 3scale and publish/manage API
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.18"}]'
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["Red Hat Integration", "Red Hat 3scale API Management"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0

--- a/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     containerImage: quay.io/3scale/3scale-operator:master
     createdAt: "2019-05-30T22:40:00Z"
     description: 3scale Operator to provision 3scale and publish/manage API
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.18"}]'
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["Red Hat Integration", "Red Hat 3scale API Management"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0

--- a/version/version.go
+++ b/version/version.go
@@ -5,8 +5,8 @@ import (
 )
 
 var (
-	Version           = "0.12.2"
-	threescaleRelease = "2.15.2"
+	Version           = "0.12.3"
+	threescaleRelease = "2.15.3"
 )
 
 func ThreescaleVersionMajorMinor() string {


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-11719

- Openshift 4.18 support
- Version bumps to prep 2.15.3