### PR TITLE
THREESCALE-11805 refactor system-app migration jobs

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -555,15 +555,15 @@ func (system *System) appPodVolumes() []v1.Volume {
 					Name: "system",
 				},
 				Items: []v1.KeyToPath{
-					v1.KeyToPath{
+					{
 						Key:  "zync.yml",
 						Path: "zync.yml",
 					},
-					v1.KeyToPath{
+					{
 						Key:  "rolling_updates.yml",
 						Path: "rolling_updates.yml",
 					},
-					v1.KeyToPath{
+					{
 						Key:  "service_discovery.yml",
 						Path: "service_discovery.yml",
 					},
@@ -663,7 +663,7 @@ func (system *System) appPodVolumes() []v1.Volume {
 			VolumeSource: v1.VolumeSource{
 				Projected: &v1.ProjectedVolumeSource{
 					Sources: []v1.VolumeProjection{
-						v1.VolumeProjection{
+						{
 							ServiceAccountToken: &v1.ServiceAccountTokenProjection{
 								Audience:          system.Options.S3FileStorageOptions.STSAudience,
 								ExpirationSeconds: &[]int64{3600}[0],
@@ -983,7 +983,8 @@ func (system *System) SidekiqPodVolumes() []v1.Volume {
 	systemTmpVolume := v1.Volume{
 		Name: "system-tmp",
 		VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{
-			Medium: v1.StorageMediumMemory}},
+			Medium: v1.StorageMediumMemory,
+		}},
 	}
 
 	res = append(res, systemTmpVolume)
@@ -993,24 +994,26 @@ func (system *System) SidekiqPodVolumes() []v1.Volume {
 
 	systemConfigVolume := v1.Volume{
 		Name: "system-config",
-		VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{
-			LocalObjectReference: v1.LocalObjectReference{
-				Name: "system",
-			},
-			Items: []v1.KeyToPath{
-				v1.KeyToPath{
-					Key:  "zync.yml",
-					Path: "zync.yml",
-				}, v1.KeyToPath{
-					Key:  "rolling_updates.yml",
-					Path: "rolling_updates.yml",
+		VolumeSource: v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "system",
 				},
-				v1.KeyToPath{
-					Key:  "service_discovery.yml",
-					Path: "service_discovery.yml",
+				Items: []v1.KeyToPath{
+					{
+						Key:  "zync.yml",
+						Path: "zync.yml",
+					},
+					{
+						Key:  "rolling_updates.yml",
+						Path: "rolling_updates.yml",
+					},
+					{
+						Key:  "service_discovery.yml",
+						Path: "service_discovery.yml",
+					},
 				},
 			},
-		},
 		},
 	}
 
@@ -1055,7 +1058,7 @@ func (system *System) SidekiqPodVolumes() []v1.Volume {
 			VolumeSource: v1.VolumeSource{
 				Projected: &v1.ProjectedVolumeSource{
 					Sources: []v1.VolumeProjection{
-						v1.VolumeProjection{
+						{
 							ServiceAccountToken: &v1.ServiceAccountTokenProjection{
 								Audience:          system.Options.S3FileStorageOptions.STSAudience,
 								ExpirationSeconds: &[]int64{3600}[0],
@@ -1211,6 +1214,7 @@ func (system *System) systemConfigVolumeMount() v1.VolumeMount {
 		MountPath: "/opt/system-extra-configs",
 	}
 }
+
 func (system *System) systemTlsVolumeMount() v1.VolumeMount {
 	return v1.VolumeMount{
 		Name:      "writable-tls",
@@ -1332,7 +1336,7 @@ func (system *System) ProviderService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,
 					Port:       3000,
@@ -1356,7 +1360,7 @@ func (system *System) MasterService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,
 					Port:       3000,
@@ -1380,7 +1384,7 @@ func (system *System) DeveloperService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,
 					Port:       3000,
@@ -1404,7 +1408,7 @@ func (system *System) MemcachedService() *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:       "memcache",
 					Protocol:   v1.ProtocolTCP,
 					Port:       11211,
@@ -1732,6 +1736,7 @@ func (system *System) systemRedisTlsVolumeMount() v1.VolumeMount {
 		MountPath: "/tls/system-redis",
 	}
 }
+
 func (system *System) backendRedisTlsVolumeMount() v1.VolumeMount {
 	return v1.VolumeMount{
 		Name:      "backend-redis-tls",

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -884,7 +884,7 @@ func (system *System) AppDeployment(ctx context.Context, k8sclient client.Client
 	}, nil
 }
 
-func (system *System) AppPreHookJob(containerImage string, currentSystemAppGeneration int64) *batchv1.Job {
+func (system *System) AppPreHookJob(containerImage string, namespace string, currentSystemAppGeneration int64) *batchv1.Job {
 	var completions int32 = 1
 
 	return &batchv1.Job{
@@ -893,8 +893,9 @@ func (system *System) AppPreHookJob(containerImage string, currentSystemAppGener
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   SystemAppPreHookJobName,
-			Labels: system.Options.CommonAppLabels,
+			Name:      SystemAppPreHookJobName,
+			Namespace: namespace,
+			Labels:    system.Options.CommonAppLabels,
 			Annotations: map[string]string{
 				helper.SystemAppGenerationAnnotation: strconv.FormatInt(currentSystemAppGeneration, 10),
 			},
@@ -925,7 +926,7 @@ func (system *System) AppPreHookJob(containerImage string, currentSystemAppGener
 	}
 }
 
-func (system *System) AppPostHookJob(containerImage string, currentSystemAppGeneration int64) *batchv1.Job {
+func (system *System) AppPostHookJob(containerImage string, namespace string, currentSystemAppGeneration int64) *batchv1.Job {
 	var completions int32 = 1
 
 	return &batchv1.Job{
@@ -934,8 +935,9 @@ func (system *System) AppPostHookJob(containerImage string, currentSystemAppGene
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   SystemAppPostHookJobName,
-			Labels: system.Options.CommonAppLabels,
+			Name:      SystemAppPostHookJobName,
+			Namespace: namespace,
+			Labels:    system.Options.CommonAppLabels,
 			Annotations: map[string]string{
 				helper.SystemAppGenerationAnnotation: strconv.FormatInt(currentSystemAppGeneration, 10),
 			},

--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -884,7 +884,7 @@ func (system *System) AppDeployment(ctx context.Context, k8sclient client.Client
 	}, nil
 }
 
-func (system *System) AppPreHookJob(containerImage string, namespace string, currentSystemAppGeneration int64) *batchv1.Job {
+func (system *System) AppPreHookJob(containerImage string, namespace string, currentSystemAppRevision int64) *batchv1.Job {
 	var completions int32 = 1
 
 	return &batchv1.Job{
@@ -897,7 +897,7 @@ func (system *System) AppPreHookJob(containerImage string, namespace string, cur
 			Namespace: namespace,
 			Labels:    system.Options.CommonAppLabels,
 			Annotations: map[string]string{
-				helper.SystemAppGenerationAnnotation: strconv.FormatInt(currentSystemAppGeneration, 10),
+				helper.SystemAppRevisionAnnotation: strconv.FormatInt(currentSystemAppRevision, 10),
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -926,7 +926,7 @@ func (system *System) AppPreHookJob(containerImage string, namespace string, cur
 	}
 }
 
-func (system *System) AppPostHookJob(containerImage string, namespace string, currentSystemAppGeneration int64) *batchv1.Job {
+func (system *System) AppPostHookJob(containerImage string, namespace string, currentSystemAppRevision int64) *batchv1.Job {
 	var completions int32 = 1
 
 	return &batchv1.Job{
@@ -939,7 +939,7 @@ func (system *System) AppPostHookJob(containerImage string, namespace string, cu
 			Namespace: namespace,
 			Labels:    system.Options.CommonAppLabels,
 			Annotations: map[string]string{
-				helper.SystemAppGenerationAnnotation: strconv.FormatInt(currentSystemAppGeneration, 10),
+				helper.SystemAppRevisionAnnotation: strconv.FormatInt(currentSystemAppRevision, 10),
 			},
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -380,7 +380,7 @@ func (r *SystemReconciler) systemAppDeploymentResourceMutator(desired, existing 
 
 	// Check containers
 	if len(desired.Spec.Template.Spec.Containers) != 3 {
-		return false, fmt.Errorf(fmt.Sprintf("%s desired spec.template.spec.containers length changed to '%d', should be 3", desiredName, len(desired.Spec.Template.Spec.Containers)))
+		return false, fmt.Errorf("%s desired spec.template.spec.containers length changed to '%d', should be 3", desiredName, len(desired.Spec.Template.Spec.Containers))
 	}
 
 	if len(existing.Spec.Template.Spec.Containers) != 3 {

--- a/pkg/helper/job.go
+++ b/pkg/helper/job.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	k8sappsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -39,20 +38,31 @@ func UIDBasedJobName(prefix string, uid types.UID) (string, error) {
 	return jobName, err
 }
 
+func lookupJob(ctx context.Context, job k8sclient.Object, client k8sclient.Client) (*batchv1.Job, error) {
+	lookupKey := types.NamespacedName{
+		Name:      job.GetName(),
+		Namespace: job.GetNamespace(),
+	}
+
+	lookup := &batchv1.Job{}
+
+	if err := client.Get(ctx, lookupKey, lookup); err != nil {
+		return nil, err
+	}
+
+	return lookup, nil
+}
+
 // HasJobCompleted checks if the provided Job has completed
-func HasJobCompleted(jName string, jNamespace string, client k8sclient.Client) bool {
-	job := &batchv1.Job{}
-	err := client.Get(context.TODO(), k8sclient.ObjectKey{
-		Namespace: jNamespace,
-		Name:      jName,
-	}, job)
+func HasJobCompleted(ctx context.Context, job k8sclient.Object, client k8sclient.Client) bool {
+	lookup, err := lookupJob(ctx, job, client)
 	// Return false on error
 	if err != nil {
 		return false
 	}
 
 	// Check if Job has completed
-	jobConditions := job.Status.Conditions
+	jobConditions := lookup.Status.Conditions
 	for _, condition := range jobConditions {
 		if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {
 			return true
@@ -63,7 +73,7 @@ func HasJobCompleted(jName string, jNamespace string, client k8sclient.Client) b
 }
 
 // HasAppGenerationChanged returns true if the system-app Deployment's generation doesn't match the Job's annotation tracking it
-func HasAppGenerationChanged(jName string, dName string, namespace string, client k8sclient.Client) (bool, error) {
+func HasAppGenerationChanged(jName string, generation int64, namespace string, client k8sclient.Client) (bool, error) {
 	job := &batchv1.Job{}
 	err := client.Get(context.TODO(), k8sclient.ObjectKey{
 		Namespace: namespace,
@@ -74,20 +84,6 @@ func HasAppGenerationChanged(jName string, dName string, namespace string, clien
 		return false, fmt.Errorf("error getting job %s: %w", job.Name, err)
 	}
 	// Return false if the Job doesn't exist yet
-	if k8serr.IsNotFound(err) {
-		return false, nil
-	}
-
-	deployment := &k8sappsv1.Deployment{}
-	err = client.Get(context.TODO(), k8sclient.ObjectKey{
-		Namespace: namespace,
-		Name:      dName,
-	}, deployment)
-	// Return error if can't get Deployment
-	if err != nil && !k8serr.IsNotFound(err) {
-		return false, fmt.Errorf("error getting deployment %s: %w", deployment.Name, err)
-	}
-	// Return false if the Deployment doesn't exist yet
 	if k8serr.IsNotFound(err) {
 		return false, nil
 	}
@@ -106,14 +102,14 @@ func HasAppGenerationChanged(jName string, dName string, namespace string, clien
 	}
 
 	// Return true if the Deployment's version doesn't match the version tracked in the Job's annotation
-	if trackedGeneration != deployment.ObjectMeta.Generation {
+	if trackedGeneration != generation {
 		return true, nil
 	}
 
 	return false, nil
 }
 
-func DeleteJob(jName string, jNamespace string, client k8sclient.Client) error {
+func DeleteJob(ctx context.Context, jName string, jNamespace string, client k8sclient.Client) error {
 	job := &batchv1.Job{}
 	err := client.Get(context.TODO(), k8sclient.ObjectKey{
 		Namespace: jNamespace,
@@ -129,7 +125,7 @@ func DeleteJob(jName string, jNamespace string, client k8sclient.Client) error {
 	}
 
 	// Return error if Job is currently running
-	if !HasJobCompleted(job.Name, job.Namespace, client) {
+	if !HasJobCompleted(ctx, job, client) {
 		return fmt.Errorf("won't delete job %s because it's still running", job.Name)
 	}
 
@@ -147,4 +143,18 @@ func DeleteJob(jName string, jNamespace string, client k8sclient.Client) error {
 	}
 
 	return nil
+}
+
+func JobExists(ctx context.Context, job k8sclient.Object, client k8sclient.Client) (bool, error) {
+	_, err := lookupJob(ctx, job, client)
+
+	if err == nil {
+		return true, nil
+	}
+
+	if k8serr.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, err
 }

--- a/pkg/helper/job.go
+++ b/pkg/helper/job.go
@@ -46,7 +46,6 @@ func HasJobCompleted(jName string, jNamespace string, client k8sclient.Client) b
 		Namespace: jNamespace,
 		Name:      jName,
 	}, job)
-
 	// Return false on error
 	if err != nil {
 		return false

--- a/pkg/helper/job.go
+++ b/pkg/helper/job.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	SystemAppGenerationAnnotation = "system-app-deployment-generation"
+	SystemAppRevisionAnnotation = "system-app-deployment-generation"
 )
 
 // UIDBasedJobName returns a Job name that is compromised of the provided prefix,
@@ -72,8 +72,8 @@ func HasJobCompleted(ctx context.Context, job k8sclient.Object, client k8sclient
 	return false
 }
 
-// HasAppGenerationChanged returns true if the system-app Deployment's generation doesn't match the Job's annotation tracking it
-func HasAppGenerationChanged(jName string, generation int64, namespace string, client k8sclient.Client) (bool, error) {
+// HasAppRevisionChanged returns true if the system-app Deployment's revision doesn't match the Job's annotation tracking it
+func HasAppRevisionChanged(jName string, revision int64, namespace string, client k8sclient.Client) (bool, error) {
 	job := &batchv1.Job{}
 	err := client.Get(context.TODO(), k8sclient.ObjectKey{
 		Namespace: namespace,
@@ -88,21 +88,21 @@ func HasAppGenerationChanged(jName string, generation int64, namespace string, c
 		return false, nil
 	}
 
-	// Parse the Job's observed Deployment generation from its annotations
-	var trackedGeneration int64 = 1
+	// Parse the Job's observed Deployment revision from its annotations
+	var trackedRevision int64 = 1
 	if job.Annotations != nil {
 		for key, val := range job.Annotations {
-			if key == SystemAppGenerationAnnotation {
-				trackedGeneration, err = strconv.ParseInt(val, 10, 64)
+			if key == SystemAppRevisionAnnotation {
+				trackedRevision, err = strconv.ParseInt(val, 10, 64)
 				if err != nil {
-					return false, fmt.Errorf("failed to parse system-app Deployment's generation from job %s annotations: %w", job.Name, err)
+					return false, fmt.Errorf("failed to parse system-app Deployment's revision from job %s annotations: %w", job.Name, err)
 				}
 			}
 		}
 	}
 
 	// Return true if the Deployment's version doesn't match the version tracked in the Job's annotation
-	if trackedGeneration != generation {
+	if trackedRevision != revision {
 		return true, nil
 	}
 


### PR DESCRIPTION
## What

Fix https://issues.redhat.com/browse/THREESCALE-11805

Change the hook jobs to fire when the deployment revision changes instead of generation, meaning the jobs will only run when a new deployment is deployed/rolled out (similar to DeploymentConfig hooks)

IMO, this is still not the best approach as it relies heavily on the fact that users won't delete completed jobs. The alternative to using the operator version is unnecessarily complex so I'm happy with this solution for now until I figure out a better one.

## Verification steps
* Checkout this branch
* Prepare cluster
```
make cluster/prepare/local
```
* Create APIManager
``` bash
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```
* Start the operator
```
make run
```
* Wait for the deployment to complete
* The system-app pre/post hooks should run once
* Change the system-app replias to `0`
* system-app pre/post hooks should not trigger
* Change the system-app replias to `1`. Again this should not trigger the job
* Rollout
```
oc rollout restart deployment/system-app
```
* The above will trigger new hook jobs