### PR TITLE
(chore) Add basic .bobignore

### DIFF
--- a/.bobignore
+++ b/.bobignore
@@ -1,0 +1,40 @@
+# Sensitive information
+.env
+secrets/
+*password*
+*credential*
+*apikey*
+
+# Large directories
+node_modules/
+.git/
+dist/
+build/
+vendor/
+
+# Binary and media files
+*.zip
+*.tar.gz
+*.mp4
+*.jpg
+*.png
+
+# Log files
+*.log
+logs/
+
+# Makefile-installed tools
+bin/
+
+# Generated TLS certificates and private keys (local dev / PR testing setup)
+**/*.crt
+**/*.key
+**/*.csr
+**/*.srl
+**/*.pem
+**/*.p12
+**/*.pfx
+config/certs/
+
+# Kustomize-processed secret files (written transiently by `make cluster/create/*` targets)
+config/dev-databases/**/secret-processed.yaml


### PR DESCRIPTION
Add a basic `.bobignore` file.

The purpose of this file is to:

- exclude sensitive files
- filter what is included in context to reduce token usage - build artifacts, images, large files

Note this only hides the files from tools that support it, it is not 100% guaranteed that files won't leak to the LLM 