### PR TITLE
Include controllers/apps in unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,10 @@ PROMETHEUS_RULES_NAMESPACE ?= "__NAMESPACE__"
 all: manager
 
 # Run all tests
-test: test-unit test-e2e test-crds test-manifests-version
+test: test-unit test-integration test-e2e test-crds test-manifests-version
 
 # Run unit tests
-TEST_UNIT_PKGS = $(shell $(GO) list ./... | grep -E 'github.com/3scale/3scale-operator/pkg|github.com/3scale/3scale-operator/apis|github.com/3scale/3scale-operator/test/unitcontrollers|github.com/3scale/3scale-operator/controllers/capabilities')
+TEST_UNIT_PKGS = $(shell $(GO) list ./... | grep -Ev 'github.com/3scale/3scale-operator/test/(e2e|integration|crds|manifests-version)')
 TEST_UNIT_COVERPKGS = $(shell $(GO) list ./... | grep -v github.com/3scale/3scale-operator/test | tr "\n" ",") # Exclude test directories as coverpkg does not accept only-tests packages
 test-unit: clean-cov generate fmt vet manifests
 	mkdir -p "$(PROJECT_PATH)/_output"
@@ -123,12 +123,16 @@ test-manifests-version:
 	$(GO) test -v $(TEST_MANIFESTS_VERSION_PKGS)
 
 # Run e2e tests
-TEST_E2E_PKGS_APPS = $(shell $(GO) list ./... | grep 'github.com/3scale/3scale-operator/controllers/apps')
-TEST_E2E_PKGS_CAPABILITIES = $(shell $(GO) list ./... | grep 'github.com/3scale/3scale-operator/controllers/capabilities')
-test-e2e: generate fmt vet manifests setup-envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" USE_EXISTING_CLUSTER=true $(GO) test $(TEST_E2E_PKGS_APPS) -coverprofile cover.out -ginkgo.v -v -timeout 0
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" USE_EXISTING_CLUSTER=true $(GO) test $(TEST_E2E_PKGS_CAPABILITIES) -coverprofile cover.out -v -timeout 0
+TEST_E2E_PKGS = $(shell $(GO) list ./... | grep 'github.com/3scale/3scale-operator/test/e2e')
+.PHONY: test-e2e
+test-e2e:
+	$(GO) test $(TEST_E2E_PKGS) -ginkgo.v -v -timeout 0
 
+# Run integration tests
+TEST_INTEGRATION_PKGS = $(shell $(GO) list ./... | grep 'github.com/3scale/3scale-operator/test/integration')
+.PHONY: test-integration
+test-integration: generate fmt vet manifests setup-envtest
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" USE_EXISTING_CLUSTER=true $(GO) test $(TEST_INTEGRATION_PKGS) -coverprofile cover.out -ginkgo.v -v -timeout 0
 
 # Build manager binary
 manager: generate fmt vet

--- a/doc/development.md
+++ b/doc/development.md
@@ -157,7 +157,7 @@ make test-unit
 Access to a Openshift v4.8.0+ cluster required
 
 ```sh
-WATCH_NAMESPACE=3scale-test make test-e2e
+WATCH_NAMESPACE=3scale-test make test-integration
 ```
 Note that the value of the WATCH_NAMESPACE is irrelevant but required. E2E test will create an new namespace regardless of the value of WATCH_NAMESPACE 
 

--- a/test/integration/apimanager_controller_test.go
+++ b/test/integration/apimanager_controller_test.go
@@ -1,4 +1,4 @@
-package controllers
+package integration
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/3scale/3scale-operator/apis/apps"
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
+	controllers "github.com/3scale/3scale-operator/controllers/apps"
 	"github.com/3scale/3scale-operator/pkg/3scale/amp/component"
 	"github.com/3scale/3scale-operator/pkg/helper"
 	"github.com/google/uuid"
@@ -975,7 +976,7 @@ func waitForAPIManagerLabels(namespace string, retryInterval time.Duration, time
 		}
 
 		expectedLabels := map[string]string{
-			fmt.Sprintf("%s%s", APImanagerSecretLabelPrefix, string(customEnvSecret.GetUID())): "true",
+			fmt.Sprintf("%s%s", controllers.APImanagerSecretLabelPrefix, string(customEnvSecret.GetUID())): "true",
 		}
 
 		// Then verify that the hash matches the hashed config secret

--- a/test/integration/apimanager_suite_test.go
+++ b/test/integration/apimanager_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package integration
 
 import (
 	"context"
@@ -37,6 +37,7 @@ import (
 	appsv1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	capabilitiesv1alpha1 "github.com/3scale/3scale-operator/apis/capabilities/v1alpha1"
 	capabilitiesv1beta1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
+	controllers "github.com/3scale/3scale-operator/controllers/apps"
 	"github.com/3scale/3scale-operator/pkg/reconcilers"
 	grafanav1alpha1 "github.com/grafana-operator/grafana-operator/v4/api/integreatly/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -125,7 +126,7 @@ var _ = BeforeSuite(func() {
 	discoveryClientAPIManager, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&APIManagerReconciler{
+	err = (&controllers.APIManagerReconciler{
 		BaseReconciler: reconcilers.NewBaseReconciler(
 			context.Background(),
 			mgr.GetClient(),


### PR DESCRIPTION
### What

Since the `make test-unit` target is the only target we currently scrape coverage from (due to e2e test being run by prow and not sending data to codecov), it would be good if the unit tests in controllers/app would also run there. 

Currently there are no unit tests defined, but there might be in the future PR. 

### How

- Move the test code that requires envtest out of directory structure for operator code
- Rename e2e test to integration test and add Makefile target

### Verification

Checked that makefile targets work as before. 
Ran the test-integration test locally against the Fyre cluster, it ran as usual. 