### PR TITLE
Fix CVE-2026-33816 and CVE-2026-33815

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,3 +139,5 @@ require (
 )
 
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20210831091943-07e756545ac1
+
+replace github.com/jackc/pgx/v5 v5.7.2 => github.com/3scale/pgx/v5 v5.7.2-cve.1

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/3scale/3scale-porta-go-client v0.11.1-0.20250124150520-23225e662421 h1:gOcBj+3tn3IJ1MLsNlpz8jo/FAPl0RgiGxLhd3UjPy0=
 github.com/3scale/3scale-porta-go-client v0.11.1-0.20250124150520-23225e662421/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
+github.com/3scale/pgx/v5 v5.7.2-cve.1 h1:S/RAq+GzIxlgBUAIXjJX6lS5docJC3HkszXForambew=
+github.com/3scale/pgx/v5 v5.7.2-cve.1/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
@@ -524,8 +526,6 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
-github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
## What

Fix
*  https://redhat.atlassian.net/browse/THREESCALE-14405
* https://redhat.atlassian.net/browse/THREESCALE-14403

github.com/3scale/pgx/v5 v5.7.2-cve.1 included the following patches
* https://github.com/jackc/pgx/commit/025d48ccb90efcebdb8ccc67079adddcde3771d5
* https://github.com/jackc/pgx/commit/6dbad4cafdb8a4daab7ff79c858c95da4b6109e8
* https://github.com/jackc/pgx/commit/d6b47a1a3cb787c5810d3c0d167403e63bca1df6
* https://github.com/jackc/pgx/commit/9844024519daaacc3c78aa127d01971b72175cdd