### PR TITLE
THREESCALE-14944 deps: bump zync db to Postgres 18

### DIFF
--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -521,7 +521,7 @@ spec:
                 - name: RELATED_IMAGE_SYSTEM_MEMCACHED
                   value: mirror.gcr.io/library/memcached:1.5
                 - name: RELATED_IMAGE_ZYNC_POSTGRESQL
-                  value: quay.io/sclorg/postgresql-15-c8s
+                  value: quay.io/sclorg/postgresql-18-c9s
                 - name: RELATED_IMAGE_OC_CLI
                   value: quay.io/openshift/origin-cli:4.7
                 - name: RELATED_IMAGE_SYSTEM_SEARCHD

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,7 +60,7 @@ spec:
         - name: RELATED_IMAGE_SYSTEM_MEMCACHED
           value: "mirror.gcr.io/library/memcached:1.5"
         - name: RELATED_IMAGE_ZYNC_POSTGRESQL
-          value: "quay.io/sclorg/postgresql-15-c8s"
+          value: "quay.io/sclorg/postgresql-18-c9s"
         - name: RELATED_IMAGE_OC_CLI
           value: "quay.io/openshift/origin-cli:4.7"
         - name: RELATED_IMAGE_SYSTEM_SEARCHD

--- a/pkg/3scale/amp/component/images.go
+++ b/pkg/3scale/amp/component/images.go
@@ -25,7 +25,7 @@ func SystemMemcachedImageURL() string {
 }
 
 func ZyncPostgreSQLImageURL() string {
-	return "quay.io/sclorg/postgresql-15-c8s"
+	return "quay.io/sclorg/postgresql-18-c9s"
 }
 
 func OCCLIImageURL() string {


### PR DESCRIPTION
## What

[THREESCALE-14944](https://redhat.atlassian.net/browse/THREESCALE-14944)

## Verification steps
* Prepare the cluster
```
make cluster/prepare/local
```
* Setup APIM
```
export NAMESPACE=3scale-test

cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  apicast:
    stagingSpec:
      replicas: 0
    productionSpec:
      replicas: 0
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```
* Start the operator
```
make run
```
* Wait for the installation to finish, you should see all routes created and no error in zync