### PR TITLE
THREESCALE-11758: Add environment variable to zync-database container to redirect all logs to stdout

### DIFF
--- a/pkg/3scale/amp/component/zync.go
+++ b/pkg/3scale/amp/component/zync.go
@@ -487,6 +487,10 @@ func (zync *Zync) DatabaseDeployment(containerImage string) *k8sappsv1.Deploymen
 									Name:  "POSTGRESQL_DATABASE",
 									Value: "zync_production",
 								},
+								{
+									Name:  "POSTGRESQL_LOG_DESTINATION",
+									Value: "/dev/stderr",
+								},
 							},
 							LivenessProbe: &v1.Probe{
 								ProbeHandler: v1.ProbeHandler{


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/THREESCALE-11758

