### PR TITLE
Add no-op CircleCI config to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+---
+version: 2.1
+
+jobs:
+  noop:
+    docker:
+      - image: alpine:latest
+    steps:
+      - run: echo "noop"
+
+workflows:
+  version: 2
+  noop:
+    jobs:
+      - noop


### PR DESCRIPTION
## Summary
- Adds a minimal no-op CircleCI config to stop PR checks from failing on master
- Real CI continues to run only on release branches (`3scale-*-stable`) which retain the full config
- This stub satisfies CircleCI without running any jobs on master or feature branches

## Test plan
- [x] Verify CircleCI reports green on this PR
- [x] Verify no jobs are actually executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)