### PR TITLE
THREESCALE-11884 - Fix unable to set ApplicationKey by ApplicationAuth CR when using OIDC auth

### DIFF
--- a/controllers/capabilities/applicationauth_controller.go
+++ b/controllers/capabilities/applicationauth_controller.go
@@ -248,12 +248,7 @@ func (r *ApplicationAuthReconciler) applicationAuthReconciler(
 	}
 	if authSecret.UserKey != "" {
 		params := make(map[string]string)
-		// this key "user_key" is configurable so will need to get the product to see if its the default or not
-		if product.Spec.AuthUserKey() == nil {
-			params["user_key"] = authSecret.UserKey
-		} else {
-			params[*product.Spec.AuthUserKey()] = authSecret.UserKey
-		}
+		params["user_key"] = authSecret.UserKey
 		// edge case if the operator is stopped before reconcile finished need to nil check application.Status.ID
 		if application.Status.ID != nil {
 			_, err := threescaleClient.UpdateApplication(*developerAccount.Status.ID, *application.Status.ID, params)

--- a/controllers/capabilities/applicationauth_controller_test.go
+++ b/controllers/capabilities/applicationauth_controller_test.go
@@ -99,7 +99,7 @@ func TestApplicationAuthReconciler_applicationAuthReconciler(t *testing.T) {
 			r := &ApplicationAuthReconciler{
 				BaseReconciler: tt.fields.BaseReconciler,
 			}
-			err := r.applicationAuthReconciler(tt.args.applicationAuth, tt.args.developerAccount, tt.args.application, tt.args.product, tt.args.authSecret, tt.args.threescaleClient)
+			err := r.applicationAuthReconciler(tt.args.applicationAuth, *tt.args.developerAccount.Status.ID, *tt.args.application.Status.ID, tt.args.product, tt.args.authSecret, tt.args.threescaleClient)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applicationAuthReconciler() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/capabilities/applicationauth_controller_test.go
+++ b/controllers/capabilities/applicationauth_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"reflect"
 	"strconv"
 	"testing"
 
@@ -100,16 +99,10 @@ func TestApplicationAuthReconciler_applicationAuthReconciler(t *testing.T) {
 			r := &ApplicationAuthReconciler{
 				BaseReconciler: tt.fields.BaseReconciler,
 			}
-			got, err := r.applicationAuthReconciler(tt.args.applicationAuth, tt.args.developerAccount, tt.args.application, tt.args.product, tt.args.authSecret, tt.args.threescaleClient)
+			err := r.applicationAuthReconciler(tt.args.applicationAuth, tt.args.developerAccount, tt.args.application, tt.args.product, tt.args.authSecret, tt.args.threescaleClient)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applicationAuthReconciler() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-			if !reflect.DeepEqual(got.reconcileError, tt.want.reconcileError) {
-				t.Errorf("applicationAuthReconciler() got = %v, want %v", got.reconcileError, tt.want.reconcileError)
-			}
-			if !reflect.DeepEqual(got.resource, tt.want.resource) {
-				t.Errorf("applicationAuthReconciler() got = %v, want %v", got.resource, tt.want.resource)
 			}
 		})
 	}

--- a/controllers/capabilities/applicationauth_controller_test.go
+++ b/controllers/capabilities/applicationauth_controller_test.go
@@ -1,108 +1,323 @@
 package controllers
 
 import (
-	"bytes"
-	"io"
+	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"slices"
 	"strconv"
+	"strings"
 	"testing"
 
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
-	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/pkg/helper"
 	threescaleapi "github.com/3scale/3scale-porta-go-client/client"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func TestApplicationAuthReconciler_applicationAuthReconciler(t *testing.T) {
-	ap, _ := threescaleapi.NewAdminPortalFromStr("https://3scale-admin.test.3scale.net")
-	applicationKey := "4efd48e3e2ecfdea1fc21eeddf0610b9"
+func TestApplicationAuthReconciler_syncApplicationAuth(t *testing.T) {
+	logger := logf.Log.WithName("applicationAuth")
 	appID := int64(3)
 	userAccountID := int64(3)
-	applicationUpdate := &threescaleapi.ApplicationElem{
-		Application: threescaleapi.Application{
-			UserAccountID: strconv.FormatInt(userAccountID, 10),
-			ID:            appID,
-			AppName:       "newName",
-		},
-	}
-	applicationKeyCreate := &threescaleapi.ApplicationElem{
-		Application: threescaleapi.Application{
-			ID: appID,
-		},
-	}
-	applicationKeyList := &threescaleapi.ApplicationKeysElem{
-		Keys: []threescaleapi.ApplicationKeyWrapper{
-			{
-				Key: threescaleapi.ApplicationKey{
-					Value: applicationKey,
-				},
-			},
-		},
-	}
 
-	type fields struct {
-		BaseReconciler *reconcilers.BaseReconciler
-	}
-	type args struct {
-		applicationAuth  *capabilitiesv1beta1.ApplicationAuth
-		developerAccount *capabilitiesv1beta1.DeveloperAccount
-		application      *capabilitiesv1beta1.Application
-		product          *capabilitiesv1beta1.Product
-		authSecret       AuthSecret
-		threescaleClient *threescaleapi.ThreeScaleClient
-	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *ApplicationAuthStatusReconciler
-		wantErr bool
+		name        string
+		mockServer  *mockApplicationAuthServer
+		authMode    string
+		authSecret  AuthSecret
+		expectedKey string
+		wantErr     bool
 	}{
 		{
-			name: "Test generate secret",
-			fields: fields{
-				BaseReconciler: getBaseReconciler(getEmptyAuthSecretObj()),
+			name: "Empty userkey with empty secret",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "1",
+				userKey:       "",
+				userAccountID: appID,
+				appID:         userAccountID,
 			},
-			args: args{
-				applicationAuth:  getApplicationAuthGenerateSecret(),
-				application:      getApplicationCR(),
-				product:          getProductCR(),
-				developerAccount: getApplicationDeveloperAccount(),
-				authSecret:       getEmptyAuthSecret(),
-				threescaleClient: threescaleapi.NewThreeScale(ap, "test", mockHttpApplicationAuthClient(applicationUpdate, applicationKeyCreate, applicationKeyList)),
+			authMode:    "1",
+			authSecret:  getEmptyAuthSecret(),
+			expectedKey: "",
+			wantErr:     false,
+		},
+		{
+			name: "update empty user_key with value from secret",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "1",
+				userKey:       "",
+				userAccountID: appID,
+				appID:         userAccountID,
 			},
-			want:    NewApplicationAuthStatusReconciler(getBaseReconciler(getApplicationAuthGenerateSecret()), getApplicationAuthGenerateSecret(), nil),
+			authMode:    "1",
+			authSecret:  getAuthSecret(),
+			expectedKey: "testkey",
+			wantErr:     false,
+		},
+		{
+			name: "update existing user_key with value from secret",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "1",
+				userKey:       "initalkey",
+				userAccountID: appID,
+				appID:         userAccountID,
+			},
+			authMode:    "1",
+			authSecret:  getAuthSecret(),
+			expectedKey: "testkey",
+			wantErr:     false,
+		},
+		{
+			name: "update existing user_key with the same value should not return error",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "1",
+				userKey:       "testkey",
+				userAccountID: appID,
+				appID:         userAccountID,
+			},
+			authMode:   "1",
+			authSecret: getAuthSecret(), expectedKey: "testkey",
 			wantErr: false,
 		},
 		{
-			name: "Test populated secret",
-			fields: fields{
-				BaseReconciler: getBaseReconciler(getAuthSecretObj()),
+			name: "returns error with empty application_key with empty secret",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "2",
+				keys:          []string{},
+				userAccountID: appID,
+				appID:         userAccountID,
 			},
-			args: args{
-				applicationAuth:  getApplicationAuth(),
-				application:      getApplicationCR(),
-				product:          getProductCR(),
-				developerAccount: getApplicationDeveloperAccount(),
-				authSecret:       getAuthSecret(),
-				threescaleClient: threescaleapi.NewThreeScale(ap, "test", mockHttpApplicationAuthClient(applicationUpdate, applicationKeyCreate, applicationKeyList)),
-			},
-			want:    NewApplicationAuthStatusReconciler(getBaseReconciler(getApplicationAuth()), getApplicationAuth(), nil),
-			wantErr: false,
+			authMode:    "2",
+			authSecret:  getEmptyAuthSecret(),
+			expectedKey: "",
+			wantErr:     true,
 		},
-		// TODO: Add test cases.
+		{
+			name: "update existing app_key with value from secret",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "2",
+				keys:          []string{"initalkey"},
+				userAccountID: appID,
+				appID:         userAccountID,
+			},
+			authMode:    "2",
+			authSecret:  getAuthSecret(),
+			expectedKey: "testkey",
+			wantErr:     false,
+		},
+		{
+			name: "update existing app_key with the same value should not return error",
+			mockServer: &mockApplicationAuthServer{
+				authMode:      "2",
+				keys:          []string{"testkey"},
+				userAccountID: appID,
+				appID:         userAccountID,
+			},
+			authMode:    "2",
+			authSecret:  getAuthSecret(),
+			expectedKey: "testkey",
+			wantErr:     false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &ApplicationAuthReconciler{
-				BaseReconciler: tt.fields.BaseReconciler,
+			srv := tt.mockServer.GetServer()
+			defer srv.Close()
+
+			ap, err := threescaleapi.NewAdminPortalFromStr(srv.URL)
+			if err != nil {
+				t.Fatalf("unexpected error = %v", err)
 			}
-			err := r.applicationAuthReconciler(tt.args.applicationAuth, *tt.args.developerAccount.Status.ID, *tt.args.application.Status.ID, tt.args.product, tt.args.authSecret, tt.args.threescaleClient)
+			threescaleClient := threescaleapi.NewThreeScale(ap, "test", srv.Client())
+
+			controller, err := GetAuthController(tt.authMode, logger)
+			if err != nil {
+				t.Fatalf("GetAuthController() failed with error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			err = controller.Sync(threescaleClient, userAccountID, appID, tt.authSecret)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("applicationAuthReconciler() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ApplicationAuth Sync() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+
+			newKey := tt.mockServer.GetKey(tt.authMode)
+			if newKey != tt.expectedKey {
+				t.Fatalf("mismatch keys, expected: %s - got: %s", tt.expectedKey, newKey)
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ApplicationAuth Sync() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplicationAuthReconciler_authSecretReferenceSource(t *testing.T) {
+	logger := logf.Log.WithName("applicationAuth")
+	ns := "test"
+
+	tests := []struct {
+		name           string
+		authMode       string
+		generateSecret bool
+		secretData     map[string][]byte
+		secretRef      string
+		wantErr        bool
+		err            string
+	}{
+		{
+			name:           "return error with non-exist secret",
+			authMode:       "1",
+			generateSecret: false,
+			secretData:     map[string][]byte{},
+			secretRef:      "unknown",
+			wantErr:        true,
+			err:            `secrets "unknown" not found`,
+		},
+		{
+			name:           "return error when secret is empty",
+			authMode:       "1",
+			generateSecret: false,
+			secretData:     map[string][]byte{},
+			wantErr:        true,
+			err:            "secret field 'UserKey' is required in secret 'test'",
+		},
+		{
+			name:           "return error when secret is empty",
+			authMode:       "1",
+			generateSecret: true,
+			secretData:     map[string][]byte{},
+			wantErr:        true,
+			err:            "secret field 'UserKey' is required in secret 'test'",
+		},
+		{
+			name:           "generate user_key when secret is empty",
+			authMode:       "1",
+			generateSecret: true,
+			secretData:     map[string][]byte{"UserKey": []byte("")},
+			wantErr:        false,
+			err:            "",
+		},
+		{
+			name:           "returns error when user_key is empty and generateSecret is off",
+			authMode:       "1",
+			generateSecret: false,
+			secretData:     map[string][]byte{"UserKey": []byte("")},
+			wantErr:        true,
+			err:            "no UserKey available in secret and generate secret is set to false",
+		},
+		{
+			name:           "use user_key value in secret is empty",
+			authMode:       "1",
+			generateSecret: false,
+			secretData:     map[string][]byte{"UserKey": []byte("testkey")},
+			wantErr:        false,
+			err:            "",
+		},
+		{
+			name:           "return error when secret is empty",
+			authMode:       "2",
+			generateSecret: true,
+			secretData:     map[string][]byte{},
+			wantErr:        true,
+			err:            "secret field 'ApplicationKey' is required in secret 'test'",
+		},
+		{
+			name:           "return error when secret is empty",
+			authMode:       "2",
+			generateSecret: false,
+			secretData:     map[string][]byte{},
+			wantErr:        true,
+			err:            "secret field 'ApplicationKey' is required in secret 'test'",
+		},
+		{
+			name:           "generate app_key when secret is empty",
+			authMode:       "2",
+			generateSecret: true,
+			secretData:     map[string][]byte{"ApplicationKey": []byte("")},
+			wantErr:        false,
+			err:            "",
+		},
+		{
+			name:           "returns error when app_key is empty and generateSecret is off",
+			authMode:       "2",
+			generateSecret: false,
+			secretData:     map[string][]byte{"ApplicationKey": []byte("")},
+			wantErr:        true,
+			err:            "no ApplicationKey available in secret and generate secret is set to false",
+		},
+		{
+			name:           "use app_key value in secret is empty",
+			authMode:       "2",
+			generateSecret: true,
+			secretData:     map[string][]byte{"ApplicationKey": []byte("testkey")},
+			wantErr:        false,
+			err:            "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Immutable:  nil,
+				Data:       tt.secretData,
+				StringData: nil,
+				Type:       "",
+			}
+
+			secretRef := &corev1.LocalObjectReference{
+				Name: "test",
+			}
+
+			if tt.secretRef != "" {
+				secretRef.Name = tt.secretRef
+			}
+
+			reconciler := getBaseReconciler(secret)
+			client := reconciler.Client()
+			controller, err := GetAuthController(tt.authMode, logger)
+			if err != nil {
+				t.Fatalf("authSecretReferenceSource() unexpected error = %v", err)
+			}
+
+			authSecret, err := controller.SecretReferenceSource(client, ns, secretRef, tt.generateSecret)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("authSecretReferenceSource() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				if tt.err != err.Error() {
+					t.Fatalf("authSecretReferenceSource() error = %v, wantErr %v", err, tt.err)
+				}
+			} else {
+				newSecret := &corev1.Secret{}
+				err = client.Get(context.Background(), types.NamespacedName{
+					Name:      secretRef.Name,
+					Namespace: ns,
+				}, newSecret)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				switch tt.authMode {
+				case "1":
+					if authSecret.UserKey != string(newSecret.Data["UserKey"]) {
+						t.Fatalf("mismatch user_key expected = '%s', got '%s'", authSecret.UserKey, newSecret.Data["UserKey"])
+					}
+				case "2":
+					if authSecret.ApplicationKey != string(newSecret.Data["ApplicationKey"]) {
+						t.Fatalf("mismatch user_key expected = '%s', got '%s'", authSecret.ApplicationKey, newSecret.Data["ApplicationKey"])
+					}
+				}
 			}
 		})
 	}
@@ -144,23 +359,6 @@ func getApplicationAuth() (CR *capabilitiesv1beta1.ApplicationAuth) {
 	return CR
 }
 
-func getEmptyAuthSecretObj() *corev1.Secret {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Immutable: nil,
-		Data: map[string][]byte{
-			"UserKey":        []byte(""),
-			"ApplicationKey": []byte(""),
-		},
-		StringData: nil,
-		Type:       "",
-	}
-	return secret
-}
-
 func getEmptyAuthSecret() AuthSecret {
 	authSecret := AuthSecret{
 		UserKey:        "",
@@ -168,23 +366,6 @@ func getEmptyAuthSecret() AuthSecret {
 		ApplicationID:  "",
 	}
 	return authSecret
-}
-
-func getAuthSecretObj() *corev1.Secret {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Immutable: nil,
-		Data: map[string][]byte{
-			"UserKey":        []byte("testkey"),
-			"ApplicationKey": []byte("testkey"),
-		},
-		StringData: nil,
-		Type:       "",
-	}
-	return secret
 }
 
 func getAuthSecret() AuthSecret {
@@ -196,32 +377,162 @@ func getAuthSecret() AuthSecret {
 	return authSecret
 }
 
-func mockHttpApplicationAuthClient(applicationUpdate *threescaleapi.ApplicationElem, applicationKeyCreate *threescaleapi.ApplicationElem, applicationKeyList *threescaleapi.ApplicationKeysElem) *http.Client {
-	// override httpClient
-	httpClient := NewTestClient(func(req *http.Request) *http.Response {
-		if req.Method == http.MethodPut && req.URL.Path == "/admin/api/accounts/3/applications/3.json" {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(bytes.NewBuffer(responseBody(applicationUpdate))),
+type mockApplicationAuthServer struct {
+	authMode      string
+	appID         int64
+	userAccountID int64
+	userKey       string
+	keys          []string
+}
+
+func (m *mockApplicationAuthServer) GetServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /admin/api/accounts/{accoundID}/applications/{applicationID}", m.applicationHandler)
+	mux.HandleFunc("PUT /admin/api/accounts/{accoundID}/applications/{applicationID}", m.applicationHandler)
+	mux.HandleFunc("GET /admin/api/accounts/{accoundID}/applications/{applicationID}/keys.json", m.applicationKeysHandler)
+	mux.HandleFunc("DELETE /admin/api/accounts/{accoundID}/applications/{applicationID}/keys/{key}", m.applicationKeysHandler)
+	mux.HandleFunc("POST /admin/api/accounts/{accoundID}/applications/{applicationID}/keys.json", m.applicationKeysHandler)
+
+	return httptest.NewServer(mux)
+}
+
+func (m *mockApplicationAuthServer) GetKey(mode string) string {
+	switch mode {
+	case "1":
+		return m.userKey
+	case "2":
+		return strings.Join(m.keys, ",")
+	default:
+		return ""
+	}
+}
+
+func (m *mockApplicationAuthServer) applicationHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPut {
+		_ = r.ParseForm()
+		userKey := r.FormValue("user_key")
+		if userKey != "" {
+			if userKey == m.userKey {
+				errorResponse(w, "user_key", []string{"has already been taken"})
+				return
+			} else {
+				m.userKey = userKey
 			}
 		}
-		if req.Method == http.MethodPost && req.URL.Path == "/admin/api/accounts/3/applications/3/keys.json" {
-			return &http.Response{
-				StatusCode: http.StatusCreated,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(bytes.NewBuffer(responseBody(applicationKeyCreate))),
-			}
-		}
-		if req.Method == http.MethodGet && req.URL.Path == "/admin/api/accounts/3/applications/3/keys.json" {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(bytes.NewBuffer(responseBody(applicationKeyList))),
-			}
+	}
+
+	data := threescaleapi.ApplicationElem{
+		Application: threescaleapi.Application{
+			UserAccountID: strconv.FormatInt(m.userAccountID, 10),
+			ID:            m.appID,
+			AppName:       "newName",
+			UserKey:       m.userKey,
+		},
+	}
+
+	json, err := json.Marshal(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	_, _ = w.Write(json)
+}
+
+func (m *mockApplicationAuthServer) applicationKeysHandler(w http.ResponseWriter, r *http.Request) {
+	var keyLimit int
+
+	switch r.Method {
+	case http.MethodPost:
+		_ = r.ParseForm()
+		key := r.FormValue("key")
+
+		if len(key) < 5 {
+			errorResponse(w, "value", []string{"is too short (minimum is 5 characters)"})
+			return
 		}
 
-		return nil
-	})
-	return httpClient
+		// if key already existed, returns error
+		if helper.ArrayContains(m.keys, key) {
+			errorResponse(w, "value", []string{"has already been taken"})
+			return
+		}
+
+		if m.authMode == "2" {
+			keyLimit = 5
+		}
+
+		// Check if the current length does not exceed 5 keys limit
+		if len(m.keys) == keyLimit {
+			errorResponse(w, "base", []string{"Limit reached"})
+			return
+		}
+
+		m.keys = append(m.keys, key)
+
+		data := &threescaleapi.ApplicationElem{
+			Application: threescaleapi.Application{
+				UserAccountID: strconv.FormatInt(m.userAccountID, 10),
+				ID:            m.appID,
+				AppName:       "newName",
+			},
+		}
+
+		json, err := json.Marshal(data)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(json)
+	case http.MethodDelete:
+		key := strings.TrimSuffix(r.PathValue("key"), ".json")
+
+		newKeys := slices.DeleteFunc(m.keys, func(existingKey string) bool {
+			return existingKey == key
+		})
+		m.keys = newKeys
+		return
+	case http.MethodGet:
+		keysObj := []threescaleapi.ApplicationKeyWrapper{}
+
+		for _, key := range m.keys {
+			keyObj := threescaleapi.ApplicationKeyWrapper{
+				Key: threescaleapi.ApplicationKey{
+					Value: key,
+				},
+			}
+			keysObj = append(keysObj, keyObj)
+		}
+
+		data := &threescaleapi.ApplicationKeysElem{
+			Keys: keysObj,
+		}
+
+		json, err := json.Marshal(data)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		_, _ = w.Write(json)
+	}
+}
+
+func errorResponse(w http.ResponseWriter, key string, value []string) {
+	errObj := struct {
+		Errors map[string][]string `json:"errors"`
+	}{
+		Errors: map[string][]string{key: value},
+	}
+
+	data, err := json.Marshal(errObj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	http.Error(w, string(data), http.StatusUnprocessableEntity)
 }

--- a/main.go
+++ b/main.go
@@ -445,9 +445,9 @@ func main() {
 	if err = (&capabilitiescontroller.ApplicationAuthReconciler{
 		BaseReconciler: reconcilers.NewBaseReconciler(
 			context.Background(), mgr.GetClient(), mgr.GetScheme(), mgr.GetAPIReader(),
-			ctrl.Log.WithName("controllers").WithName("Application"),
+			ctrl.Log.WithName("controllers").WithName("ApplicationAuth"),
 			discoveryApplicationAuth,
-			mgr.GetEventRecorderFor("Application")),
+			mgr.GetEventRecorderFor("ApplicationAuth")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Application")
 		os.Exit(1)


### PR DESCRIPTION
## What
Close #1078 

Fix:
* https://issues.redhat.com/browse/THREESCALE-11884
* https://issues.redhat.com/browse/THREESCALE-11911

## Verification steps:
* Checkout this branch
* Prepare local env
```shell
make cluster/prepare/local
```
* Install APIM
```shell
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```
* Start the operator and wait for all pods to come online
* Open another terminal and setup the product
<details>

```shell
DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
ADMIN_ACCESS_TOKEN=$(oc get secret system-seed -n 3scale-test -o jsonpath="{.data.ADMIN_ACCESS_TOKEN}"| base64 --decode)

cat << EOF |oc apply -f -
---
apiVersion: v1
kind: Secret
metadata:
  name: mytenant
type: Opaque
stringData:
  adminURL: https://3scale-admin.$DOMAIN
  token: $ADMIN_ACCESS_TOKEN
---
apiVersion: v1
kind: Secret
metadata:
  name: myusername01
stringData:
  password: "123456"
EOF

cat << EOF | oc apply -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperUser
metadata:
  name: developeruser01
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  developerAccountRef:
    name: developeraccount01
  email: myusername01@example.com
  passwordCredentialsRef:
    name: myusername01
  providerAccountRef:
    name: mytenant
  role: admin
  username: myusername01
EOF

sleep 30

cat << EOF | oc apply -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: DeveloperAccount
metadata:
  name: developeraccount01
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  orgName: 3scale-test
  providerAccountRef:
    name: mytenant
EOF

cat << EOF | oc apply -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend1-cr
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  mappingRules:
    - httpMethod: GET
      increment: 1
      last: true
      metricMethodRef: hits
      pattern: /
    - httpMethod: POST
      pattern : "/"
      metricMethodRef: hits
      increment: 1    
  name: backend1
  privateBaseURL: 'http://httpbin.httpbin.svc:8080'
  systemName: backend1
EOF

cat << EOF | oc apply -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product1-cr
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  applicationPlans:
    plan01:
      name: "My Plan 01"
  deployment:
    apicastHosted:
      authentication:
        userkey:
          authUserKey: token
  name: product1
  backendUsages:
    backend1:
      path: /
  mappingRules:
    - httpMethod: GET
      pattern : "/"
      metricMethodRef: hits
      increment: 1
    - httpMethod: POST
      pattern : "/"
      metricMethodRef: hits
      increment: 1    
EOF

cat << EOF | oc apply -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: Application
metadata:
  name: application-cr
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  accountCR: 
    name: developeraccount01
  applicationPlanName: plan01
  productCR: 
    name: product1-cr
  name: testApp
  description: further testing
EOF

cat << EOF | oc apply -f -
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ProxyConfigPromote
metadata:
  name: product1-v1-production
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  productCRName: product1-cr
  production: true
  deleteCR: true
EOF

sleep 30
echo Product Route: 
echo "https://$(oc get routes | grep product1 |grep production| awk '{print $2}')" 
echo
echo User_key: 
echo $(curl -s -X 'GET' "https://3scale-admin.$DOMAIN/admin/api/applications.xml?access_token=$ADMIN_ACCESS_TOKEN&page=1&per_page=500&service_id=3" -H 'accept: */*' | grep -oP '<user_key>\K[^<]+' | sed 's/\s//g')
```

</details>

NOTE: `user_key` is set to custom field called `token`
* Prepare ApplicationAuth CR

<details>

```shell
cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: auth-secret
  namespace: 3scale-test
data:
  ApplicationID: ''
  ApplicationKey: ''
  UserKey: >-
    dGVzdGtleQo=
type: Opaque
EOF

oc apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ApplicationAuth
metadata:
  name: applicationauthcr1
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  applicationCRName: application-cr 
  generateSecret: true
  authSecretRef: 
     name: auth-secret-unknown
EOF
```

</details>

* Check ApplicationAuth CR, you should see the 
```shell
{                                                         
    "lastTransitionTime": "2025-09-01T07:00:46Z",         
    "message": "Secret \"auth-secret-unknown\" not found",
    "status": "True",                                     
    "type": "Failed"                                      
},
```
* Update ApplicationAuth to use correct secret
```shell
oc apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ApplicationAuth
metadata:
  name: applicationauthcr1
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  applicationCRName: application-cr 
  generateSecret: true
  authSecretRef: 
     name: auth-secret
EOF
```
* This time it should reconcile successfully 
```
{                                                                                                                                  
    "lastTransitionTime": "2025-09-01T07:03:14Z",                                                                                  
    "message": "Application authentication has been successfully pushed, any further interactions with this CR will not be applied"
    "status": "True",                                                                                                              
    "type": "Ready"                                                                                                                
}                                                                                                                                  
```
* Login to admin portal and navigate to

```
Products -> product1 -> Integration -> Settings 
``` 
Under `API Key (user_key) Basics` you shall see `Auth user key` is set to `token`

* Now navigate to
```
Products -> product1 -> Application -> listing -> testApp
```
you should see `User Key` is set to `testkey`

* Update `auth-secret` and set `UserKey` to `testkey2` 
* Delete ApplicationAuth CR
* Recreate ApplicationAuth CR
```shell
oc apply -f - <<EOF
---
apiVersion: capabilities.3scale.net/v1beta1
kind: ApplicationAuth
metadata:
  name: applicationauthcr1
  namespace: 3scale-test
  annotations:
    "insecure_skip_verify": "true"
spec:
  applicationCRName: application-cr 
  generateSecret: true
  authSecretRef: 
     name: auth-secret
EOF
```
* Once the CR is ready, the user_key in the admin portal should be updated to `testkey2`
