### PR TITLE
THREESCALE-11850  Preflight check fails on redis-sentinel

### DIFF
--- a/pkg/helper/redis_database_version_helper.go
+++ b/pkg/helper/redis_database_version_helper.go
@@ -162,7 +162,6 @@ func configureRedisSentinel(cfg *RedisConfig) (*goredis.Client, error) {
 	}
 
 	client := goredis.NewFailoverClient(opts)
-
 	return client, nil
 }
 
@@ -182,9 +181,12 @@ func sentinelOptions(cfg *RedisConfig) (*goredis.FailoverOptions, error) {
 
 	sentinels := make([]string, len(urls))
 
-	// 3scale system does not support username/password in the sentinel URL.
 	for i := range urls {
 		url := strings.TrimSpace(urls[i])
+		// Backward compatible, assmuming the scheme to be redis if missing
+		if !strings.Contains(url, "://") {
+			url = "redis://" + url
+		}
 		opt, err := goredis.ParseURL(url)
 		if err != nil {
 			return nil, err

--- a/pkg/helper/redis_database_version_test.go
+++ b/pkg/helper/redis_database_version_test.go
@@ -246,7 +246,7 @@ func TestSentinelOptions(t *testing.T) {
 		expected    *redis.FailoverOptions
 	}{
 		{
-			"no sentiel master",
+			"no sentinel master",
 			&RedisConfig{
 				SentinelURL: "redis://sentinel1:5000",
 			},
@@ -255,7 +255,7 @@ func TestSentinelOptions(t *testing.T) {
 			},
 		},
 		{
-			"with sentiel master",
+			"with sentinel master",
 			&RedisConfig{
 				URL:         "redis://master:3000/1",
 				SentinelURL: "redis://sentinel1:5000",
@@ -269,7 +269,7 @@ func TestSentinelOptions(t *testing.T) {
 			"with username/password in master url",
 			&RedisConfig{
 				URL:         "redis://username:password@master:3000/1",
-				SentinelURL: "redis://sentinel:sentinelpass@sentinel1:5000",
+				SentinelURL: "redis://sentinel1:5000",
 			},
 			&redis.FailoverOptions{
 				MasterName:    "master",
@@ -282,10 +282,22 @@ func TestSentinelOptions(t *testing.T) {
 			"with multiple sentiels",
 			&RedisConfig{
 				URL:         "redis://master:3000/1",
-				SentinelURL: "redis://sentinel:sentinelpass@sentinel1:5000, redis://sentinel2:5000, redis://sentinel3:5000",
+				SentinelURL: "redis://sentinel1:5000, redis://sentinel2:5000, redis://sentinel3:5000",
 			},
 			&redis.FailoverOptions{
 				MasterName:    "master",
+				SentinelAddrs: []string{"sentinel1:5000", "sentinel2:5000", "sentinel3:5000"},
+			},
+		},
+		{
+			"sentinels without scheme",
+			&RedisConfig{
+				URL:         "redis://:pass@master:3000/1",
+				SentinelURL: "sentinel1:5000, sentinel2:5000, sentinel3:5000",
+			},
+			&redis.FailoverOptions{
+				MasterName:    "master",
+				Password:      "pass",
 				SentinelAddrs: []string{"sentinel1:5000", "sentinel2:5000", "sentinel3:5000"},
 			},
 		},


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-11850

## Verification steps
* Checkout this branch
* Modify system-redis secret as follow
```diff
diff --git a/config/dev-databases/system-redis/secret.yaml b/config/dev-databases/system-redis/secret.yaml
index 4af6d7c4..f75260f3 100644                                                                           
--- a/config/dev-databases/system-redis/secret.yaml                                                       
+++ b/config/dev-databases/system-redis/secret.yaml                                                       
@@ -3,7 +3,7 @@ kind: Secret                                                                              
 metadata:                                                                                                
   name: system-redis                                                                                     
 stringData:                                                                                              
-  SENTINEL_HOSTS: ""                                                                                     
-  SENTINEL_ROLE: ""                                                                                      
-  URL: redis://system-redis.$(NAMESPACE).svc.cluster.local:6379/1                                        
+  SENTINEL_HOSTS: ":sentinelpass@redis-sentinel.3scale-test.svc.cluster.local:26379"                     
+  SENTINEL_ROLE: "master"                                                                                
+  URL: redis://:redispass@mymaster:6379/1                                                                
 type: Opaque 
```
* Prepare local env
```
make cluster/prepare/project
make cluster/create/backend-redis
make cluster/create/system-redis
make cluster/create/system-mysql
```
* Create apim
```
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF
```
* Setup redis password
```
oc set env deployment/system-redis REDIS_PASSWORD=redispass
```
* Prepare redis-sentinel
```
cat << EOF | oc create -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: redis-sentinel-config 
data:
  sentinel.conf: |
    requirepass sentinelpass

    sentinel monitor mymaster system-redis.3scale-test.svc.cluster.local 6379 2
     
    sentinel down-after-milliseconds mymaster 5000
    sentinel failover-timeout mymaster 10000
    sentinel parallel-syncs mymaster 1
    sentinel auth-pass mymaster redispass
    sentinel resolve-hostnames yes
    sentinel announce-hostnames no
EOF
```
* Run redis-sentinel
```
cat << EOF | oc create -f -
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: redis-sentinel
spec:
  serviceName: "redis-sentinel"
  replicas: 3
  selector:
    matchLabels:
      app: redis-sentinel
  template:
    metadata:
      labels:
        app: redis-sentinel
    spec:
      initContainers:
        - name: copy-sentinel-config
          image: mirror.gcr.io/library/redis:7
          command: ["/bin/sh", "-c", "cp /etc/redis/sentinel.conf /mnt/config/sentinel.conf"]
          volumeMounts:
            - name: redis-config-volume
              mountPath: /etc/redis/sentinel.conf
              subPath: sentinel.conf  # Read-only mount from ConfigMap
            - name: sentinel-config-writable
              mountPath: /mnt/config  # Writable volume for copying the file
      containers:
        - name: redis-sentinel
          image: mirror.gcr.io/library/redis:7
          ports:
            - containerPort: 26379
            - containerPort: 26380
          volumeMounts:
            - name: sentinel-config-writable
              mountPath: /mnt/config  # Use writable volume for accessing sentinel.conf
          # Command now points to the correct location in the writable volume
          command: ["/bin/sh", "-c", "redis-server /mnt/config/sentinel.conf --sentinel"]
      volumes:
        - name: redis-config-volume
          configMap:
            name: redis-sentinel-config
        - name: sentinel-config-writable
          emptyDir: {}  # Writable volume to store the sentinel.conf
EOF
```
* Create redis-sentinel service
```
cat << EOF | oc create -f -
apiVersion: v1
kind: Service
metadata:
  name: redis-sentinel
spec:
  selector:
    app: redis-sentinel
  ports:
    - name: redis-sentinel
      protocol: TCP
      port: 26379 
      targetPort: 26379 
  clusterIP: None  # This makes the service headless
EOF
```
* Create new catalog
```
cat << EOF | oc create -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: threescale-dev
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/an_tran/3scale-index:v0.95.0
EOF
```
* Navigate to 3scale-test ns and install 3scale from threescale-dev catalog
* create apim with the following spec
```
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
```
* Check operator log, all preflight check shall pass