### PR TITLE
THREESCALE-11757 fix local dev make cluster/create/system-mysql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,6 @@ jobs:
     resource_class: large
     steps:
       - unit-tests
-      - run:
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-          when: always
 
   test-crds:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,9 @@ cluster/create/system-postgres:
 .PHONY: cluster/create/system-mysql
 cluster/create/system-mysql:
 	sed "s/\$$(NAMESPACE)/$(NAMESPACE)/g" ./config/dev-databases/system-mysql/secret.yaml > ./config/dev-databases/system-mysql/secret-processed.yaml
-	sed "s/\$$(NAMESPACE)/$(NAMESPACE)/g" ./config/dev-databases/system-mysql/mysql-main-conf.yaml > ./config/dev-databases/system-mysql/mysql-main-conf-processed.yaml
-	sed "s/\$$(NAMESPACE)/$(NAMESPACE)/g" ./config/dev-databases/system-mysql/mysql-extra-conf.yaml > ./config/dev-databases/system-mysql/mysql-extra-conf-processed.yaml
 	kustomize build ./config/dev-databases/system-mysql | kubectl apply -f -
 	rm ./config/dev-databases/system-mysql/secret-processed.yaml
-	rm ./config/dev-databases/system-mysql/mysql-main-conf-processed.yaml
-	rm ./config/dev-databases/system-mysql/mysql-extra-conf-processed.yaml
+
 
 .PHONY: cluster/create/provision-database
 cluster/create/provision-database:

--- a/config/dev-databases/system-mysql/kustomization.yaml
+++ b/config/dev-databases/system-mysql/kustomization.yaml
@@ -3,8 +3,6 @@ resources:
   - service.yaml
   - pvc.yaml
   - secret-processed.yaml
-  - mysql-main-conf-processed.yaml
-  - mysql-extra-conf-processed.yaml
 
 images:
   - name: mysql


### PR DESCRIPTION
# What
fix `make cluster/create/system-mysql`

# Verify
- run  `make cluster/create/system-mysql` against a cluster
- confirm that it completes successfully 
```bash
make cluster/create/system-mysql
make[1]: Entering directory '/home/austincunningham/repo/3scale-operator'
sed "s/\$(NAMESPACE)/3scale-test/g" ./config/dev-databases/system-mysql/secret.yaml > ./config/dev-databases/system-mysql/secret-processed.yaml
kustomize build ./config/dev-databases/system-mysql | kubectl apply -f -
secret/system-database created
service/system-mysql created
persistentvolumeclaim/system-mysql-pvc created
deployment.apps/system-mysql created
rm ./config/dev-databases/system-mysql/secret-processed.yaml
make[1]: Leaving directory '/home/3scale-operator'
```