### PR TITLE
THREESCALE-11841 Update validation to match Porta

### DIFF
--- a/apis/capabilities/v1beta1/activedoc_types.go
+++ b/apis/capabilities/v1beta1/activedoc_types.go
@@ -84,7 +84,7 @@ type ActiveDocSpec struct {
 
 	// SystemName identifies uniquely the activedoc within the account provider
 	// Default value will be sanitized Name
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]+$`
+	// +kubebuilder:validation:Pattern=`^\w[\w\-/_]+$`
 	// +optional
 	SystemName *string `json:"systemName,omitempty"`
 

--- a/bundle/manifests/capabilities.3scale.net_activedocs.yaml
+++ b/bundle/manifests/capabilities.3scale.net_activedocs.yaml
@@ -136,7 +136,7 @@ spec:
                 description: |-
                   SystemName identifies uniquely the activedoc within the account provider
                   Default value will be sanitized Name
-                pattern: ^[a-z0-9]+$
+                pattern: ^\w[\w\-/_]+$
                 type: string
             required:
             - activeDocOpenAPIRef

--- a/config/crd/bases/capabilities.3scale.net_activedocs.yaml
+++ b/config/crd/bases/capabilities.3scale.net_activedocs.yaml
@@ -130,7 +130,7 @@ spec:
                 description: |-
                   SystemName identifies uniquely the activedoc within the account provider
                   Default value will be sanitized Name
-                pattern: ^[a-z0-9]+$
+                pattern: ^\w[\w\-/_]+$
                 type: string
             required:
             - activeDocOpenAPIRef


### PR DESCRIPTION
Fixes:
- https://redhat.atlassian.net/browse/THREESCALE-11841

### Validation

Set up minimal 3scale dev environment.

This PR touches CRDs - re-create them. This is very destructive so make sure you're on a throwaway cluster. 

```
make uninstall
make install
```

```
oc new-project $NAMESPACE
make cluster/create/system-mysql
make cluster/create/system-redis
make cluster/create/backend-redis
```

```
cat << EOF | oc create -f -
kind: Secret
apiVersion: v1
metadata:
  name: s3-credentials
  namespace: $NAMESPACE
data:
  AWS_ACCESS_KEY_ID: c29tZXRoaW5nCg==
  AWS_BUCKET: c29tZXRoaW5nCg==
  AWS_REGION: dXMtd2VzdC0xCg==
  AWS_SECRET_ACCESS_KEY: c29tZXRoaW5nCg==
type: Opaque
EOF

DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
cat << EOF | oc create -f -
kind: APIManager
apiVersion: apps.3scale.net/v1alpha1
metadata:
  name: 3scale
  namespace: $NAMESPACE
spec:
  wildcardDomain: $DOMAIN
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: s3-credentials
  backend:
  externalComponents:
    backend:
      redis: true
    system:
      database: true
      redis: true
EOF
```

Run the operator locally.

```
make run
```

Wait for reconciliation. 

Then test the OpenApi will be created with underscore in the name:

_note: the successful processing of activedoc requires fix https://github.com/3scale/3scale-operator/pull/1192 to be applied_

```
cat << 'EOF' > test-activedoc-underscore.yaml
apiVersion: capabilities.3scale.net/v1beta1
kind: ActiveDoc
metadata:
  name: test-activedoc-underscore
  annotations:
    insecure_skip_verify: "true"
spec:
  name: "Test ActiveDoc"
  systemName: "test_activedoc"
  activeDocOpenAPIRef:
    url: "https://gist.githubusercontent.com/borisurbanik/3dbc318142c14987897c4bf2abace478/raw/3ce9030d37ea60ff3f70ac6f1457e45ffb85493b/openapi.json"
EOF
kubectl apply -f test-activedoc-underscore.yaml
```

Expected to succeed (Failed condition status == false):

```
% oc get activedoc test-activedoc-underscore -o json | jq -r '.status.conditions | map(select(.type=="Failed"))'
[
  {
    "lastTransitionTime": "2026-09-11T07:14:29Z",
    "status": "False",
    "type": "Failed"
  }
]
```

If the name contains a bad character, it's expected to fail:

```
cat << 'EOF' > test-activedoc-bad.yaml
apiVersion: capabilities.3scale.net/v1beta1
kind: ActiveDoc
metadata:
  name: test-activedoc-bad
  annotations:
    insecure_skip_verify: "true"
spec:
  name: "Test ActiveDoc"
  systemName: "bad@name"
  activeDocOpenAPIRef:
    url: "https://gist.githubusercontent.com/borisurbanik/3dbc318142c14987897c4bf2abace478/raw/3ce9030d37ea60ff3f70ac6f1457e45ffb85493b/openapi.json"
EOF
kubectl apply -f test-activedoc-bad.yaml
```

Expected to show error:

```
The ActiveDoc "test-activedoc-bad" is invalid: spec.systemName: Invalid value: "bad@name": spec.systemName in body should match '^\w[\w\-/_]+$'
```

