### PR TITLE
THREESCALE-15600 Set master (unreleased) versions to x.99.99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 # Current Operator version
 VERSION ?= 0.0.0
 # Current Threescale version
-THREESCALE_VERSION ?= 2.16
+THREESCALE_VERSION ?= 2.99
 
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)

--- a/bundle/manifests/3scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/3scale-operator.clusterserviceversion.yaml
@@ -493,7 +493,7 @@ spec:
                 com.company: Red_Hat
                 control-plane: controller-manager
                 rht.comp: 3scale
-                rht.comp_ver: "2.16"
+                rht.comp_ver: "2.99"
                 rht.prod_name: Red_Hat_Integration
                 rht.prod_ver: master
                 rht.subcomp: 3scale_operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
         rht.prod_name: Red_Hat_Integration
         rht.prod_ver: master
         rht.comp: 3scale
-        rht.comp_ver: "2.16"
+        rht.comp_ver: "2.99"
         rht.subcomp: 3scale_operator
         rht.subcomp_t: infrastructure
     spec:

--- a/version/version.go
+++ b/version/version.go
@@ -5,8 +5,8 @@ import (
 )
 
 var (
-	Version           = "0.13.0"
-	threescaleRelease = "2.16.0"
+	Version           = "0.99.99"
+	threescaleRelease = "2.99.99"
 )
 
 func ThreescaleVersionMajorMinor() string {


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/THREESCALE-15600

This is created for purposes of identification of branch via annotations on the ApiManager CR.