### PR TITLE
THREESCALE-14267 Add 3 status conditions; Use new status for requeue

### DIFF
--- a/apis/apps/v1alpha1/apimanager_types.go
+++ b/apis/apps/v1alpha1/apimanager_types.go
@@ -149,9 +149,12 @@ type APIManager struct {
 }
 
 const (
-	APIManagerAvailableConditionType  common.ConditionType = "Available"
-	APIManagerWarningConditionType    common.ConditionType = "Warning"
-	APIManagerPreflightsConditionType common.ConditionType = "Preflights"
+	APIManagerAvailableConditionType            common.ConditionType = "Available"
+	APIManagerWarningConditionType              common.ConditionType = "Warning"
+	APIManagerPreflightsConditionType           common.ConditionType = "Preflights"
+	APIManagerDeploymentsAvailableConditionType common.ConditionType = "DeploymentsAvailable"
+	APIManagerRoutesReadyConditionType          common.ConditionType = "RoutesReady"
+	APIManagerSecretsAvailableConditionType     common.ConditionType = "SecretsAvailable"
 )
 
 type APIManagerCommonSpec struct {

--- a/controllers/apps/apimanager_status_reconciler.go
+++ b/controllers/apps/apimanager_status_reconciler.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
 	k8sappsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,16 +49,14 @@ func (s *APIManagerStatusReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, fmt.Errorf("failed to calculate status: %w", err)
 	}
 
-	apiManagerAvailable := false
-	for _, s := range s.apimanagerResource.Status.Conditions {
-		if s.Type == appsv1alpha1.APIManagerAvailableConditionType && s.IsTrue() {
-			apiManagerAvailable = true
-		}
-	}
+	// Read availability from the newly computed status, not the stale pre-reconcile snapshot.
+	// Using old status caused a True-to-False requeue gap: old=Available=True would suppress
+	// the requeue even after writing Available=False to the API server (THREESCALE-10754).
+	newAvailable := newStatus.Conditions.IsTrueFor(appsv1alpha1.APIManagerAvailableConditionType)
 
 	equalStatus := s.apimanagerResource.Status.Equals(newStatus, s.logger)
 	s.logger.V(1).Info("Status", "status is different", !equalStatus)
-	if equalStatus && apiManagerAvailable {
+	if equalStatus && newAvailable {
 		// Steady state
 		s.logger.V(1).Info("Status was not updated")
 		return reconcile.Result{}, nil
@@ -75,7 +74,7 @@ func (s *APIManagerStatusReconciler) Reconcile() (reconcile.Result, error) {
 		return reconcile.Result{}, fmt.Errorf("failed to update status: %w", updateErr)
 	}
 
-	if !apiManagerAvailable {
+	if !newAvailable {
 		return reconcile.Result{Requeue: true}, nil
 	}
 
@@ -85,21 +84,45 @@ func (s *APIManagerStatusReconciler) Reconcile() (reconcile.Result, error) {
 func (s *APIManagerStatusReconciler) calculateStatus() (*appsv1alpha1.APIManagerStatus, error) {
 	newStatus := &appsv1alpha1.APIManagerStatus{}
 
-	deployments, err := s.existingDeployments()
+	expectedDeploymentNames := apimanagerExpectedDeploymentNames(s.apimanagerResource)
+	expectedRouteHosts := apimanagerExpectedRouteHosts(s.apimanagerResource)
+
+	deployments, err := s.existingDeployments(expectedDeploymentNames)
 	if err != nil {
 		return nil, err
+	}
+
+	routes, err := helper.ListRoutes(s.Client(), s.apimanagerResource.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list routes: %w", err)
 	}
 
 	newStatus.Conditions = s.apimanagerResource.Status.Conditions.Copy()
 
-	// Check if any of the watched secrets are missing
-	watchedSecretsExist, watchedSecretsMessage := s.watchedSecretsExist(s.apimanagerResource)
+	deploymentsAvailCond := deploymentsAvailableCondition(expectedDeploymentNames, deployments)
+	routesReadyCond := routesReadyCondition(expectedRouteHosts, routes, s.logger)
+	secretsAvailCond := secretsAvailableCondition(s.watchedSecretsExist(s.apimanagerResource))
 
-	availableCondition, err := s.apimanagerAvailableCondition(deployments, watchedSecretsExist, watchedSecretsMessage)
-	if err != nil {
-		return nil, err
+	s.logger.V(1).Info("Status calculateStatus", "deploymentsAvailable", deploymentsAvailCond.IsTrue(), "routesReady", routesReadyCond.IsTrue(), "secretsAvailable", secretsAvailCond.IsTrue())
+
+	newStatus.Conditions.SetCondition(deploymentsAvailCond)
+	newStatus.Conditions.SetCondition(routesReadyCond)
+	newStatus.Conditions.SetCondition(secretsAvailCond)
+
+	// Available is a roll-up: True iff all three sub-conditions are True
+	availCond := common.Condition{
+		Type:   appsv1alpha1.APIManagerAvailableConditionType,
+		Status: v1.ConditionFalse,
 	}
-	newStatus.Conditions.SetCondition(availableCondition)
+	if deploymentsAvailCond.IsTrue() && routesReadyCond.IsTrue() && secretsAvailCond.IsTrue() {
+		availCond.Status = v1.ConditionTrue
+	}
+	// Preserve backwards compatibility: surface secrets reason/message on Available when secrets are missing
+	if !secretsAvailCond.IsTrue() {
+		availCond.Reason = secretsAvailCond.Reason
+		availCond.Message = secretsAvailCond.Message
+	}
+	newStatus.Conditions.SetCondition(availCond)
 
 	if s.preflightsErr == nil {
 		s.reconcileHpaWarningMessages(&newStatus.Conditions, s.apimanagerResource)
@@ -119,23 +142,17 @@ func (s *APIManagerStatusReconciler) calculateStatus() (*appsv1alpha1.APIManager
 	return newStatus, nil
 }
 
-func (s *APIManagerStatusReconciler) expectedDeploymentNames(instance *appsv1alpha1.APIManager) []string {
-	var externalZyncDatabase bool
-
-	if instance.IsExternal(appsv1alpha1.ZyncDatabase) && s.apimanagerResource.IsZyncEnabled() {
-		externalZyncDatabase = true
-	}
-
-	deploymentLister := component.DeploymentsLister{
+func apimanagerExpectedDeploymentNames(instance *appsv1alpha1.APIManager) []string {
+	externalZyncDatabase := instance.IsExternal(appsv1alpha1.ZyncDatabase) && instance.IsZyncEnabled()
+	lister := component.DeploymentsLister{
 		ExternalZyncDatabase: externalZyncDatabase,
-		IsZyncEnabled:        s.apimanagerResource.IsZyncEnabled(),
+		IsZyncEnabled:        instance.IsZyncEnabled(),
 	}
-
-	return deploymentLister.DeploymentNames()
+	return lister.DeploymentNames()
 }
 
-func (s *APIManagerStatusReconciler) deploymentsAvailable(existingDeployments []k8sappsv1.Deployment) bool {
-	expectedDeploymentNames := s.expectedDeploymentNames(s.apimanagerResource)
+func deploymentsAvailableCondition(expectedDeploymentNames []string, existingDeployments []k8sappsv1.Deployment) common.Condition {
+	var notReadyNames []string
 	for _, deploymentName := range expectedDeploymentNames {
 		foundExistingDeploymentIdx := -1
 		for idx, existingDeployment := range existingDeployments {
@@ -145,16 +162,67 @@ func (s *APIManagerStatusReconciler) deploymentsAvailable(existingDeployments []
 			}
 		}
 		if foundExistingDeploymentIdx == -1 || !helper.IsDeploymentAvailable(&existingDeployments[foundExistingDeploymentIdx]) {
-			return false
+			notReadyNames = append(notReadyNames, deploymentName)
 		}
 	}
-
-	return true
+	if len(notReadyNames) == 0 {
+		return common.Condition{
+			Type:   appsv1alpha1.APIManagerDeploymentsAvailableConditionType,
+			Status: v1.ConditionTrue,
+		}
+	}
+	return common.Condition{
+		Type:    appsv1alpha1.APIManagerDeploymentsAvailableConditionType,
+		Status:  v1.ConditionFalse,
+		Reason:  "DeploymentsNotAvailable",
+		Message: fmt.Sprintf("The following deployment(s) are not available: %s", strings.Join(notReadyNames, ", ")),
+	}
 }
 
-func (s *APIManagerStatusReconciler) existingDeployments() ([]k8sappsv1.Deployment, error) {
-	expectedDeploymentNames := s.expectedDeploymentNames(s.apimanagerResource)
+func apimanagerExpectedRouteHosts(apimanager *appsv1alpha1.APIManager) []string {
+	if apimanager.Spec.TenantName == nil {
+		return nil
+	}
+	wildcardDomain := apimanager.Spec.WildcardDomain
+	tenantName := *apimanager.Spec.TenantName
+	hosts := []string{
+		fmt.Sprintf("backend-%s.%s", tenantName, wildcardDomain), // Backend Listener route
+	}
+	if apimanager.IsZyncEnabled() {
+		hosts = append(hosts,
+			fmt.Sprintf("api-%s-apicast-production.%s", tenantName, wildcardDomain), // Apicast Production default tenant Route
+			fmt.Sprintf("api-%s-apicast-staging.%s", tenantName, wildcardDomain),    // Apicast Staging default tenant Route
+			fmt.Sprintf("master.%s", wildcardDomain),                                // System's Master Portal Route
+			fmt.Sprintf("%s.%s", tenantName, wildcardDomain),                        // System's default tenant Developer Portal Route
+			fmt.Sprintf("%s-admin.%s", tenantName, wildcardDomain),                  // System's default tenant Admin Portal Route
+		)
+	}
+	return hosts
+}
 
+func routesReadyCondition(expectedHosts []string, routes []routev1.Route, logger logr.Logger) common.Condition {
+	if expectedHosts == nil {
+		return common.Condition{
+			Type:   appsv1alpha1.APIManagerRoutesReadyConditionType,
+			Status: v1.ConditionFalse,
+		}
+	}
+	ready, notReadyHosts := helper.CheckRoutesReady(expectedHosts, routes, logger)
+	if ready {
+		return common.Condition{
+			Type:   appsv1alpha1.APIManagerRoutesReadyConditionType,
+			Status: v1.ConditionTrue,
+		}
+	}
+	return common.Condition{
+		Type:    appsv1alpha1.APIManagerRoutesReadyConditionType,
+		Status:  v1.ConditionFalse,
+		Reason:  "RoutesNotReady",
+		Message: fmt.Sprintf("The following route(s) are not yet admitted: %s", strings.Join(notReadyHosts, ", ")),
+	}
+}
+
+func (s *APIManagerStatusReconciler) existingDeployments(expectedDeploymentNames []string) ([]k8sappsv1.Deployment, error) {
 	var deployments []k8sappsv1.Deployment
 	for _, dName := range expectedDeploymentNames {
 		existingDeployment := &k8sappsv1.Deployment{}
@@ -176,32 +244,6 @@ func (s *APIManagerStatusReconciler) existingDeployments() ([]k8sappsv1.Deployme
 	sort.Slice(deployments, func(i, j int) bool { return deployments[i].Name < deployments[j].Name })
 
 	return deployments, nil
-}
-
-func (s *APIManagerStatusReconciler) apimanagerAvailableCondition(existingDeployments []k8sappsv1.Deployment, watchedSecretsExist bool, missingSecretsMessage string) (common.Condition, error) {
-	deploymentsAvailable := s.deploymentsAvailable(existingDeployments)
-
-	defaultRoutesReady, err := helper.DefaultRoutesReady(s.apimanagerResource, s.Client(), s.logger)
-	if err != nil {
-		return common.Condition{}, err
-	}
-
-	newAvailableCondition := common.Condition{
-		Type:   appsv1alpha1.APIManagerAvailableConditionType,
-		Status: v1.ConditionFalse,
-	}
-
-	s.logger.V(1).Info("Status apimanagerAvailableCondition", "deploymentsAvailable", deploymentsAvailable, "defaultRoutesReady", defaultRoutesReady, "watchedSecretsExist", watchedSecretsExist)
-	if deploymentsAvailable && defaultRoutesReady && watchedSecretsExist {
-		newAvailableCondition.Status = v1.ConditionTrue
-	}
-
-	if !watchedSecretsExist {
-		newAvailableCondition.Message = missingSecretsMessage
-		newAvailableCondition.Reason = "MissingWatchedSecrets"
-	}
-
-	return newAvailableCondition, nil
 }
 
 func (s *APIManagerStatusReconciler) reconcileHpaWarningMessages(conditions *common.Conditions, cr *appsv1alpha1.APIManager) {
@@ -362,6 +404,21 @@ func (s *APIManagerStatusReconciler) reconcilePreflightsStatus(conditions *commo
 	}
 
 	return nil
+}
+
+func secretsAvailableCondition(exists bool, message string) common.Condition {
+	if exists {
+		return common.Condition{
+			Type:   appsv1alpha1.APIManagerSecretsAvailableConditionType,
+			Status: v1.ConditionTrue,
+		}
+	}
+	return common.Condition{
+		Type:    appsv1alpha1.APIManagerSecretsAvailableConditionType,
+		Status:  v1.ConditionFalse,
+		Reason:  "MissingWatchedSecrets",
+		Message: message,
+	}
 }
 
 func (s *APIManagerStatusReconciler) watchedSecretsExist(cr *appsv1alpha1.APIManager) (bool, string) {

--- a/controllers/apps/apimanager_status_reconciler_test.go
+++ b/controllers/apps/apimanager_status_reconciler_test.go
@@ -1,0 +1,646 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	"github.com/3scale/3scale-operator/pkg/apispkg/common"
+	"github.com/3scale/3scale-operator/pkg/helper"
+	"github.com/3scale/3scale-operator/pkg/reconcilers"
+	"github.com/3scale/3scale-operator/version"
+	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	testWildcardDomain = "test.example.com"
+	testTenantName     = "3scale"
+)
+
+// getTestAPIManager returns a basic APIManager CR for testing.
+func getTestAPIManager(namespace string) *appsv1alpha1.APIManager {
+	return &appsv1alpha1.APIManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-apimanager",
+			Namespace: namespace,
+			UID:       "test-uid-123",
+		},
+		Spec: appsv1alpha1.APIManagerSpec{
+			APIManagerCommonSpec: appsv1alpha1.APIManagerCommonSpec{
+				WildcardDomain:              testWildcardDomain,
+				TenantName:                  ptr.To(testTenantName),
+				ResourceRequirementsEnabled: ptr.To(true),
+			},
+			Backend: &appsv1alpha1.BackendSpec{
+				ListenerSpec: &appsv1alpha1.BackendListenerSpec{},
+				WorkerSpec:   &appsv1alpha1.BackendWorkerSpec{},
+			},
+			Apicast: &appsv1alpha1.ApicastSpec{
+				ProductionSpec: &appsv1alpha1.ApicastProductionSpec{},
+				StagingSpec:    &appsv1alpha1.ApicastStagingSpec{},
+			},
+		},
+		Status: appsv1alpha1.APIManagerStatus{
+			Conditions: common.Conditions{},
+		},
+	}
+}
+
+// getTestDeployment returns a Deployment owned by the given APIManager UID, with availability controlled by available.
+func getTestDeployment(name, namespace string, apimanagerUID string, available bool) *k8sappsv1.Deployment {
+	replicas := int32(1)
+	availableReplicas := int32(0)
+	conditionStatus := corev1.ConditionFalse
+	if available {
+		availableReplicas = int32(1)
+		conditionStatus = corev1.ConditionTrue
+	}
+
+	return &k8sappsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps.3scale.net/v1alpha1",
+					Kind:       "APIManager",
+					Name:       "example-apimanager",
+					UID:        types.UID(apimanagerUID),
+				},
+			},
+		},
+		Spec: k8sappsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: k8sappsv1.DeploymentStatus{
+			Replicas:          replicas,
+			UpdatedReplicas:   availableReplicas,
+			ReadyReplicas:     availableReplicas,
+			AvailableReplicas: availableReplicas,
+			Conditions: []k8sappsv1.DeploymentCondition{
+				{
+					Type:   k8sappsv1.DeploymentAvailable,
+					Status: conditionStatus,
+				},
+			},
+		},
+	}
+}
+
+// getAllStandardDeployments returns all standard APIManager deployments as a []runtime.Object slice.
+func getAllStandardDeployments(namespace string, apimanagerUID string, available bool) []runtime.Object {
+	deploymentNames := []string{
+		"apicast-staging",
+		"apicast-production",
+		"backend-listener",
+		"backend-worker",
+		"backend-cron",
+		"system-memcache",
+		"system-app",
+		"system-sidekiq",
+		"system-searchd",
+		"zync",
+		"zync-que",
+		"zync-database",
+	}
+
+	deployments := make([]runtime.Object, 0, len(deploymentNames))
+	for _, name := range deploymentNames {
+		deployments = append(deployments, getTestDeployment(name, namespace, apimanagerUID, available))
+	}
+	return deployments
+}
+
+// getAPIManagerBaseReconciler returns a BaseReconciler backed by a fake client pre-populated with objects.
+func getAPIManagerBaseReconciler(objects ...runtime.Object) *reconcilers.BaseReconciler {
+	s := scheme.Scheme
+	err := appsv1alpha1.AddToScheme(s)
+	if err != nil {
+		return nil
+	}
+	err = routev1.AddToScheme(s)
+	if err != nil {
+		return nil
+	}
+
+	var clientObjects []client.Object
+	for _, o := range objects {
+		co, ok := o.(client.Object)
+		if ok {
+			clientObjects = append(clientObjects, co)
+		}
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).WithStatusSubresource(clientObjects...).Build()
+	log := logf.Log.WithName("apimanager status reconciler test")
+	clientset := fakeclientset.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10000)
+	return reconcilers.NewBaseReconciler(context.TODO(), cl, s, cl, log, clientset.Discovery(), recorder)
+}
+
+// getRequiredSecrets returns the secrets that the default APIManager configuration references.
+func getRequiredSecrets(namespace string) []runtime.Object {
+	return []runtime.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "system-redis", Namespace: namespace},
+			Data:       map[string][]byte{"URL": []byte("redis://system-redis:6379/1")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "backend-redis", Namespace: namespace},
+			Data: map[string][]byte{
+				"REDIS_STORAGE_URL": []byte("redis://backend-redis:6379/0"),
+				"REDIS_QUEUES_URL":  []byte("redis://backend-redis:6379/1"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "system-database", Namespace: namespace},
+			Data:       map[string][]byte{"URL": []byte("mysql2://root:password@system-mysql:3306/system")},
+		},
+	}
+}
+
+// makeAdmittedRoute returns a Route with the Admitted condition set to True.
+func makeAdmittedRoute(name, namespace, host string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       routev1.RouteSpec{Host: host},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{Conditions: []routev1.RouteIngressCondition{
+					{Type: routev1.RouteAdmitted, Status: corev1.ConditionTrue},
+				}},
+			},
+		},
+	}
+}
+
+// getRequiredRoutes returns all routes expected by the default APIManager tenant configuration.
+func getRequiredRoutes(namespace, wildcardDomain, tenantName string) []runtime.Object {
+	return []runtime.Object{
+		makeAdmittedRoute("backend-route", namespace, fmt.Sprintf("backend-%s.%s", tenantName, wildcardDomain)),
+		makeAdmittedRoute("apicast-production-route", namespace, fmt.Sprintf("api-%s-apicast-production.%s", tenantName, wildcardDomain)),
+		makeAdmittedRoute("apicast-staging-route", namespace, fmt.Sprintf("api-%s-apicast-staging.%s", tenantName, wildcardDomain)),
+		makeAdmittedRoute("master-route", namespace, fmt.Sprintf("master.%s", wildcardDomain)),
+		makeAdmittedRoute("developer-portal-route", namespace, fmt.Sprintf("%s.%s", tenantName, wildcardDomain)),
+		makeAdmittedRoute("admin-portal-route", namespace, fmt.Sprintf("%s-admin.%s", tenantName, wildcardDomain)),
+	}
+}
+
+// concat joins multiple []runtime.Object slices into one.
+func concat(slices ...[]runtime.Object) []runtime.Object {
+	var result []runtime.Object
+	for _, s := range slices {
+		result = append(result, s...)
+	}
+	return result
+}
+
+func TestAPIManagerStatusReconciler_Reconcile_statusConditions(t *testing.T) {
+	namespace := "test-namespace"
+	// WATCH_NAMESPACE is read by non-bypassed preflight cases; harmless for all others.
+	t.Setenv("WATCH_NAMESPACE", namespace)
+
+	am := getTestAPIManager(namespace)
+	amUID := string(am.UID)
+
+	// Namespace is environment-derived, not configurable.
+	operatorNs, err := helper.GetOperatorNamespace()
+	if err != nil {
+		t.Fatalf("GetOperatorNamespace: %v", err)
+	}
+
+	requirementsConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helper.OperatorRequirementsConfigMapName,
+			Namespace: operatorNs,
+		},
+		Data: map[string]string{
+			helper.RHTThreescaleVersion: version.ThreescaleVersionMajorMinor(),
+		},
+	}
+
+	healthy := func(apimanager *appsv1alpha1.APIManager) []runtime.Object {
+		return concat(
+			getAllStandardDeployments(namespace, amUID, true),
+			getRequiredSecrets(namespace),
+			getRequiredRoutes(namespace, testWildcardDomain, testTenantName),
+			[]runtime.Object{apimanager},
+		)
+	}
+
+	condTrue := func(t *testing.T, updated *appsv1alpha1.APIManager, condType common.ConditionType) {
+		t.Helper()
+		cond := updated.Status.Conditions.GetCondition(condType)
+		if cond == nil {
+			t.Errorf("condition %q not found", condType)
+			return
+		}
+		if !cond.IsTrue() {
+			t.Errorf("condition %q: got False, want True", condType)
+		}
+	}
+	condFalse := func(t *testing.T, updated *appsv1alpha1.APIManager, condType common.ConditionType) {
+		t.Helper()
+		cond := updated.Status.Conditions.GetCondition(condType)
+		if cond == nil {
+			t.Errorf("condition %q not found", condType)
+			return
+		}
+		if cond.IsTrue() {
+			t.Errorf("condition %q: got True, want False", condType)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		objects       []runtime.Object
+		preflightsErr error
+		bypass        bool
+		assert        func(t *testing.T, updated *appsv1alpha1.APIManager)
+	}{
+		{
+			name:    "All healthy - Available and all sub-conditions are True",
+			objects: healthy(am),
+			bypass:  true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				condTrue(t, updated, appsv1alpha1.APIManagerAvailableConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerDeploymentsAvailableConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerRoutesReadyConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerSecretsAvailableConditionType)
+				if len(updated.Status.Deployments.Ready) == 0 && len(updated.Status.Deployments.Starting) == 0 && len(updated.Status.Deployments.Stopped) == 0 {
+					t.Error("Deployments status is empty")
+				}
+			},
+		},
+		{
+			name: "All deployments unavailable - Available and DeploymentsAvailable are False",
+			objects: concat(
+				getAllStandardDeployments(namespace, amUID, false),
+				getRequiredSecrets(namespace),
+				getRequiredRoutes(namespace, testWildcardDomain, testTenantName),
+				[]runtime.Object{am},
+			),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				condFalse(t, updated, appsv1alpha1.APIManagerAvailableConditionType)
+				condFalse(t, updated, appsv1alpha1.APIManagerDeploymentsAvailableConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerRoutesReadyConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerSecretsAvailableConditionType)
+			},
+		},
+		{
+			name: "One deployment unavailable - DeploymentsAvailable condition names the failing deployment",
+			objects: func() []runtime.Object {
+				deps := getAllStandardDeployments(namespace, amUID, true)
+				for i, obj := range deps {
+					if d, ok := obj.(*k8sappsv1.Deployment); ok && d.Name == "apicast-staging" {
+						deps[i] = getTestDeployment("apicast-staging", namespace, amUID, false)
+						break
+					}
+				}
+				return concat(deps, getRequiredSecrets(namespace), getRequiredRoutes(namespace, testWildcardDomain, testTenantName), []runtime.Object{am})
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerDeploymentsAvailableConditionType)
+				if cond == nil {
+					t.Fatal("DeploymentsAvailable condition not found")
+				}
+				if cond.IsTrue() {
+					t.Error("DeploymentsAvailable: got True, want False")
+				}
+				if cond.Reason != "DeploymentsNotAvailable" {
+					t.Errorf("Reason = %q, want %q", cond.Reason, "DeploymentsNotAvailable")
+				}
+				if !strings.Contains(cond.Message, "apicast-staging") {
+					t.Errorf("Message = %q, want it to contain %q", cond.Message, "apicast-staging")
+				}
+			},
+		},
+		{
+			name: "One deployment missing from cluster - DeploymentsAvailable condition names the missing deployment",
+			objects: func() []runtime.Object {
+				var deps []runtime.Object
+				for _, obj := range getAllStandardDeployments(namespace, amUID, true) {
+					if d, ok := obj.(*k8sappsv1.Deployment); ok && d.Name == "apicast-staging" {
+						continue
+					}
+					deps = append(deps, obj)
+				}
+				return concat(deps, getRequiredSecrets(namespace), getRequiredRoutes(namespace, testWildcardDomain, testTenantName), []runtime.Object{am})
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerDeploymentsAvailableConditionType)
+				if cond == nil {
+					t.Fatal("DeploymentsAvailable condition not found")
+				}
+				if cond.IsTrue() {
+					t.Error("DeploymentsAvailable: got True, want False")
+				}
+				if !strings.Contains(cond.Message, "apicast-staging") {
+					t.Errorf("Message = %q, want it to contain %q", cond.Message, "apicast-staging")
+				}
+			},
+		},
+		{
+			name: "Route not admitted - RoutesReady is False with host in message",
+			objects: func() []runtime.Object {
+				routes := getRequiredRoutes(namespace, testWildcardDomain, testTenantName)
+				for i, obj := range routes {
+					if r, ok := obj.(*routev1.Route); ok && r.Name == "backend-route" {
+						r.Status.Ingress[0].Conditions[0].Status = corev1.ConditionFalse
+						routes[i] = r
+					}
+				}
+				return concat(getAllStandardDeployments(namespace, amUID, true), getRequiredSecrets(namespace), routes, []runtime.Object{am})
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				condFalse(t, updated, appsv1alpha1.APIManagerAvailableConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerDeploymentsAvailableConditionType)
+				condTrue(t, updated, appsv1alpha1.APIManagerSecretsAvailableConditionType)
+				cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerRoutesReadyConditionType)
+				if cond == nil {
+					t.Fatal("RoutesReady condition not found")
+				}
+				if cond.IsTrue() {
+					t.Error("RoutesReady: got True, want False")
+				}
+				host := fmt.Sprintf("backend-%s.%s", testTenantName, testWildcardDomain)
+				if !strings.Contains(cond.Message, host) {
+					t.Errorf("RoutesReady Message = %q, want it to contain %q", cond.Message, host)
+				}
+			},
+		},
+		{
+			name: "Route missing from cluster - RoutesReady is False with host in message",
+			objects: func() []runtime.Object {
+				var routes []runtime.Object
+				for _, obj := range getRequiredRoutes(namespace, testWildcardDomain, testTenantName) {
+					if r, ok := obj.(*routev1.Route); ok && r.Name == "backend-route" {
+						continue
+					}
+					routes = append(routes, obj)
+				}
+				return concat(getAllStandardDeployments(namespace, amUID, true), getRequiredSecrets(namespace), routes, []runtime.Object{am})
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerRoutesReadyConditionType)
+				if cond == nil {
+					t.Fatal("RoutesReady condition not found")
+				}
+				if cond.IsTrue() {
+					t.Error("RoutesReady: got True, want False")
+				}
+				host := fmt.Sprintf("backend-%s.%s", testTenantName, testWildcardDomain)
+				if !strings.Contains(cond.Message, host) {
+					t.Errorf("RoutesReady Message = %q, want it to contain %q", cond.Message, host)
+				}
+			},
+		},
+		{
+			// SecretsAvailable=False is also asserted to carry its Reason and Message up to the
+			// top-level Available condition for backwards compatibility with automation that reads
+			// failure details from Available rather than the dedicated sub-condition.
+			name: "Watched secret missing - SecretsAvailable is False; Available carries its Reason and Message",
+			objects: func() []runtime.Object {
+				amSecret := getTestAPIManager(namespace)
+				amSecret.Spec.Apicast = &appsv1alpha1.ApicastSpec{
+					ProductionSpec: &appsv1alpha1.ApicastProductionSpec{
+						CustomEnvironments: []appsv1alpha1.CustomEnvironmentSpec{
+							{SecretRef: &corev1.LocalObjectReference{Name: "missing-secret"}},
+						},
+					},
+					StagingSpec: &appsv1alpha1.ApicastStagingSpec{},
+				}
+				return concat(
+					getAllStandardDeployments(namespace, amUID, true),
+					getRequiredRoutes(namespace, testWildcardDomain, testTenantName),
+					[]runtime.Object{amSecret},
+				)
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				secretsCond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerSecretsAvailableConditionType)
+				if secretsCond == nil {
+					t.Fatal("SecretsAvailable condition not found")
+				}
+				if secretsCond.IsTrue() {
+					t.Error("SecretsAvailable: got True, want False")
+				}
+				if secretsCond.Reason != "MissingWatchedSecrets" {
+					t.Errorf("SecretsAvailable Reason = %q, want %q", secretsCond.Reason, "MissingWatchedSecrets")
+				}
+				if !strings.Contains(secretsCond.Message, "missing-secret") {
+					t.Errorf("SecretsAvailable Message = %q, want it to contain %q", secretsCond.Message, "missing-secret")
+				}
+				// availCond to match secretsCond for backward compatibility
+				availCond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerAvailableConditionType)
+				if availCond == nil {
+					t.Fatal("Available condition not found")
+				}
+				if availCond.Reason != secretsCond.Reason {
+					t.Errorf("Available.Reason = %q, want %q (from SecretsAvailable)", availCond.Reason, secretsCond.Reason)
+				}
+				if availCond.Message != secretsCond.Message {
+					t.Errorf("Available.Message = %q, want %q (from SecretsAvailable)", availCond.Message, secretsCond.Message)
+				}
+			},
+		},
+		{
+			name: "HPA with ResourceRequirements disabled - Warning conditions emitted",
+			objects: func() []runtime.Object {
+				amHPA := getTestAPIManager(namespace)
+				amHPA.Spec.ResourceRequirementsEnabled = ptr.To(false)
+				amHPA.Spec.Backend.ListenerSpec.Hpa = true
+				amHPA.Spec.Backend.WorkerSpec.Hpa = true
+				amHPA.Spec.Apicast.ProductionSpec.Hpa = true
+				return healthy(amHPA)
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				wantReasons := map[string]bool{
+					"HPA & ResourceRequirementsEnabled false": true,
+					"HPA": true,
+				}
+				var actualReasons []string
+				for _, cond := range updated.Status.Conditions {
+					if cond.Type == appsv1alpha1.APIManagerWarningConditionType {
+						actualReasons = append(actualReasons, string(cond.Reason))
+					}
+				}
+				if len(actualReasons) != len(wantReasons) {
+					t.Errorf("warning reasons: got %v, want %v", actualReasons, wantReasons)
+					return
+				}
+				for _, r := range actualReasons {
+					if !wantReasons[r] {
+						t.Errorf("unexpected warning reason %q", r)
+					}
+				}
+			},
+		},
+		{
+			name: "OpenTracing enabled - deprecation Warning conditions emitted",
+			objects: func() []runtime.Object {
+				amOT := getTestAPIManager(namespace)
+				amOT.Spec.Apicast.ProductionSpec.OpenTracing = &appsv1alpha1.APIcastOpenTracingSpec{Enabled: ptr.To(true)}
+				amOT.Spec.Apicast.StagingSpec.OpenTracing = &appsv1alpha1.APIcastOpenTracingSpec{Enabled: ptr.To(true)}
+				return healthy(amOT)
+			}(),
+			bypass: true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				wantReasons := map[string]bool{
+					"Apicast Staging OpenTracing Deprecation":    true,
+					"Apicast Production OpenTracing Deprecation": true,
+				}
+				var actualReasons []string
+				for _, cond := range updated.Status.Conditions {
+					if cond.Type == appsv1alpha1.APIManagerWarningConditionType {
+						actualReasons = append(actualReasons, string(cond.Reason))
+					}
+				}
+				if len(actualReasons) != len(wantReasons) {
+					t.Errorf("warning reasons: got %v, want %v", actualReasons, wantReasons)
+					return
+				}
+				for _, r := range actualReasons {
+					if !wantReasons[r] {
+						t.Errorf("unexpected warning reason %q", r)
+					}
+				}
+			},
+		},
+		{
+			name:    "Preflights bypassed - condition not written",
+			objects: healthy(am),
+			bypass:  true,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				if cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerPreflightsConditionType); cond != nil {
+					t.Error("Preflights condition present, want absent")
+				}
+			},
+		},
+		{
+			name:    "Preflights met - condition is True",
+			objects: append(healthy(am), requirementsConfigMap),
+			bypass:  false,
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerPreflightsConditionType)
+				if cond == nil {
+					t.Fatal("Preflights condition not found")
+				}
+				if !cond.IsTrue() {
+					t.Errorf("Preflights: got False, want True (message: %q)", cond.Message)
+				}
+				if !strings.Contains(cond.Message, "All requirements") {
+					t.Errorf("Preflights Message = %q, want to contain %q", cond.Message, "All requirements")
+				}
+			},
+		},
+		{
+			name:          "Preflights failed - condition is False with error in message",
+			objects:       append(healthy(am), requirementsConfigMap),
+			bypass:        false,
+			preflightsErr: fmt.Errorf("system-database secret missing required key"),
+			assert: func(t *testing.T, updated *appsv1alpha1.APIManager) {
+				cond := updated.Status.Conditions.GetCondition(appsv1alpha1.APIManagerPreflightsConditionType)
+				if cond == nil {
+					t.Fatal("Preflights condition not found")
+				}
+				if cond.IsTrue() {
+					t.Error("Preflights: got True, want False")
+				}
+				if !strings.Contains(cond.Message, "Preflights failed") {
+					t.Errorf("Preflights Message = %q, want to contain %q", cond.Message, "Preflights failed")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.bypass {
+				t.Setenv("PREFLIGHT_CHECKS_BYPASS", "true")
+			}
+
+			base := getAPIManagerBaseReconciler(tt.objects...)
+
+			fetched := &appsv1alpha1.APIManager{}
+			if err := base.Client().Get(context.TODO(), types.NamespacedName{Name: "example-apimanager", Namespace: namespace}, fetched); err != nil {
+				t.Fatalf("get APIManager: %v", err)
+			}
+
+			s := &APIManagerStatusReconciler{
+				BaseReconciler:     base,
+				apimanagerResource: fetched,
+				logger:             logr.Discard(),
+				preflightsErr:      tt.preflightsErr,
+			}
+
+			if _, err := s.Reconcile(); err != nil {
+				t.Fatalf("Reconcile() unexpected error: %v", err)
+			}
+
+			updated := &appsv1alpha1.APIManager{}
+			if err := base.Client().Get(context.TODO(), types.NamespacedName{Name: "example-apimanager", Namespace: namespace}, updated); err != nil {
+				t.Fatalf("get updated APIManager: %v", err)
+			}
+
+			tt.assert(t, updated)
+		})
+	}
+}
+
+// TestAPIManagerStatusReconciler_Reconcile_requeueOnTrueToFalseTransition is a regression
+// test for the stale-read requeue bug: when Available transitions from True to False the
+// reconciler must requeue, not settle silently at Available=False.
+func TestAPIManagerStatusReconciler_Reconcile_requeueOnTrueToFalseTransition(t *testing.T) {
+	namespace := "test-namespace"
+	t.Setenv("PREFLIGHT_CHECKS_BYPASS", "true")
+
+	// Seed the CR with Available=True in its current status (old state).
+	am := getTestAPIManager(namespace)
+	am.Status.Conditions = common.Conditions{
+		{Type: appsv1alpha1.APIManagerAvailableConditionType, Status: corev1.ConditionTrue},
+	}
+
+	// Cluster state: deployments not available, so calculateStatus() will return Available=False.
+	objects := concat(
+		getAllStandardDeployments(namespace, string(am.UID), false),
+		getRequiredSecrets(namespace),
+		getRequiredRoutes(namespace, testWildcardDomain, testTenantName),
+		[]runtime.Object{am},
+	)
+
+	s := &APIManagerStatusReconciler{
+		BaseReconciler:     getAPIManagerBaseReconciler(objects...),
+		apimanagerResource: am,
+		logger:             logr.Discard(),
+	}
+
+	result, err := s.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile() unexpected error: %v", err)
+	}
+	if !result.Requeue {
+		t.Errorf("Reconcile() Requeue = false, want true on Available True-to-False transition")
+	}
+}

--- a/doc/apimanager-reference.md
+++ b/doc/apimanager-reference.md
@@ -668,39 +668,64 @@ When zync `database` is enabled the following secret has to be pre-created by th
 Used by the Operator/Kubernetes to control the state of the APIManager.
 an `APIManager` status field should never be modified by the user.
 
-| **Field** | **json/yaml field**| **Type** | **Info** |
-| --- | --- | --- | --- |
-| Available | `available` | v1.Condition | Indicates whether the APIManager is in `Available` state. See [ConditionSpec](#ConditionSpec) for a description on the meaning of `Available`|
+| **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
+| --- | --- | --- | --- | --- | --- |
+| Conditions | `conditions` | []Condition | No | N/A | An array of Conditions through which the Product has or has not passed. See [Condition](#condition) |
+| Deployments | `deployments` | DeploymentStatus | Yes | N/A | Records state of deployments owned by the operator. See [DeploymentStatus](#deploymentstatus) |
 
-#### ConditionSpec
+#### Condition
 
-The status object has an array of Conditions through which the Product has or has not passed.
-Each element of the Condition array has the following fields:
+Each element of the Conditions array has the following fields:
 
-* The *lastTransitionTime* field provides a timestamp for when the entity last transitioned from one status to another.
-* The *message* field is a human-readable message indicating details about the transition.
-* The *reason* field is a unique, one-word, CamelCase reason for the condition’s last transition.
-* The *status* field is a string, with possible values **True**, **False**, and **Unknown**.
-* The *type* field is a string indicating the type of the condition. The types are:
-  * `Available`: An APIManager is in `Available` state when *all* of the following scenarios are true:
-    * All expected Deployments to be deployed exist and have the `Available` condition set to true
-    * All 3scale default OpenShift routes exist and have the Admitted condition set to true. The default routes are:
-      * Master route
-      * Backend Listener route
-      * Default tenant admin route, developer route, APIcast staging and production routes beloinging to the default tenant
+| **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
+| --- | --- | --- | --- | --- | --- |
+| Type | `type` | string | yes | N/A | Condition Type idenfitying a specific condition. See [ConditionTypes](#condition-types) |
+| Status | `status` | string | yes | N/A | Status: True, False, Unknown |
+| Reason | `reason` | string | no | N/A | Unique, one-word, CamelCase reason for the condition’s last transition |
+| Message | `message` | string | no | N/A | A human-readable message indicating details about the transition |
+| LastTransitionTime | `lastTransitionTime` | timestamp | no | N/A | Provides a timestamp for when the entity last transitioned from one status to another |
 
-Note: If you had zync disabled and then re-enabled it, the routes must be manually re-created for the APIManager to report status completed.
+##### Condition Types
 
+**`Available`** is a roll-up condition. It is `True` if and only if `DeploymentsAvailable`, `RoutesReady`, and `SecretsAvailable` are all `True`. When secrets are missing, the `reason` and `message` fields on `Available` mirror those from `SecretsAvailable` for backwards compatibility with automation that reads failure details from `Available` directly. When deployments or routes are the cause of unavailability, `Available` carries no `reason` or `message`; read the sub-conditions for details.
 
-| **Field** | **json field**| **Type** | **Info** |
-| --- | --- | --- | --- |
-| Type | `type` | string | Condition Type |
-| Status | `status` | string | Status: True, False, Unknown |
-| Reason | `reason` | string | Condition state reason |
-| Message | `message` | string | Condition state description |
-| LastTransitionTime | `lastTransitionTime` | timestamp | Last transition timestap |
+**`DeploymentsAvailable`** becomes `True` when expected Deployments are present on the cluster and in Ready state. The `message` field lists the names of the failing Deployments, for example:
 
+```
+The following deployment(s) are not available: backend-listener, backend-worker
+```
 
+**`RoutesReady`** becomes `True` when all routes are created and admitted by the router. The routes the operator checks are:
+
+- Backend Listener route (always checked)
+- When Zync is enabled:
+  - Default tenant routes for: Master Portal, Developer Portal, Admin Portal, Apicast Production, Apicast Staging
+
+> **Note:** If `spec.tenantName` is not set, `RoutesReady` will be `False` with no `reason` or `message`. This is expected — the operator cannot determine route hostnames without a tenant name. In practice `tenantName` always defaults to `"3scale"`.
+
+> **Note:** If you had Zync disabled and then re-enabled it, the Zync-managed routes must be manually re-created for `RoutesReady` to become `True`. See the [operator user guide](operator-user-guide.md) for the resync command.
+
+The `message` field lists the hostnames that prevent the condition from passing, for example:
+
+```
+The following route(s) are not yet admitted: backend-3scale.apps.example.com
+```
+
+**`SecretsAvailable`** becomes `True` when secrets referenced in the APIManager spec (Redis URLs, database credentials, custom environment secrets, custom policy secrets, etc.) are missing from the cluster. The `message` field names the missing secrets, for example:
+
+```
+The following secret(s) could not be found: system-redis
+```
+
+#### DeploymentStatus
+
+Operator manages a set of deployments and exposes the overall status of the deployment via this field.
+
+| **Field** | **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
+| --- | --- | --- | --- | --- | --- |
+| Ready | ready | []string | no | N/A | Listed deployments are ready to server requests |
+| Starting | starting | []string | no | N/A | Listed deployments are starting, may or may not succeed |
+| Stopped | stopped | []string | no | N/A | Listed deployments are not starting |
 
 ## PersistentVolumeClaimResourcesSpec
 

--- a/doc/operator-user-guide.md
+++ b/doc/operator-user-guide.md
@@ -1025,7 +1025,7 @@ spec:
 ```
 The operator will remove zync deployment, routes it previously created and all other associated with the deployment resources.
 If you wish to have zync re-enabled, change the value of the flag to "true".
-Note, that APIManager requires at minimum 5 basic routes to be available to report it's status as "available=true".
+Note, that when Zync is enabled the APIManager requires the Backend Listener route plus 5 Zync-managed routes to be admitted for the `RoutesReady` condition to become `True` (which is required for `Available=True`).
 After re-enabling zync, it's up to you to re-sync routes to have them re-created. This can be achieved by running following command against sidekiq deployment:
 ```
 oc rsh $(oc get pods -l 'deployment=system-sidekiq' -o json | jq '.items[0].metadata.name' -r) bash -c 'bundle exec rake zync:resync:domains'

--- a/pkg/helper/route.go
+++ b/pkg/helper/route.go
@@ -5,66 +5,39 @@ import (
 	"fmt"
 	"sort"
 
-	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
-
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// DefaultRoutesReady returns true when the expected default routes are available
-func DefaultRoutesReady(apimanager *appsv1alpha1.APIManager, k8sclient client.Client, logger logr.Logger) (bool, error) {
-	var expectedRouteHosts []string
-	wildcardDomain := apimanager.Spec.WildcardDomain
-	if apimanager.Spec.TenantName != nil {
-		expectedRouteHosts = []string{
-			fmt.Sprintf("backend-%s.%s", *apimanager.Spec.TenantName, wildcardDomain), // Backend Listener route
-		}
-		if apimanager.IsZyncEnabled() {
-			zyncRoutes := []string{
-				fmt.Sprintf("api-%s-apicast-production.%s", *apimanager.Spec.TenantName, wildcardDomain), // Apicast Production default tenant Route
-				fmt.Sprintf("api-%s-apicast-staging.%s", *apimanager.Spec.TenantName, wildcardDomain),    // Apicast Staging default tenant Route
-				fmt.Sprintf("master.%s", wildcardDomain),                                                 // System's Master Portal Route
-				fmt.Sprintf("%s.%s", *apimanager.Spec.TenantName, wildcardDomain),                        // System's default tenant Developer Portal Route
-				fmt.Sprintf("%s-admin.%s", *apimanager.Spec.TenantName, wildcardDomain),                  // System's default tenant Admin Portal Route
-			}
-			expectedRouteHosts = append(expectedRouteHosts, zyncRoutes...)
-		}
-	} else {
-		return false, nil
-	}
-
-	listOps := []client.ListOption{
-		client.InNamespace(apimanager.Namespace),
-	}
-
+// ListRoutes returns the routes in the given namespace, sorted by name.
+func ListRoutes(k8sclient client.Client, namespace string) ([]routev1.Route, error) {
 	routeList := &routev1.RouteList{}
-	err := k8sclient.List(context.TODO(), routeList, listOps...)
+	err := k8sclient.List(context.TODO(), routeList, client.InNamespace(namespace))
 	if err != nil {
-		return false, fmt.Errorf("failed to list routes: %w", err)
+		return nil, fmt.Errorf("failed to list routes: %w", err)
 	}
-
 	routes := append([]routev1.Route(nil), routeList.Items...)
 	sort.Slice(routes, func(i, j int) bool { return routes[i].Name < routes[j].Name })
+	return routes, nil
+}
 
-	allDefaultRoutesReady := true
-	for _, expectedRouteHost := range expectedRouteHosts {
+// CheckRoutesReady checks whether all expectedHosts are present and admitted in routes.
+// Returns (allReady, notReadyHosts).
+func CheckRoutesReady(expectedHosts []string, routes []routev1.Route, logger logr.Logger) (bool, []string) {
+	var notReadyHosts []string
+	for _, expectedRouteHost := range expectedHosts {
 		routeIdx := RouteFindByHost(routes, expectedRouteHost)
 		if routeIdx == -1 {
 			logger.V(1).Info("Status defaultRoutesReady: route not found", "expectedRouteHost", expectedRouteHost)
-			allDefaultRoutesReady = false
-		} else {
-			matchedRoute := &routes[routeIdx]
-			routeReady := IsRouteReady(matchedRoute)
-			if !routeReady {
-				logger.V(1).Info("Status defaultRoutesReady: route not ready", "expectedRouteHost", expectedRouteHost)
-				allDefaultRoutesReady = false
-			}
+			notReadyHosts = append(notReadyHosts, expectedRouteHost)
+		} else if !IsRouteReady(&routes[routeIdx]) {
+			logger.V(1).Info("Status defaultRoutesReady: route not ready", "expectedRouteHost", expectedRouteHost)
+			notReadyHosts = append(notReadyHosts, expectedRouteHost)
 		}
 	}
-
-	return allDefaultRoutesReady, nil
+	return len(notReadyHosts) == 0, notReadyHosts
 }
 
 // IsRouteReady returns true when all Ingresses of the Route have the

--- a/pkg/helper/route_test.go
+++ b/pkg/helper/route_test.go
@@ -1,0 +1,141 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeRoute(name, host string, admitted bool) routev1.Route {
+	condStatus := corev1.ConditionFalse
+	if admitted {
+		condStatus = corev1.ConditionTrue
+	}
+	return routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       routev1.RouteSpec{Host: host},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{Conditions: []routev1.RouteIngressCondition{
+					{Type: routev1.RouteAdmitted, Status: condStatus},
+				}},
+			},
+		},
+	}
+}
+
+func TestCheckRoutesReady(t *testing.T) {
+	backendHost := "backend-3scale.example.com"
+	apicastProdHost := "api-3scale-apicast-production.example.com"
+	apicastStagHost := "api-3scale-apicast-staging.example.com"
+	masterHost := "master.example.com"
+	devPortalHost := "3scale.example.com"
+	adminHost := "3scale-admin.example.com"
+
+	allHosts := []string{backendHost, apicastProdHost, apicastStagHost, masterHost, devPortalHost, adminHost}
+	allRoutes := []routev1.Route{
+		makeRoute("backend", backendHost, true),
+		makeRoute("apicast-prod", apicastProdHost, true),
+		makeRoute("apicast-stag", apicastStagHost, true),
+		makeRoute("master", masterHost, true),
+		makeRoute("dev-portal", devPortalHost, true),
+		makeRoute("admin", adminHost, true),
+	}
+
+	tests := []struct {
+		name                 string
+		expectedHosts        []string
+		routes               []routev1.Route
+		wantReady            bool
+		wantNotReadyContains []string
+	}{
+		{
+			name:          "all routes ready",
+			expectedHosts: allHosts,
+			routes:        allRoutes,
+			wantReady:     true,
+		},
+		{
+			name:          "one route not admitted",
+			expectedHosts: allHosts,
+			routes: []routev1.Route{
+				makeRoute("backend", backendHost, true),
+				makeRoute("apicast-prod", apicastProdHost, false),
+				makeRoute("apicast-stag", apicastStagHost, true),
+				makeRoute("master", masterHost, true),
+				makeRoute("dev-portal", devPortalHost, true),
+				makeRoute("admin", adminHost, true),
+			},
+			wantReady:            false,
+			wantNotReadyContains: []string{apicastProdHost},
+		},
+		{
+			name:          "one route missing",
+			expectedHosts: allHosts,
+			routes: []routev1.Route{
+				makeRoute("backend", backendHost, true),
+				makeRoute("apicast-stag", apicastStagHost, true),
+				makeRoute("master", masterHost, true),
+				makeRoute("dev-portal", devPortalHost, true),
+				makeRoute("admin", adminHost, true),
+			},
+			wantReady:            false,
+			wantNotReadyContains: []string{apicastProdHost},
+		},
+		{
+			name:          "multiple routes not ready",
+			expectedHosts: allHosts,
+			routes: []routev1.Route{
+				makeRoute("backend", backendHost, false),
+				makeRoute("apicast-prod", apicastProdHost, false),
+				makeRoute("apicast-stag", apicastStagHost, true),
+				makeRoute("master", masterHost, true),
+				makeRoute("dev-portal", devPortalHost, true),
+				makeRoute("admin", adminHost, true),
+			},
+			wantReady:            false,
+			wantNotReadyContains: []string{backendHost, apicastProdHost},
+		},
+		{
+			name:          "only backend route required, ready",
+			expectedHosts: []string{backendHost},
+			routes:        []routev1.Route{makeRoute("backend", backendHost, true)},
+			wantReady:     true,
+		},
+		{
+			name:                 "only backend route required, not admitted",
+			expectedHosts:        []string{backendHost},
+			routes:               []routev1.Route{makeRoute("backend", backendHost, false)},
+			wantReady:            false,
+			wantNotReadyContains: []string{backendHost},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ready, notReadyHosts := CheckRoutesReady(tt.expectedHosts, tt.routes, logr.Discard())
+
+			if ready != tt.wantReady {
+				t.Errorf("ready = %v, want %v", ready, tt.wantReady)
+			}
+			if len(notReadyHosts) != len(tt.wantNotReadyContains) {
+				t.Errorf("len(notReadyHosts) = %d, want %d; hosts: %v", len(notReadyHosts), len(tt.wantNotReadyContains), notReadyHosts)
+			}
+			for _, expected := range tt.wantNotReadyContains {
+				found := false
+				for _, h := range notReadyHosts {
+					if h == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected %q in notReadyHosts %v", expected, notReadyHosts)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix: 
- https://issues.redhat.com/browse/THREESCALE-12161

### What

Previously, APIManager exposed a single Available condition that collapsed three independent system checks into one opaque signal. When `Available=False` there was no way to tell from the CR alone whether the problem was with deployments, routes, or secrets.

#### New conditions

Three independent sub-conditions are now present in `.status.conditions`:

  | Condition | True when |
  |---|---|
  | `DeploymentsAvailable` | All expected deployments have at least one available replica |
  | `RoutesReady` | All expected routes are admitted by the router |
  | `SecretsAvailable` | All externally-referenced secrets (Redis, database, custom policies, etc.) exist in the cluster |

Available remains a roll-up: True if all above sub-conditions are True.

#### Change in status reporting

  Before: On a broken install you would see:

```yaml
  - type: Available
    status: "False"
```

  After: The root cause is visible without inspecting cluster resources:

```yaml
  - type: Available
    status: "False"
  - type: DeploymentsAvailable
    status: "False"
    reason: DeploymentsNotAvailable
    message: "The following deployment(s) are not available: backend-listener, backend-worker"
  - type: RoutesReady
    status: "True"
  - type: SecretsAvailable
    status: "True"
```

####  Backwards compatibility

The Available condition continues to surface Reason and Message from SecretsAvailable when secrets are missing, preserving existing automation that reads those fields from Available.

### Verification

Tested that the status behaves as expected (namespace `3scale-abc` below).

Also verified that if a different version of operator (earlier 2.16 from public bundle) is installed in a different namespace (namespace `3scale-parallel`), it will be able to set status on the CR in that namespace.

```
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get apimanager -n 3scale-parallel 3scale -o yaml | yq '.status.conditions'
- lastTransitionTime: "2026-04-08T14:52:05Z"
  status: "False"
  type: Available
- message: All requirements for the current version are met
  reason: PreflightsPass
  status: "True"
  type: Preflights
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get apimanager -n 3scale-abc 3scale -o yaml | yq '.status.conditions'
- lastTransitionTime: "2026-04-08T14:55:50Z"
  status: "False"
  type: Available
- lastTransitionTime: "2026-04-08T14:55:50Z"
  message: 'The following deployment(s) are not available: apicast-staging, apicast-production, backend-listener, backend-worker, system-memcache, system-app, system-sidekiq, system-searchd, zync, zync-que, zync-database'
  reason: DeploymentsNotAvailable
  status: "False"
  type: DeploymentsAvailable
- lastTransitionTime: "2026-04-08T14:55:50Z"
  message: 'The following route(s) are not yet admitted: backend-3scale.apps.burbanik.cp.fyre.ibm.com, api-3scale-apicast-production.apps.burbanik.cp.fyre.ibm.com, api-3scale-apicast-staging.apps.burbanik.cp.fyre.ibm.com, master.apps.burbanik.cp.fyre.ibm.com, 3scale.apps.burbanik.cp.fyre.ibm.com, 3scale-admin.apps.burbanik.cp.fyre.ibm.com'
  reason: RoutesNotReady
  status: "False"
  type: RoutesReady
- lastTransitionTime: "2026-04-08T14:55:50Z"
  status: "True"
  type: SecretsAvailable
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get apimanager -n 3scale-abc 3scale -o yaml | yq '.status.conditions'
- lastTransitionTime: "2026-04-08T14:55:50Z"
  status: "False"
  type: Available
- lastTransitionTime: "2026-04-08T15:02:33Z"
  status: "True"
  type: DeploymentsAvailable
- lastTransitionTime: "2026-04-08T14:55:50Z"
  message: 'The following route(s) are not yet admitted: backend-3scale.apps.burbanik.cp.fyre.ibm.com'
  reason: RoutesNotReady
  status: "False"
  type: RoutesReady
- lastTransitionTime: "2026-04-08T14:55:50Z"
  status: "True"
  type: SecretsAvailable
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get apimanager -n 3scale-parallel 3scale -o yaml | yq '.status.conditions'
- lastTransitionTime: "2026-04-08T14:52:05Z"
  status: "False"
  type: Available
- message: All requirements for the current version are met
  reason: PreflightsPass
  status: "True"
  type: Preflights
borisurbanik@Boriss-MacBook-Pro 3scale-operator % oc get apimanager -n 3scale-parallel 3scale -o yaml | yq '.status.conditions'
- lastTransitionTime: "2026-04-08T16:08:24Z"
  status: "True"
  type: Available
- message: All requirements for the current version are met
  reason: PreflightsPass
  status: "True"
  type: Preflights
```