### PR TITLE
THREESCALE-11897 - Bump PostgreSQL to version 15

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -249,7 +249,7 @@ metadata:
     repository: https://github.com/3scale/3scale-operator
     rht_backend_redis_requirements: 7.0.0
     rht_mysql_requirements: 8.0.0
-    rht_postgres_requirements: 13.0.0
+    rht_postgres_requirements: 15.0.0
     rht_system_redis_requirements: 7.0.0
     support: Red Hat
     tectonic-visibility: ocs
@@ -557,7 +557,7 @@ spec:
                 - name: RELATED_IMAGE_SYSTEM_MEMCACHED
                   value: mirror.gcr.io/library/memcached:1.5
                 - name: RELATED_IMAGE_ZYNC_POSTGRESQL
-                  value: quay.io/sclorg/postgresql-13-c8s
+                  value: quay.io/sclorg/postgresql-15-c8s
                 - name: RELATED_IMAGE_OC_CLI
                   value: quay.io/openshift/origin-cli:4.7
                 - name: RELATED_IMAGE_SYSTEM_SEARCHD

--- a/config/dev-databases/system-postgresql/deployment.yaml
+++ b/config/dev-databases/system-postgresql/deployment.yaml
@@ -20,17 +20,17 @@ spec:
           ports:
             - containerPort: 5432
           env:
-            - name: POSTGRES_USER
+            - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
                   name: system-database
                   key: DB_USER
-            - name: POSTGRES_PASSWORD
+            - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: system-database
                   key: DB_PASSWORD
-            - name: POSTGRES_DB
+            - name: POSTGRESQL_DATABASE
               value: "dev"
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata              

--- a/config/dev-databases/system-postgresql/kustomization.yaml
+++ b/config/dev-databases/system-postgresql/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 
 images:
   - name: postgres
-    newName: mirror.gcr.io/library/postgres:13
+    newName: quay.io/sclorg/postgresql-15-c8s

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,7 +60,7 @@ spec:
         - name: RELATED_IMAGE_SYSTEM_MEMCACHED
           value: "mirror.gcr.io/library/memcached:1.5"
         - name: RELATED_IMAGE_ZYNC_POSTGRESQL
-          value: "quay.io/sclorg/postgresql-13-c8s"
+          value: "quay.io/sclorg/postgresql-15-c8s"
         - name: RELATED_IMAGE_OC_CLI
           value: "quay.io/openshift/origin-cli:4.7"
         - name: RELATED_IMAGE_SYSTEM_SEARCHD

--- a/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/3scale-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     repository: https://github.com/3scale/3scale-operator
     rht_backend_redis_requirements: 7.0.0
     rht_mysql_requirements: 8.0.0
-    rht_postgres_requirements: 13.0.0
+    rht_postgres_requirements: 15.0.0
     rht_system_redis_requirements: 7.0.0
     support: Red Hat
     tectonic-visibility: ocs

--- a/config/requirements/operator-requirements.yaml
+++ b/config/requirements/operator-requirements.yaml
@@ -10,7 +10,7 @@ objects:
     data:
       rht_threescale_version_requirements: ${THREESCALE_VERSION}
       rht_mysql_requirements: 8.0.0
-      rht_postgres_requirements: 13.0.0
+      rht_postgres_requirements: 15.0.0
       rht_system_redis_requirements: 7.0.0
       rht_backend_redis_requirements: 7.0.0
 parameters:

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -25,7 +25,7 @@ func SystemMemcachedImageURL() string {
 }
 
 func ZyncPostgreSQLImageURL() string {
-	return "quay.io/sclorg/postgresql-13-c8s"
+	return "quay.io/sclorg/postgresql-15-c8s"
 }
 
 func OCCLIImageURL() string {


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/THREESCALE-11897

Including:
* Bump zync-db to PostgreSQL 15
* Bump dev PostgreSQL to 15
* Change preflight requirement to PostgreSQL 15

## Verification steps
* Checkout this PR
* Prepare local env
```
DEV_SYSTEM_DB_POSTGRES=true make cluster/prepare/local
```
* Install APIM
```
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```
* Start the operator
```
make run
```
* Wait for the 3scale installation to complete
* Check that all pods are running